### PR TITLE
Expose CLI scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,17 @@ coverage report -m
 
 Our test suite achieves **95% code coverage**, guaranteeing reliability and robustness.
 
+## 🖥 Command Line Interface
+
+Two console scripts are provided for zero-knowledge proofs:
+
+```bash
+cryptosuite-bulletproof 42
+cryptosuite-zksnark secret
+```
+
+Run each command with `-h` for detailed help.
+
 ---
 
 ## 🔒 Security Best Practices

--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import argparse
 
-from .bulletproof import prove as bp_prove, verify as bp_verify, setup as bp_setup
+from .zk.bulletproof import prove as bp_prove, verify as bp_verify, setup as bp_setup
 
 try:
     from . import zksnark
@@ -25,11 +25,13 @@ def bulletproof_cli(argv: list[str] | None = None) -> None:
 
 
 def zksnark_cli(argv: list[str] | None = None) -> None:
-    if not ZKSNARK_AVAILABLE:
-        raise RuntimeError("PySNARK not installed")
     parser = argparse.ArgumentParser(description="SHA256 pre-image proof")
     parser.add_argument("preimage", help="Preimage string")
+    if not ZKSNARK_AVAILABLE and argv and not any(a in ("-h", "--help") for a in argv):
+        raise RuntimeError("PySNARK not installed")
     args = parser.parse_args(argv)
+    if not ZKSNARK_AVAILABLE:
+        raise RuntimeError("PySNARK not installed")
     zksnark.setup()
     hash_hex, proof_path = zksnark.prove(args.preimage.encode())
     valid = zksnark.verify(hash_hex, proof_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ fhe = ["Pyfhel"]
 zk = ["pybulletproofs", "PySNARK"]
 dev = ["pytest", "pytest-cov", "coverage", "coveralls"]
 
+[project.scripts]
+cryptosuite-bulletproof = "cryptography_suite.cli:bulletproof_cli"
+cryptosuite-zksnark = "cryptography_suite.cli:zksnark_cli"
+
 [tool.black]
 line-length = 88
 target-version = ['py310']


### PR DESCRIPTION
## Summary
- expose bulletproof/zksnark CLI commands via project.scripts
- fix CLI imports and help for missing dependencies
- document available CLI commands in README

## Testing
- `pytest -q`
