### PR TITLE
Add advanced protocol exports and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,14 @@ decrypt_file("secret.enc", "secret.out", password)
 Generate RSA key pairs and perform encryption/decryption.
 
 ```python
-from cryptography_suite.asymmetric import generate_rsa_keypair, rsa_encrypt, rsa_decrypt
+from cryptography_suite import ec_encrypt
+from cryptography_suite.asymmetric import (
+    generate_rsa_keypair,
+    rsa_encrypt,
+    rsa_decrypt,
+    ec_decrypt,
+    generate_x25519_keypair,
+)
 
 # Generate RSA key pair
 private_key, public_key = generate_rsa_keypair()
@@ -202,6 +209,40 @@ from cryptography_suite import zksnark
 zksnark.setup()
 hash_hex, proof_file = zksnark.prove(b"secret")
 print(zksnark.verify(hash_hex, proof_file))
+```
+
+## Advanced Protocols
+
+### SPAKE2 Key Exchange
+
+```python
+from cryptography_suite import SPAKE2Client, SPAKE2Server
+
+c, s = SPAKE2Client("pw"), SPAKE2Server("pw")
+ck = c.compute_shared_key(s.generate_message())
+sk = s.compute_shared_key(c.generate_message())
+print(ck == sk)
+```
+Requires the optional `spake2` package.
+
+### ECIES Encryption
+
+```python
+from cryptography_suite import ec_encrypt, ec_decrypt, generate_x25519_keypair
+
+priv, pub = generate_x25519_keypair()
+cipher = ec_encrypt(b"secret", pub)
+print(ec_decrypt(cipher, priv))
+```
+
+### Signal Protocol Messaging
+
+```python
+from cryptography_suite import initialize_signal_session
+
+sender, receiver = initialize_signal_session()
+msg = sender.encrypt(b"hi")
+print(receiver.decrypt(msg))
 ```
 
 ---

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -38,6 +38,8 @@ from .asymmetric import (
     generate_x25519_keypair,
     derive_x25519_shared_key,
     generate_ec_keypair,
+    ec_encrypt,
+    ec_decrypt,
 )
 from .asymmetric.signatures import (
     generate_ed25519_keypair,
@@ -175,6 +177,8 @@ __all__ = [
     "generate_x25519_keypair",
     "derive_x25519_shared_key",
     "generate_ec_keypair",
+    "ec_encrypt",
+    "ec_decrypt",
     # Signatures
     "generate_ed25519_keypair",
     "sign_message",


### PR DESCRIPTION
## Summary
- export `ec_encrypt` and `ec_decrypt` from package root
- document SPAKE2, ECIES, and Signal Protocol usage
- show root-level import for `ec_encrypt`

## Testing
- `coverage run -m unittest discover -s tests`
