### PR TITLE
Use Argon2 by default in symmetric encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pip install .
 
 ## 🔑 Key Features
 
-- **Symmetric Encryption**: AES-GCM, ChaCha20-Poly1305 encryption with password-based key derivation using PBKDF2, Scrypt, or Argon2.
+- **Symmetric Encryption**: AES-GCM and ChaCha20-Poly1305 with Argon2 key derivation by default (PBKDF2 and Scrypt also supported).
 - **Asymmetric Encryption**: RSA encryption/decryption, key generation, serialization, and loading.
 - **Digital Signatures**: Support for Ed25519, ECDSA, and BLS (BLS12-381) algorithms for secure message signing and verification.
 - **Hashing Functions**: Implements SHA-256, SHA-384, SHA-512, and BLAKE2b hashing algorithms.
@@ -81,9 +81,9 @@ print(f"Encrypted: {encrypted_message}")
 decrypted_message = aes_decrypt(encrypted_message, password)
 print(f"Decrypted: {decrypted_message}")
 
-# Use Argon2 key derivation
-argon2_encrypted = aes_encrypt(message, password, kdf="argon2")
-print(aes_decrypt(argon2_encrypted, password, kdf="argon2"))
+# Use Scrypt key derivation for compatibility
+scrypt_encrypted = aes_encrypt(message, password, kdf="scrypt")
+print(aes_decrypt(scrypt_encrypted, password, kdf="scrypt"))
 ```
 
 Argon2id support is provided by the `cryptography` package and requires no

--- a/cryptography_suite/symmetric/aes.py
+++ b/cryptography_suite/symmetric/aes.py
@@ -93,7 +93,7 @@ def encrypt_file(
 
     Argon2id is used by default. Specify ``kdf='scrypt'`` or ``kdf='pbkdf2'`` to
     maintain compatibility with existing files.
-    
+
     The file is processed in chunks to avoid loading the entire file into
     memory. The output file begins with the salt and nonce and ends with the
     authentication tag.

--- a/cryptography_suite/symmetric/aes.py
+++ b/cryptography_suite/symmetric/aes.py
@@ -20,8 +20,12 @@ CHUNK_SIZE = 4096
 TAG_SIZE = 16  # AES-GCM authentication tag size
 
 
-def aes_encrypt(plaintext: str, password: str, kdf: str = "scrypt") -> str:
-    """Encrypt plaintext using AES-GCM with a password-derived key."""
+def aes_encrypt(plaintext: str, password: str, kdf: str = "argon2") -> str:
+    """Encrypt plaintext using AES-GCM with a password-derived key.
+
+    Argon2id is used by default. Pass ``kdf='scrypt'`` or ``kdf='pbkdf2'`` for
+    compatibility with older data.
+    """
     if not plaintext:
         raise ValueError("Plaintext cannot be empty.")
     if not password:
@@ -43,8 +47,12 @@ def aes_encrypt(plaintext: str, password: str, kdf: str = "scrypt") -> str:
     return base64.b64encode(salt + nonce + ciphertext).decode()
 
 
-def aes_decrypt(encrypted_data: str, password: str, kdf: str = "scrypt") -> str:
-    """Decrypt AES-GCM encrypted data using a password-derived key."""
+def aes_decrypt(encrypted_data: str, password: str, kdf: str = "argon2") -> str:
+    """Decrypt AES-GCM encrypted data using a password-derived key.
+
+    Argon2id is used by default. Pass ``kdf='scrypt'`` or ``kdf='pbkdf2'`` for
+    compatibility with data encrypted using those KDFs.
+    """
     if not encrypted_data:
         raise ValueError("Encrypted data cannot be empty.")
     if not password:
@@ -79,10 +87,13 @@ def encrypt_file(
     input_file_path: str,
     output_file_path: str,
     password: str,
-    kdf: str = "scrypt",
+    kdf: str = "argon2",
 ) -> None:
     """Encrypt a file using AES-GCM with a password-derived key.
 
+    Argon2id is used by default. Specify ``kdf='scrypt'`` or ``kdf='pbkdf2'`` to
+    maintain compatibility with existing files.
+    
     The file is processed in chunks to avoid loading the entire file into
     memory. The output file begins with the salt and nonce and ends with the
     authentication tag.
@@ -122,9 +133,12 @@ def decrypt_file(
     encrypted_file_path: str,
     output_file_path: str,
     password: str,
-    kdf: str = "scrypt",
+    kdf: str = "argon2",
 ) -> None:
     """Decrypt a file encrypted with AES-GCM using a password-derived key.
+
+    Argon2id is used by default. Specify ``kdf='scrypt'`` or ``kdf='pbkdf2'`` if
+    the file was encrypted using one of those KDFs.
 
     Data is streamed in chunks, verifying the authentication tag at the end.
     The output file is removed if decryption fails.

--- a/cryptography_suite/symmetric/chacha.py
+++ b/cryptography_suite/symmetric/chacha.py
@@ -5,18 +5,23 @@ from os import urandom
 
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 
-from .kdf import CHACHA20_KEY_SIZE, NONCE_SIZE, SALT_SIZE, derive_key_scrypt
+from .kdf import (
+    CHACHA20_KEY_SIZE,
+    NONCE_SIZE,
+    SALT_SIZE,
+    derive_key_argon2,
+)
 
 
 def chacha20_encrypt(plaintext: str, password: str) -> str:
-    """Encrypt using ChaCha20-Poly1305 with a Scrypt-derived key."""
+    """Encrypt using ChaCha20-Poly1305 with an Argon2-derived key."""
     if not plaintext:
         raise ValueError("Plaintext cannot be empty.")
     if not password:
         raise ValueError("Password cannot be empty.")
 
     salt = urandom(SALT_SIZE)
-    key = derive_key_scrypt(password, salt, key_size=CHACHA20_KEY_SIZE)
+    key = derive_key_argon2(password, salt, key_size=CHACHA20_KEY_SIZE)
     chacha = ChaCha20Poly1305(key)
     nonce = urandom(NONCE_SIZE)
 
@@ -39,7 +44,7 @@ def chacha20_decrypt(encrypted_data: str, password: str) -> str:
     nonce = encrypted_data_bytes[SALT_SIZE : SALT_SIZE + NONCE_SIZE]
     ciphertext = encrypted_data_bytes[SALT_SIZE + NONCE_SIZE :]
 
-    key = derive_key_scrypt(password, salt, key_size=CHACHA20_KEY_SIZE)
+    key = derive_key_argon2(password, salt, key_size=CHACHA20_KEY_SIZE)
     chacha = ChaCha20Poly1305(key)
     try:
         plaintext = chacha.decrypt(nonce, ciphertext, None)

--- a/cryptography_suite/symmetric/kdf.py
+++ b/cryptography_suite/symmetric/kdf.py
@@ -7,21 +7,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-
-try:  # pragma: no cover - optional in older cryptography versions
-    from cryptography.hazmat.primitives.kdf.argon2 import Argon2id
-    _ARGON2_CRYPTOGRAPHY = True
-except Exception:  # pragma: no cover - argon2 not supported
-    Argon2id = None
-    _ARGON2_CRYPTOGRAPHY = False
-
-try:  # pragma: no cover - optional external dependency
-    from argon2.low_level import hash_secret_raw, Type as _ArgonType
-    _ARGON2_CFFI = True
-except Exception:  # pragma: no cover - argon2-cffi missing
-    _ARGON2_CFFI = False
-
-_ARGON2_AVAILABLE = _ARGON2_CRYPTOGRAPHY or _ARGON2_CFFI
+from cryptography.hazmat.primitives.kdf.argon2 import Argon2id
 
 # Constants
 AES_KEY_SIZE = 32  # 256 bits
@@ -113,26 +99,14 @@ def derive_key_argon2(
     """Derive a key using Argon2id."""
     if not password:
         raise ValueError("Password cannot be empty.")
-    if _ARGON2_CRYPTOGRAPHY:
-        kdf = Argon2id(
-            salt=salt,
-            length=key_size,
-            iterations=time_cost,
-            lanes=parallelism,
-            memory_cost=memory_cost,
-        )
-        return kdf.derive(password.encode())
-    if _ARGON2_CFFI:
-        return hash_secret_raw(
-            password.encode(),
-            salt,
-            time_cost,
-            memory_cost,
-            parallelism,
-            key_size,
-            _ArgonType.ID,
-        )
-    raise RuntimeError("Argon2id KDF is not available in this environment.")
+    kdf = Argon2id(
+        salt=salt,
+        length=key_size,
+        iterations=time_cost,
+        lanes=parallelism,
+        memory_cost=memory_cost,
+    )
+    return kdf.derive(password.encode())
 
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "cryptography>=41.0.3",
+    "cryptography>=44.0.0",
     "py_ecc",
     "spake2",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography~=43.0.3
+cryptography>=44.0.0
 pqcrypto
 py_ecc
 spake2


### PR DESCRIPTION
## Summary
- switch all symmetric encryption helpers to Argon2 key derivation by default
- simplify Argon2 key derivation implementation
- update docs to mention the new default and show how to use Scrypt

## Testing
- `pip install -r requirements.txt`
- `pip install argon2-cffi-bindings`
- `pip install -e .`
- `pytest -q`
