### PR TITLE
Add BLS signature support using py_ecc

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install .
 
 - **Symmetric Encryption**: AES-GCM, ChaCha20-Poly1305 encryption with password-based key derivation using PBKDF2 and Scrypt.
 - **Asymmetric Encryption**: RSA encryption/decryption, key generation, serialization, and loading.
-- **Digital Signatures**: Support for Ed25519 and ECDSA algorithms for secure message signing and verification.
+- **Digital Signatures**: Support for Ed25519, ECDSA, and BLS (BLS12-381) algorithms for secure message signing and verification.
 - **Hashing Functions**: Implements SHA-256, SHA-384, SHA-512, and BLAKE2b hashing algorithms.
 - **Key Management**: Secure generation, storage, loading, and rotation of cryptographic keys.
 - **Secret Sharing**: Implementation of Shamir's Secret Sharing scheme for splitting and reconstructing secrets.
@@ -104,22 +104,26 @@ print(f"Decrypted: {decrypted_message}")
 
 ### Digital Signatures
 
-Sign and verify messages using Ed25519.
+Sign and verify messages using Ed25519 or BLS.
 
 ```python
-from cryptography_suite.signatures import generate_ed25519_keypair, sign_message, verify_signature
+from cryptography_suite.signatures import (
+    generate_ed25519_keypair,
+    sign_message,
+    verify_signature,
+)
 
-# Generate key pair
-private_key, public_key = generate_ed25519_keypair()
+# Generate Ed25519 key pair
+ed_priv, ed_pub = generate_ed25519_keypair()
+signature = sign_message(b"Authenticate this message", ed_priv)
+print(verify_signature(b"Authenticate this message", signature, ed_pub))
 
-message = b"Authenticate this message"
+from cryptography_suite.bls import generate_bls_keypair, bls_sign, bls_verify
 
-# Sign the message
-signature = sign_message(message, private_key)
-
-# Verify the signature
-is_valid = verify_signature(message, signature, public_key)
-print(f"Signature valid: {is_valid}")
+# Generate BLS key pair
+bls_sk, bls_pk = generate_bls_keypair()
+bls_sig = bls_sign(b"Authenticate this message", bls_sk)
+print(bls_verify(b"Authenticate this message", bls_sig, bls_pk))
 ```
 
 ### Secret Sharing

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -54,6 +54,14 @@ from .signatures import (
     load_ecdsa_public_key,
 )
 
