### PR TITLE
Add streaming AES-GCM file encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ print(aes_decrypt(argon2_encrypted, password, kdf="argon2"))
 Argon2id support is provided by the `cryptography` package and requires no
 additional dependencies.
 
+### File Encryption
+
+Stream files of any size with AES-GCM. The functions read and write in
+chunks, so even large files can be processed efficiently.
+
+```python
+from cryptography_suite import encrypt_file, decrypt_file
+
+encrypt_file("secret.txt", "secret.enc", password)
+decrypt_file("secret.enc", "secret.out", password)
+```
+
 ### Asymmetric Encryption
 
 Generate RSA key pairs and perform encryption/decryption.

--- a/cryptography_suite/symmetric/aes.py
+++ b/cryptography_suite/symmetric/aes.py
@@ -4,12 +4,8 @@ import base64
 import os
 from os import urandom
 
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-
-# Constants for streaming file encryption
-CHUNK_SIZE = 4096
-TAG_SIZE = 16  # AES-GCM authentication tag size
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 from .kdf import (
     NONCE_SIZE,
@@ -18,6 +14,10 @@ from .kdf import (
     derive_key_pbkdf2,
     derive_key_scrypt,
 )
+
+# Constants for streaming file encryption
+CHUNK_SIZE = 4096
+TAG_SIZE = 16  # AES-GCM authentication tag size
 
 
 def aes_encrypt(plaintext: str, password: str, kdf: str = "scrypt") -> str:

--- a/cryptography_suite/symmetric/aes.py
+++ b/cryptography_suite/symmetric/aes.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import base64
+import os
 from os import urandom
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+# Constants for streaming file encryption
+CHUNK_SIZE = 4096
+TAG_SIZE = 16  # AES-GCM authentication tag size
 
 from .kdf import (
     NONCE_SIZE,
@@ -75,7 +81,12 @@ def encrypt_file(
     password: str,
     kdf: str = "scrypt",
 ) -> None:
-    """Encrypt a file using AES-GCM with a password-derived key."""
+    """Encrypt a file using AES-GCM with a password-derived key.
+
+    The file is processed in chunks to avoid loading the entire file into
+    memory. The output file begins with the salt and nonce and ends with the
+    authentication tag.
+    """
     if not password:
         raise ValueError("Password cannot be empty.")
 
@@ -89,16 +100,21 @@ def encrypt_file(
     else:
         raise ValueError("Unsupported KDF specified.")
 
-    aesgcm = AESGCM(key)
     nonce = urandom(NONCE_SIZE)
+    cipher = Cipher(algorithms.AES(key), modes.GCM(nonce))
+    encryptor = cipher.encryptor()
 
     try:
-        with open(input_file_path, "rb") as f:
-            data = f.read()
-        ciphertext = aesgcm.encrypt(nonce, data, None)
-        with open(output_file_path, "wb") as f:
-            f.write(salt + nonce + ciphertext)
+        with open(input_file_path, "rb") as f_in, open(output_file_path, "wb") as f_out:
+            f_out.write(salt + nonce)
+            while chunk := f_in.read(CHUNK_SIZE):
+                f_out.write(encryptor.update(chunk))
+            encryptor.finalize()
+            f_out.write(encryptor.tag)
     except Exception as exc:
+        # Remove potentially partial output on error
+        if os.path.exists(output_file_path):
+            os.remove(output_file_path)
         raise IOError(f"File encryption failed: {exc}")
 
 
@@ -108,44 +124,61 @@ def decrypt_file(
     password: str,
     kdf: str = "scrypt",
 ) -> None:
-    """Decrypt a file encrypted with AES-GCM using a password-derived key."""
+    """Decrypt a file encrypted with AES-GCM using a password-derived key.
+
+    Data is streamed in chunks, verifying the authentication tag at the end.
+    The output file is removed if decryption fails.
+    """
     if not password:
         raise ValueError("Password cannot be empty.")
 
     try:
-        with open(encrypted_file_path, "rb") as f:
-            encrypted_data = f.read()
+        file_size = os.path.getsize(encrypted_file_path)
+        f_in = open(encrypted_file_path, "rb")
     except Exception as exc:
-        raise IOError(f"Failed to read encrypted file: {exc}")
+        raise IOError(f"Failed to read encrypted file: {exc}") from exc
 
-    if len(encrypted_data) < SALT_SIZE + NONCE_SIZE:
-        raise ValueError("Invalid encrypted file.")
+    with f_in:
+        if file_size < SALT_SIZE + NONCE_SIZE + TAG_SIZE:
+            raise ValueError("Invalid encrypted file.")
 
-    salt = encrypted_data[:SALT_SIZE]
-    nonce = encrypted_data[SALT_SIZE : SALT_SIZE + NONCE_SIZE]
-    ciphertext = encrypted_data[SALT_SIZE + NONCE_SIZE :]
+        salt = f_in.read(SALT_SIZE)
+        nonce = f_in.read(NONCE_SIZE)
+        ciphertext_len = file_size - SALT_SIZE - NONCE_SIZE - TAG_SIZE
 
-    if kdf == "scrypt":
-        key = derive_key_scrypt(password, salt)
-    elif kdf == "pbkdf2":
-        key = derive_key_pbkdf2(password, salt)
-    elif kdf == "argon2":
-        key = derive_key_argon2(password, salt)
-    else:
-        raise ValueError("Unsupported KDF specified.")
+        if kdf == "scrypt":
+            key = derive_key_scrypt(password, salt)
+        elif kdf == "pbkdf2":
+            key = derive_key_pbkdf2(password, salt)
+        elif kdf == "argon2":
+            key = derive_key_argon2(password, salt)
+        else:
+            raise ValueError("Unsupported KDF specified.")
 
-    aesgcm = AESGCM(key)
-    try:
-        data = aesgcm.decrypt(nonce, ciphertext, None)
-        with open(output_file_path, "wb") as f:
-            f.write(data)
-    except Exception as exc:  # pragma: no cover - high-level error handling
-        raise ValueError(
-            "File decryption failed: Invalid password or corrupted file."
-        ) from exc
+        cipher = Cipher(algorithms.AES(key), modes.GCM(nonce))
+        decryptor = cipher.decryptor()
+
+        try:
+            with open(output_file_path, "wb") as f_out:
+                processed = 0
+                while processed < ciphertext_len:
+                    to_read = min(CHUNK_SIZE, ciphertext_len - processed)
+                    chunk = f_in.read(to_read)
+                    processed += len(chunk)
+                    f_out.write(decryptor.update(chunk))
+
+                tag = f_in.read(TAG_SIZE)
+                decryptor.finalize_with_tag(tag)
+        except Exception as exc:  # pragma: no cover - high-level error handling
+            if os.path.exists(output_file_path):
+                os.remove(output_file_path)
+            raise ValueError(
+                "File decryption failed: Invalid password or corrupted file."
+            ) from exc
 
 
 # Convenience wrappers -------------------------------------------------------
+
 
 def scrypt_encrypt(plaintext: str, password: str) -> str:
     return aes_encrypt(plaintext, password, kdf="scrypt")

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -23,20 +23,20 @@ class TestEncryption(unittest.TestCase):
 
     def test_aes_encrypt_decrypt_scrypt(self):
         """Test AES encryption and decryption with Scrypt KDF."""
-        encrypted = aes_encrypt(self.message, self.password, kdf='scrypt')
-        decrypted = aes_decrypt(encrypted, self.password, kdf='scrypt')
+        encrypted = aes_encrypt(self.message, self.password, kdf="scrypt")
+        decrypted = aes_decrypt(encrypted, self.password, kdf="scrypt")
         self.assertEqual(self.message, decrypted)
 
     def test_aes_encrypt_decrypt_pbkdf2(self):
         """Test AES encryption and decryption with PBKDF2 KDF."""
-        encrypted = aes_encrypt(self.message, self.password, kdf='pbkdf2')
-        decrypted = aes_decrypt(encrypted, self.password, kdf='pbkdf2')
+        encrypted = aes_encrypt(self.message, self.password, kdf="pbkdf2")
+        decrypted = aes_decrypt(encrypted, self.password, kdf="pbkdf2")
         self.assertEqual(self.message, decrypted)
 
     def test_aes_encrypt_decrypt_argon2(self):
         """Test AES encryption and decryption with Argon2id KDF."""
-        encrypted = aes_encrypt(self.message, self.password, kdf='argon2')
-        decrypted = aes_decrypt(encrypted, self.password, kdf='argon2')
+        encrypted = aes_encrypt(self.message, self.password, kdf="argon2")
+        decrypted = aes_decrypt(encrypted, self.password, kdf="argon2")
         self.assertEqual(self.message, decrypted)
 
     def test_derive_key_argon2(self):
@@ -219,7 +219,7 @@ class TestEncryption(unittest.TestCase):
             aes_encrypt(
                 self.message,
                 self.password,
-                kdf='invalid_kdf',
+                kdf="invalid_kdf",
             )
 
     def test_aes_encrypt_with_unsupported_kdf(self):
@@ -228,13 +228,13 @@ class TestEncryption(unittest.TestCase):
             aes_encrypt(
                 self.message,
                 self.password,
-                kdf='unsupported_kdf',
+                kdf="unsupported_kdf",
             )
 
     def test_aes_decrypt_with_empty_encrypted_data(self):
         """Test AES decryption with empty encrypted data."""
         with self.assertRaises(ValueError) as context:
-            aes_decrypt('', self.password)
+            aes_decrypt("", self.password)
         self.assertEqual(
             str(context.exception),
             "Encrypted data cannot be empty.",
@@ -244,12 +244,12 @@ class TestEncryption(unittest.TestCase):
         """Test AES decryption with empty password."""
         encrypted = aes_encrypt(self.message, self.password)
         with self.assertRaises(ValueError) as context:
-            aes_decrypt(encrypted, '')
+            aes_decrypt(encrypted, "")
         self.assertEqual(str(context.exception), "Password cannot be empty.")
 
     def test_aes_decrypt_with_invalid_encrypted_data(self):
         """Test AES decryption with invalid encrypted data length."""
-        invalid_data = base64.b64encode(b'short').decode()
+        invalid_data = base64.b64encode(b"short").decode()
         with self.assertRaises(ValueError) as context:
             aes_decrypt(invalid_data, self.password)
         self.assertEqual(str(context.exception), "Invalid encrypted data.")
@@ -257,18 +257,18 @@ class TestEncryption(unittest.TestCase):
     def test_aes_encrypt_with_empty_plaintext(self):
         """Test AES encryption with empty plaintext."""
         with self.assertRaises(ValueError) as context:
-            aes_encrypt('', self.password)
+            aes_encrypt("", self.password)
         self.assertEqual(str(context.exception), "Plaintext cannot be empty.")
 
     def test_chacha20_encrypt_with_empty_plaintext(self):
         """Test ChaCha20 encryption with empty plaintext."""
         with self.assertRaises(ValueError) as context:
-            chacha20_encrypt('', self.password)
+            chacha20_encrypt("", self.password)
         self.assertEqual(str(context.exception), "Plaintext cannot be empty.")
 
     def test_aes_decrypt_with_invalid_encrypted_data_length(self):
         """Test AES decryption with invalid encrypted data length."""
-        invalid_data = base64.b64encode(b'short').decode()
+        invalid_data = base64.b64encode(b"short").decode()
         with self.assertRaises(ValueError) as context:
             aes_decrypt(invalid_data, self.password)
         self.assertEqual(str(context.exception), "Invalid encrypted data.")
@@ -279,7 +279,7 @@ class TestEncryption(unittest.TestCase):
         with open(test_filename, "w") as f:
             f.write(self.message)
         with self.assertRaises(ValueError) as context:
-            encrypt_file(test_filename, "output.enc", '')
+            encrypt_file(test_filename, "output.enc", "")
         self.assertEqual(
             str(context.exception),
             "Password cannot be empty.",
@@ -296,7 +296,7 @@ class TestEncryption(unittest.TestCase):
                 test_filename,
                 "output.enc",
                 self.password,
-                kdf='unsupported_kdf',
+                kdf="unsupported_kdf",
             )
         self.assertEqual(
             str(context.exception),
@@ -316,7 +316,7 @@ class TestEncryption(unittest.TestCase):
                 encrypted_filename,
                 "output_decrypted.txt",
                 self.password,
-                kdf='unsupported_kdf',
+                kdf="unsupported_kdf",
             )
         self.assertEqual(
             str(context.exception),
@@ -352,6 +352,44 @@ class TestEncryption(unittest.TestCase):
                 "Failed to read encrypted file",
                 str(context.exception),
             )
+
+    def test_encrypt_decrypt_empty_file(self):
+        """Encrypt and decrypt an empty file."""
+        test_filename = "empty.txt"
+        encrypted_filename = "empty.enc"
+        decrypted_filename = "empty.dec"
+
+        open(test_filename, "wb").close()
+
+        encrypt_file(test_filename, encrypted_filename, self.password)
+        decrypt_file(encrypted_filename, decrypted_filename, self.password)
+
+        with open(decrypted_filename, "rb") as f:
+            self.assertEqual(b"", f.read())
+
+        os.remove(test_filename)
+        os.remove(encrypted_filename)
+        os.remove(decrypted_filename)
+
+    def test_encrypt_decrypt_large_file(self):
+        """Encrypt and decrypt a large file (~5MB)."""
+        test_filename = "large.txt"
+        encrypted_filename = "large.enc"
+        decrypted_filename = "large.dec"
+
+        data = b"A" * (5 * 1024 * 1024)
+        with open(test_filename, "wb") as f:
+            f.write(data)
+
+        encrypt_file(test_filename, encrypted_filename, self.password)
+        decrypt_file(encrypted_filename, decrypted_filename, self.password)
+
+        with open(decrypted_filename, "rb") as f:
+            self.assertEqual(data, f.read())
+
+        os.remove(test_filename)
+        os.remove(encrypted_filename)
+        os.remove(decrypted_filename)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement chunk-based AES-GCM encrypt_file and decrypt_file
- add README example and document streaming
- test streaming encryption with empty and large files

## Testing
- `pip install -e .`
- `pytest -q`
