### PR TITLE
Add homomorphic encryption wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cryptography Suite
 
-[![Python Version](https://img.shields.io/badge/python-3.8%2B-blue)](https://www.python.org/downloads/)
+[![Python Version](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-macOS%20|%20Linux%20|%20Windows-informational)]()
 [![Build Status](https://github.com/Psychevus/cryptography-suite/actions/workflows/python-app.yml/badge.svg)](https://github.com/Psychevus/cryptography-suite/actions)
@@ -31,7 +31,7 @@ Install the latest stable release from PyPI:
 pip install cryptography-suite
 ```
 
-> **Note**: Requires Python 3.8 or higher.
+> **Note**: Requires Python 3.10 or higher. Homomorphic encryption features need `Pyfhel` installed separately.
 
 ### Install from Source
 
@@ -56,6 +56,7 @@ pip install .
 - **Password-Authenticated Key Exchange (PAKE)**: SPAKE2 protocol implementation for secure password-based key exchange.
 - **One-Time Passwords (OTP)**: HOTP and TOTP algorithms for generating and verifying one-time passwords.
 - **Utility Functions**: Includes Base62 encoding/decoding, secure random string generation, and memory zeroing.
+- **Homomorphic Encryption**: Wrapper around Pyfhel supporting CKKS and BFV schemes.
 
 ---
 
@@ -141,6 +142,31 @@ recovered_secret = reconstruct_secret(selected_shares)
 print(f"Recovered secret: {recovered_secret}")
 ```
 
+### Homomorphic Encryption
+
+Perform arithmetic over encrypted values using Pyfhel.
+
+```python
+from cryptography_suite.homomorphic import (
+    fhe_keygen,
+    fhe_encrypt,
+    fhe_decrypt,
+    fhe_add,
+    fhe_multiply,
+)
+
+he = fhe_keygen("CKKS")
+
+ct1 = fhe_encrypt(he, 10.5)
+ct2 = fhe_encrypt(he, 5.25)
+
+sum_ct = fhe_add(he, ct1, ct2)
+prod_ct = fhe_multiply(he, ct1, ct2)
+
+print(f"Sum: {fhe_decrypt(he, sum_ct)}")
+print(f"Product: {fhe_decrypt(he, prod_ct)}")
+```
+
 ---
 
 ## 🧪 Running Tests
@@ -189,6 +215,7 @@ cryptography-suite/
 │   ├── pake.py
 │   ├── secret_sharing.py
 │   ├── signatures.py
+│   ├── homomorphic.py
 │   └── utils.py
 ├── tests/
 │   ├── test_asymmetric.py
@@ -201,6 +228,7 @@ cryptography-suite/
 │   ├── test_signatures.py
 │   └── test_utils.py
 ├── README.md
+├── demo_homomorphic.py
 ├── setup.py
 ├── LICENSE
 └── .github/

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -8,7 +8,7 @@ password-authenticated key exchange, and one-time passwords.
 Now includes additional algorithms and enhanced features for cutting-edge security applications.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 from .encryption import (
     aes_encrypt,
@@ -106,6 +106,18 @@ from .otp import (
     verify_hotp,
 )
 
+try:  # pragma: no cover - optional dependency
+    from .homomorphic import (
+        keygen as fhe_keygen,
+        encrypt as fhe_encrypt,
+        decrypt as fhe_decrypt,
+        add as fhe_add,
+        multiply as fhe_multiply,
+    )
+    FHE_AVAILABLE = True
+except Exception:  # pragma: no cover - handle missing Pyfhel
+    FHE_AVAILABLE = False
+
 from .utils import (
     base62_encode,
     base62_decode,
@@ -198,5 +210,16 @@ if PQCRYPTO_AVAILABLE:
             "generate_dilithium_keypair",
             "dilithium_sign",
             "dilithium_verify",
+        ]
+    )
+
+if FHE_AVAILABLE:
+    __all__.extend(
+        [
+            "fhe_keygen",
+            "fhe_encrypt",
+            "fhe_decrypt",
+            "fhe_add",
+            "fhe_multiply",
         ]
     )

--- a/cryptography_suite/homomorphic.py
+++ b/cryptography_suite/homomorphic.py
@@ -1,0 +1,73 @@
+"""Homomorphic Encryption Wrapper using Pyfhel.
+
+Provides simple APIs for key generation, encryption, decryption,
+and arithmetic on ciphertexts using either the CKKS or BFV scheme.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Union
+
+try:  # pragma: no cover - optional dependency
+    from Pyfhel import PyCtxt, Pyfhel
+except Exception as exc:  # pragma: no cover - gracefully handle missing package
+    raise ImportError(
+        "Pyfhel is required for homomorphic encryption features"
+    ) from exc
+
+Number = Union[int, float]
+
+
+def keygen(scheme: str = "CKKS") -> Pyfhel:
+    """Generate keys for the chosen FHE scheme.
+
+    Parameters
+    ----------
+    scheme:
+        Either ``"CKKS"`` for approximate arithmetic on real numbers or
+        ``"BFV"`` for exact integer arithmetic.
+
+    Returns
+    -------
+    Pyfhel
+        Configured ``Pyfhel`` instance with generated keys.
+    """
+    scheme = scheme.upper()
+    he = Pyfhel()
+    if scheme == "CKKS":
+        he.contextGen(scheme="CKKS", n=2**14, scale=2**30, qi_sizes=[60, 30, 30, 60])
+    elif scheme == "BFV":
+        he.contextGen(scheme="BFV", n=2**14, t_bits=20)
+    else:
+        raise ValueError("Unsupported scheme: %s" % scheme)
+    he.keyGen()
+    he.scheme = scheme  # type: ignore[attr-defined]
+    return he
+
+
+def encrypt(he: Pyfhel, value: Union[Number, Iterable[Number]]) -> PyCtxt:
+    """Encrypt a value using the provided ``Pyfhel`` instance."""
+    if he.scheme == "CKKS":  # type: ignore[attr-defined]
+        return he.encryptFrac(value)
+    return he.encryptInt(value)
+
+
+def decrypt(he: Pyfhel, ctxt: PyCtxt) -> Union[Number, List[Number]]:
+    """Decrypt a ciphertext using the provided ``Pyfhel`` instance."""
+    if he.scheme == "CKKS":  # type: ignore[attr-defined]
+        res = he.decryptFrac(ctxt)
+        if isinstance(res, list) and len(res) == 1:
+            return float(res[0])
+        return res
+    return he.decryptInt(ctxt)
+
+
+def add(_: Pyfhel, c1: PyCtxt, c2: PyCtxt) -> PyCtxt:
+    """Add two ciphertexts."""
+    return c1 + c2
+
+
+def multiply(_: Pyfhel, c1: PyCtxt, c2: PyCtxt) -> PyCtxt:
+    """Multiply two ciphertexts."""
+    return c1 * c2
+

--- a/demo_homomorphic.py
+++ b/demo_homomorphic.py
@@ -1,0 +1,18 @@
+"""Demonstration of homomorphic encryption operations."""
+from cryptography_suite.homomorphic import keygen, encrypt, decrypt, add, multiply
+
+
+def main() -> None:
+    he = keygen("CKKS")
+    ct1 = encrypt(he, 10.5)
+    ct2 = encrypt(he, 5.25)
+
+    sum_ct = add(he, ct1, ct2)
+    prod_ct = multiply(he, ct1, ct2)
+
+    print("Decrypted Sum:", decrypt(he, sum_ct))
+    print("Decrypted Product:", decrypt(he, prod_ct))
+
+
+if __name__ == "__main__":
+    main()

--- a/example_usage.py
+++ b/example_usage.py
@@ -222,5 +222,24 @@ def main():
     rotated_key = rotate_aes_key()
     print(f"Rotated AES Key: {rotated_key.hex()}")
 
+    # Homomorphic Encryption Demo
+    print("\n=== Homomorphic Encryption ===")
+    try:
+        from cryptography_suite.homomorphic import (
+            fhe_keygen,
+            fhe_encrypt,
+            fhe_decrypt,
+            fhe_add,
+            fhe_multiply,
+        )
+
+        fhe = fhe_keygen("CKKS")
+        c1 = fhe_encrypt(fhe, 10.5)
+        c2 = fhe_encrypt(fhe, 5.25)
+        print("Decrypted Sum:", fhe_decrypt(fhe, fhe_add(fhe, c1, c2)))
+        print("Decrypted Product:", fhe_decrypt(fhe, fhe_multiply(fhe, c1, c2)))
+    except ImportError:
+        print("Pyfhel not installed; skipping homomorphic encryption demo.")
+
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ['py38']
+target-version = ['py310']
 
 [tool.isort]
 profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cryptography-suite",
-    version="1.0.0",
+    version="1.1.0",
     description="A comprehensive and secure cryptographic toolkit.",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
@@ -34,7 +34,7 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     install_requires=[
         "cryptography>=41.0.3",
     ],


### PR DESCRIPTION
## Summary
- add Pyfhel-based homomorphic encryption module
- provide CLI demo script
- update example usage
- bump package version to 1.1.0 and require Python 3.10+
- document new features in README
- update tool configuration for Python 3.10

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e09b5e1c4832a876da52a1a4d9b6b