+from .bls import (
+    generate_bls_keypair,
+    bls_sign,
+    bls_verify,
+    bls_aggregate,
+    bls_aggregate_verify,
+)
+
 try:  # pragma: no cover - optional dependency
     from .post_quantum import (
         generate_kyber_keypair,
@@ -179,6 +187,12 @@ __all__ = [
     "serialize_ecdsa_public_key",
     "load_ecdsa_private_key",
     "load_ecdsa_public_key",
+    # BLS Signatures
+    "generate_bls_keypair",
+    "bls_sign",
+    "bls_verify",
+    "bls_aggregate",
+    "bls_aggregate_verify",
     # Hashing
     "sha384_hash",
     "sha256_hash",

--- a/cryptography_suite/bls.py
+++ b/cryptography_suite/bls.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""BLS signature primitives using BLS12-381."""
+
+from os import urandom
+from typing import Iterable, List, Sequence, Tuple
+
+from py_ecc.bls import G2Basic
+
+
+def generate_bls_keypair(seed: bytes | None = None) -> Tuple[int, bytes]:
+    """Generate a BLS12-381 key pair.
+
+    Parameters
+    ----------
+    seed:
+        Optional 32 byte seed. If not provided a secure random seed is used.
+
+    Returns
+    -------
+    Tuple[int, bytes]
+        Private key as integer and public key as bytes.
+    """
+    if seed is not None and len(seed) == 0:
+        raise ValueError("Seed cannot be empty.")
+
+    ikm = seed if seed is not None else urandom(32)
+    sk = G2Basic.KeyGen(ikm)
+    pk = G2Basic.SkToPk(sk)
+    return sk, pk
+
+
+def bls_sign(message: bytes, private_key: int) -> bytes:
+    """Sign a message using BLS12-381."""
+    if not message:
+        raise ValueError("Message cannot be empty.")
+    if not isinstance(private_key, int):
+        raise TypeError("Private key must be an int.")
+    return G2Basic.Sign(private_key, message)
+
+
+def bls_verify(message: bytes, signature: bytes, public_key: bytes) -> bool:
+    """Verify a BLS12-381 signature."""
+    if not message:
+        raise ValueError("Message cannot be empty.")
+    if not signature:
+        raise ValueError("Signature cannot be empty.")
+    if not isinstance(public_key, (bytes, bytearray)):
+        raise TypeError("Public key must be bytes.")
+    return G2Basic.Verify(public_key, message, signature)
+
+
+def bls_aggregate(signatures: Iterable[bytes]) -> bytes:
+    """Aggregate multiple BLS signatures into one."""
+    sig_list: List[bytes] = list(signatures)
+    if not sig_list:
+        raise ValueError("No signatures provided for aggregation.")
+    return G2Basic.Aggregate(sig_list)
+
+
+def bls_aggregate_verify(
+    public_keys: Sequence[bytes],
+    messages: Sequence[bytes],
+    signature: bytes,
+) -> bool:
+    """Verify an aggregated BLS signature against multiple messages."""
+    if not public_keys or not messages:
+        raise ValueError("Public keys and messages cannot be empty.")
+    if len(public_keys) != len(messages):
+        raise ValueError("Number of public keys must match number of messages.")
+    if not signature:
+        raise ValueError("Signature cannot be empty.")
+    return G2Basic.AggregateVerify(list(public_keys), list(messages), signature)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cryptography~=43.0.3
 pqcrypto
+py_ecc

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     python_requires=">=3.10",
     install_requires=[
         "cryptography>=41.0.3",
+        "py_ecc",
     ],
     extras_require={
         "dev": [

--- a/tests/test_bls.py
+++ b/tests/test_bls.py
@@ -1,0 +1,51 @@
+import unittest
+from cryptography_suite.bls import (
+    generate_bls_keypair,
+    bls_sign,
+    bls_verify,
+    bls_aggregate,
+    bls_aggregate_verify,
+)
+
+
+class TestBLS(unittest.TestCase):
+    def setUp(self):
+        self.message1 = b"Hello BLS"
+        self.message2 = b"Another message"
+
+    def test_sign_and_verify(self):
+        sk, pk = generate_bls_keypair()
+        signature = bls_sign(self.message1, sk)
+        self.assertTrue(bls_verify(self.message1, signature, pk))
+
+    def test_sign_with_empty_message(self):
+        sk, _ = generate_bls_keypair()
+        with self.assertRaises(ValueError):
+            bls_sign(b"", sk)
+
+    def test_verify_with_invalid_public_key_type(self):
+        sk, _ = generate_bls_keypair()
+        sig = bls_sign(self.message1, sk)
+        with self.assertRaises(TypeError):
+            bls_verify(self.message1, sig, "not_bytes")
+
+    def test_aggregate_and_verify(self):
+        sk1, pk1 = generate_bls_keypair()
+        sk2, pk2 = generate_bls_keypair()
+        sig1 = bls_sign(self.message1, sk1)
+        sig2 = bls_sign(self.message2, sk2)
+        agg_sig = bls_aggregate([sig1, sig2])
+        self.assertTrue(
+            bls_aggregate_verify([pk1, pk2], [self.message1, self.message2], agg_sig)
+        )
+
+    def test_aggregate_verify_mismatched_lengths(self):
+        sk, pk = generate_bls_keypair()
+        sig = bls_sign(self.message1, sk)
+        agg = bls_aggregate([sig])
+        with self.assertRaises(ValueError):
+            bls_aggregate_verify([pk, pk], [self.message1], agg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `bls.py` providing BLS12-381 signing with py_ecc
- expose BLS functions in the package API
- update requirements
- add unit tests for BLS operations

## Testing
- `python -m unittest discover tests -v`
