### PR TITLE
Improve BLS docs and add deterministic test

### DIFF
--- a/tests/test_bls.py
+++ b/tests/test_bls.py
@@ -46,6 +46,28 @@ class TestBLS(unittest.TestCase):
         with self.assertRaises(ValueError):
             bls_aggregate_verify([pk, pk], [self.message1], agg)
 
+    def test_known_vector(self):
+        """Verify implementation against a deterministic test vector."""
+        seed = b"\x11" * 32
+        expected_sk = 23657700540186605117143072292512185602964840914375503215744843051745997498405
+        expected_pk = bytes.fromhex(
+            "8e5a712e4cb2c51893c27ae19afb3455f3efcc66030dc25e13eb1afc2edf3973"
+            "17a0bb2d28a55513a32d7dcc404be3ba"
+        )
+        expected_sig = bytes.fromhex(
+            "a008c7df216b75c7497dbde10d2188fb6b943f999b654df82a064c10723b9249"
+            "93d9d4933c4670e7e2e536ddc87b9a7a0e0f8ecf5faedbeda5ee2ea7bee4065f"
+            "4aefed8f4d665569ec636b04f36ff6fd853f66283d413843761acbda652fd43d"
+        )
+
+        sk, pk = generate_bls_keypair(seed)
+        self.assertEqual(sk, expected_sk)
+        self.assertEqual(pk, expected_pk)
+
+        sig = bls_sign(b"hello world", sk)
+        self.assertEqual(sig, expected_sig)
+        self.assertTrue(bls_verify(b"hello world", sig, pk))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- expand documentation and parameter checks for BLS helpers
- add deterministic test vector for BLS signing

## Testing
- `black cryptography_suite/bls.py tests/test_bls.py`
- `pytest -q`
