### PR TITLE
Add Ascon-128a AEAD cipher

### DIFF
--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -22,6 +22,7 @@ from .encryption import (
     pbkdf2_encrypt,
     pbkdf2_decrypt,
 )
+from .ascon_cipher import encrypt as ascon_encrypt, decrypt as ascon_decrypt
 
 from .asymmetric import (
     generate_rsa_keypair,
@@ -148,6 +149,8 @@ __all__ = [
     "scrypt_decrypt",
     "pbkdf2_encrypt",
     "pbkdf2_decrypt",
+    "ascon_encrypt",
+    "ascon_decrypt",
     "encrypt_file",
     "decrypt_file",
     # Asymmetric

--- a/cryptography_suite/ascon_cipher.py
+++ b/cryptography_suite/ascon_cipher.py
@@ -1,0 +1,156 @@
+"""Ascon-128a authenticated encryption based on the NIST specification."""
+
+from __future__ import annotations
+
+from typing import List
+
+def _to_bytes(data: List[int]) -> bytes:
+    return bytes(bytearray(data))
+
+
+def _zero_bytes(n: int) -> bytes:
+    return b"\x00" * n
+
+
+def _bytes_to_int(b: bytes) -> int:
+    return int.from_bytes(b, "big")
+
+
+def _int_to_bytes(value: int, n: int) -> bytes:
+    return value.to_bytes(n, "big")
+
+
+def _bytes_to_state(b: bytes) -> List[int]:
+    return [_bytes_to_int(b[i : i + 8]) for i in range(0, 40, 8)]
+
+
+def _rotr(val: int, r: int) -> int:
+    return ((val >> r) | ((val & ((1 << r) - 1)) << (64 - r))) & ((1 << 64) - 1)
+
+
+def _ascon_permutation(S: List[int], rounds: int) -> None:
+    assert rounds <= 12
+    for r in range(12 - rounds, 12):
+        S[2] ^= 0xF0 - 0x10 * r + r
+        S[0] ^= S[4]
+        S[4] ^= S[3]
+        S[2] ^= S[1]
+        T = [((~S[i]) & S[(i + 1) % 5]) & 0xFFFFFFFFFFFFFFFF for i in range(5)]
+        for i in range(5):
+            S[i] ^= T[(i + 1) % 5]
+        S[1] ^= S[0]
+        S[0] ^= S[4]
+        S[3] ^= S[2]
+        S[2] ^= 0xFFFFFFFFFFFFFFFF
+        S[0] ^= _rotr(S[0], 19) ^ _rotr(S[0], 28)
+        S[1] ^= _rotr(S[1], 61) ^ _rotr(S[1], 39)
+        S[2] ^= _rotr(S[2], 1) ^ _rotr(S[2], 6)
+        S[3] ^= _rotr(S[3], 10) ^ _rotr(S[3], 17)
+        S[4] ^= _rotr(S[4], 7) ^ _rotr(S[4], 41)
+
+
+def _initialize(key: bytes, nonce: bytes) -> List[int]:
+    if len(key) != 16 or len(nonce) != 16:
+        raise ValueError("Key and nonce must be 16 bytes each.")
+    iv = _to_bytes([128, 16 * 8, 12, 8]) + _zero_bytes(4)
+    state_bytes = iv + key + nonce
+    S = _bytes_to_state(state_bytes)
+    _ascon_permutation(S, 12)
+    zero_key = _bytes_to_state(_zero_bytes(24) + key)
+    for i in range(5):
+        S[i] ^= zero_key[i]
+    return S
+
+
+def _process_ad(S: List[int], ad: bytes) -> None:
+    rate = 16
+    if ad:
+        pad_len = rate - (len(ad) % rate) - 1
+        padded = ad + b"\x80" + _zero_bytes(pad_len)
+        for i in range(0, len(padded), rate):
+            S[0] ^= _bytes_to_int(padded[i : i + 8])
+            S[1] ^= _bytes_to_int(padded[i + 8 : i + 16])
+            _ascon_permutation(S, 8)
+    S[4] ^= 1
+
+
+def _process_plaintext(S: List[int], plaintext: bytes) -> bytes:
+    rate = 16
+    last_len = len(plaintext) % rate
+    padded = plaintext + b"\x80" + _zero_bytes(rate - last_len - 1)
+    ciphertext = b""
+    for i in range(0, len(padded) - rate, rate):
+        S[0] ^= _bytes_to_int(padded[i : i + 8])
+        S[1] ^= _bytes_to_int(padded[i + 8 : i + 16])
+        ciphertext += _int_to_bytes(S[0], 8) + _int_to_bytes(S[1], 8)
+        _ascon_permutation(S, 8)
+    i = len(padded) - rate
+    S[0] ^= _bytes_to_int(padded[i : i + 8])
+    S[1] ^= _bytes_to_int(padded[i + 8 : i + 16])
+    ciphertext += (
+        _int_to_bytes(S[0], 8)[: min(8, last_len)]
+        + _int_to_bytes(S[1], 8)[: max(0, last_len - 8)]
+    )
+    return ciphertext
+
+
+def _process_ciphertext(S: List[int], ciphertext: bytes) -> bytes:
+    rate = 16
+    last_len = len(ciphertext) % rate
+    padded = ciphertext + _zero_bytes(rate - last_len)
+    plaintext = b""
+    for i in range(0, len(padded) - rate, rate):
+        c0 = _bytes_to_int(padded[i : i + 8])
+        c1 = _bytes_to_int(padded[i + 8 : i + 16])
+        plaintext += _int_to_bytes(S[0] ^ c0, 8) + _int_to_bytes(S[1] ^ c1, 8)
+        S[0], S[1] = c0, c1
+        _ascon_permutation(S, 8)
+    i = len(padded) - rate
+    c0 = _bytes_to_int(padded[i : i + 8])
+    c1 = _bytes_to_int(padded[i + 8 : i + 16])
+    plaintext += (
+        _int_to_bytes(S[0] ^ c0, 8) + _int_to_bytes(S[1] ^ c1, 8)
+    )[:last_len]
+    if last_len < 8:
+        mask = (1 << (64 - last_len * 8)) - 1
+        S[0] = c0 ^ (S[0] & mask) ^ (0x80 << ((8 - last_len - 1) * 8))
+    else:
+        mask = (1 << (64 - (last_len - 8) * 8)) - 1
+        S[0] = c0
+        S[1] = c1 ^ (S[1] & mask) ^ (0x80 << ((8 - (last_len - 8) - 1) * 8))
+    return plaintext
+
+
+def _finalize(S: List[int], key: bytes) -> bytes:
+    rate = 16
+    S[2] ^= _bytes_to_int(key[0:8])
+    S[3] ^= _bytes_to_int(key[8:16])
+    _ascon_permutation(S, 12)
+    S[3] ^= _bytes_to_int(key[0:8])
+    S[4] ^= _bytes_to_int(key[8:16])
+    return _int_to_bytes(S[3], 8) + _int_to_bytes(S[4], 8)
+
+
+def encrypt(key: bytes, nonce: bytes, associated_data: bytes, plaintext: bytes) -> bytes:
+    """Encrypt and authenticate using Ascon-128a."""
+    S = _initialize(key, nonce)
+    _process_ad(S, associated_data)
+    ciphertext = _process_plaintext(S, plaintext)
+    tag = _finalize(S, key)
+    return ciphertext + tag
+
+
+def decrypt(key: bytes, nonce: bytes, associated_data: bytes, ciphertext: bytes) -> bytes:
+    """Decrypt and verify using Ascon-128a."""
+    if len(ciphertext) < 16:
+        raise ValueError("Ciphertext too short.")
+    S = _initialize(key, nonce)
+    _process_ad(S, associated_data)
+    plaintext = _process_ciphertext(S, ciphertext[:-16])
+    tag = _finalize(S, key)
+    if tag != ciphertext[-16:]:
+        raise ValueError("Invalid authentication tag.")
+    return plaintext
+
+
+__all__ = ["encrypt", "decrypt"]

--- a/tests/test_ascon.py
+++ b/tests/test_ascon.py
@@ -1,0 +1,39 @@
+import unittest
+
+from cryptography_suite.ascon_cipher import encrypt, decrypt
+
+
+class TestAscon128a(unittest.TestCase):
+    def setUp(self):
+        self.key = bytes(range(16))
+        self.nonce = bytes(range(16))
+        self.msg = b"hello ascon"
+        self.ad = b"adata"
+
+    def test_encrypt_decrypt(self):
+        ct = encrypt(self.key, self.nonce, self.ad, self.msg)
+        pt = decrypt(self.key, self.nonce, self.ad, ct)
+        self.assertEqual(pt, self.msg)
+
+    def test_invalid_tag(self):
+        ct = encrypt(self.key, self.nonce, self.ad, self.msg)
+        tampered = ct[:-1] + bytes([ct[-1] ^ 0x01])
+        with self.assertRaises(ValueError):
+            decrypt(self.key, self.nonce, self.ad, tampered)
+
+    def test_reference_vectors(self):
+        vectors = [
+            (b"", b"", "7a834e6f09210957067b10fd831f0078"),
+            (b"", b"\x00", "6e652b55bfdc8cad2ec43815b1666b1a3a"),
+            (b"\x00", b"", "af3031b07b129ec84153373ddcaba528"),
+            (b"\x00", b"\x00", "e9c2813cc8c6dd2f245f3bb976da566e9d"),
+            (bytes(range(16)), bytes(range(16)), "52499ac9c84323a4ae24eaeccf45c137316d7ab17724ba67a85ecd3c0457c459"),
+        ]
+        for ad, pt, expected in vectors:
+            ct = encrypt(self.key, self.nonce, ad, pt)
+            self.assertEqual(ct.hex(), expected)
+            self.assertEqual(decrypt(self.key, self.nonce, ad, ct), pt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement Ascon-128a AEAD `encrypt` and `decrypt` functions
- expose functions via package init
- add tests including NIST reference vectors

## Testing
- `python -m pytest -q`
