### PR TITLE
Add Argon2id KDF option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pip install .
 
 ## 🔑 Key Features
 
-- **Symmetric Encryption**: AES-GCM, ChaCha20-Poly1305 encryption with password-based key derivation using PBKDF2 and Scrypt.
+- **Symmetric Encryption**: AES-GCM, ChaCha20-Poly1305 encryption with password-based key derivation using PBKDF2, Scrypt, or Argon2.
 - **Asymmetric Encryption**: RSA encryption/decryption, key generation, serialization, and loading.
 - **Digital Signatures**: Support for Ed25519, ECDSA, and BLS (BLS12-381) algorithms for secure message signing and verification.
 - **Hashing Functions**: Implements SHA-256, SHA-384, SHA-512, and BLAKE2b hashing algorithms.
@@ -80,7 +80,14 @@ print(f"Encrypted: {encrypted_message}")
 # Decrypt the message
 decrypted_message = aes_decrypt(encrypted_message, password)
 print(f"Decrypted: {decrypted_message}")
+
+# Use Argon2 key derivation
+argon2_encrypted = aes_encrypt(message, password, kdf="argon2")
+print(aes_decrypt(argon2_encrypted, password, kdf="argon2"))
 ```
+
+Argon2id support is provided by the `cryptography` package and requires no
+additional dependencies.
 
 ### Asymmetric Encryption
 

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -1,11 +1,12 @@
 """
 Cryptography Suite Package Initialization.
 
-Provides a comprehensive suite of cryptographic functions including symmetric encryption,
-asymmetric encryption, hashing, key management, digital signatures, secret sharing,
-password-authenticated key exchange, and one-time passwords.
+Provides a comprehensive suite of cryptographic functions including symmetric
+encryption, asymmetric encryption, hashing, key management, digital signatures,
+secret sharing, password-authenticated key exchange, and one-time passwords.
 
-Now includes additional algorithms and enhanced features for cutting-edge security applications.
+Now includes additional algorithms and enhanced features for cutting-edge
+security applications.
 """
 
 __version__ = "1.1.0"
@@ -17,10 +18,13 @@ from .encryption import (
     chacha20_decrypt,
     scrypt_encrypt,
     scrypt_decrypt,
+    argon2_encrypt,
+    argon2_decrypt,
     encrypt_file,
     decrypt_file,
     pbkdf2_encrypt,
     pbkdf2_decrypt,
+    derive_key_argon2,
 )
 from .ascon_cipher import encrypt as ascon_encrypt, decrypt as ascon_decrypt
 
@@ -164,6 +168,8 @@ __all__ = [
     "chacha20_decrypt",
     "scrypt_encrypt",
     "scrypt_decrypt",
+    "argon2_encrypt",
+    "argon2_decrypt",
     "pbkdf2_encrypt",
     "pbkdf2_decrypt",
     "ascon_encrypt",
@@ -209,6 +215,7 @@ __all__ = [
     "blake2b_hash",
     "derive_key_scrypt",
     "derive_key_pbkdf2",
+    "derive_key_argon2",
     "verify_derived_key_scrypt",
     "verify_derived_key_pbkdf2",
     "generate_salt",


### PR DESCRIPTION
## Summary
- implement `derive_key_argon2` using Argon2id
- integrate Argon2 into encryption and file helpers
- expose Argon2 helpers in package
- document Argon2 usage in README
- add unit tests for Argon2 KDF and encryption

## Testing
- `pycodestyle cryptography_suite/encryption.py cryptography_suite/__init__.py tests/test_encryption.py`
- `pytest -q`
