### PR TITLE
Implement SPAKE2 using spake2 library

### DIFF
--- a/cryptography_suite/pake.py
+++ b/cryptography_suite/pake.py
@@ -1,5 +1,4 @@
 from cryptography.exceptions import InvalidKey
-from cryptography.exceptions import InvalidKey
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import x25519
 from spake2 import SPAKE2_A, SPAKE2_B, SPAKEError

--- a/cryptography_suite/symmetric/kdf.py
+++ b/cryptography_suite/symmetric/kdf.py
@@ -4,7 +4,18 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-from cryptography.hazmat.primitives.kdf.argon2 import Argon2id
+try:  # pragma: no cover - optional in older cryptography versions
+    from cryptography.hazmat.primitives.kdf.argon2 import Argon2id
+    _ARGON2_CRYPTOGRAPHY = True
+except Exception:  # pragma: no cover - argon2 not supported
+    Argon2id = None
+    _ARGON2_CRYPTOGRAPHY = False
+try:  # pragma: no cover - optional external dependency
+    from argon2.low_level import hash_secret_raw, Type as _ArgonType
+    _ARGON2_CFFI = True
+except Exception:  # pragma: no cover - argon2-cffi missing
+    _ARGON2_CFFI = False
+_ARGON2_AVAILABLE = _ARGON2_CRYPTOGRAPHY or _ARGON2_CFFI
 from cryptography.exceptions import InvalidKey
 from os import urandom
 
@@ -98,14 +109,26 @@ def derive_key_argon2(
     """Derive a key using Argon2id."""
     if not password:
         raise ValueError("Password cannot be empty.")
-    kdf = Argon2id(
-        salt=salt,
-        length=key_size,
-        iterations=time_cost,
-        lanes=parallelism,
-        memory_cost=memory_cost,
-    )
-    return kdf.derive(password.encode())
+    if _ARGON2_CRYPTOGRAPHY:
+        kdf = Argon2id(
+            salt=salt,
+            length=key_size,
+            iterations=time_cost,
+            lanes=parallelism,
+            memory_cost=memory_cost,
+        )
+        return kdf.derive(password.encode())
+    if _ARGON2_CFFI:
+        return hash_secret_raw(
+            password.encode(),
+            salt,
+            time_cost,
+            memory_cost,
+            parallelism,
+            key_size,
+            _ArgonType.ID,
+        )
+    raise RuntimeError("Argon2id KDF is not available in this environment.")
 
 
 __all__ = [

--- a/cryptography_suite/symmetric/kdf.py
+++ b/cryptography_suite/symmetric/kdf.py
@@ -1,23 +1,27 @@
 from __future__ import annotations
 
+from os import urandom
+
+from cryptography.exceptions import InvalidKey
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
 try:  # pragma: no cover - optional in older cryptography versions
     from cryptography.hazmat.primitives.kdf.argon2 import Argon2id
     _ARGON2_CRYPTOGRAPHY = True
 except Exception:  # pragma: no cover - argon2 not supported
     Argon2id = None
     _ARGON2_CRYPTOGRAPHY = False
+
 try:  # pragma: no cover - optional external dependency
     from argon2.low_level import hash_secret_raw, Type as _ArgonType
     _ARGON2_CFFI = True
 except Exception:  # pragma: no cover - argon2-cffi missing
     _ARGON2_CFFI = False
+
 _ARGON2_AVAILABLE = _ARGON2_CRYPTOGRAPHY or _ARGON2_CFFI
-from cryptography.exceptions import InvalidKey
-from os import urandom
 
 # Constants
 AES_KEY_SIZE = 32  # 256 bits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 dependencies = [
     "cryptography>=41.0.3",
     "py_ecc",
+    "spake2",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cryptography~=43.0.3
 pqcrypto
 py_ecc
+spake2

--- a/tests/test_pake.py
+++ b/tests/test_pake.py
@@ -67,3 +67,13 @@ class TestPAKE(unittest.TestCase):
         client.compute_shared_key(sm)
         server.compute_shared_key(cm)
         self.assertEqual(client.get_shared_key(), server.get_shared_key())
+
+    def test_spake2_mismatched_password(self):
+        """Clients with different passwords should derive different keys."""
+        client = SPAKE2Client(self.password)
+        server = SPAKE2Server("other_password")
+        client_msg = client.generate_message()
+        server_msg = server.generate_message()
+        ck = client.compute_shared_key(server_msg)
+        sk = server.compute_shared_key(client_msg)
+        self.assertNotEqual(ck, sk)


### PR DESCRIPTION
## Summary
- implement SPAKE2 protocol with masking using `spake2` package
- gracefully fall back for Argon2 KDF using `argon2-cffi` when Cryptography lacks support
- add dependency entries
- extend PAKE tests with mismatched password case

## Testing
- `pytest -q`
