### PR TITLE
Add SHA3 and BLAKE3 hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pip install .
 - **Symmetric Encryption**: AES-GCM and ChaCha20-Poly1305 with Argon2 key derivation by default (PBKDF2 and Scrypt also supported).
 - **Asymmetric Encryption**: RSA encryption/decryption, key generation, serialization, and loading.
 - **Digital Signatures**: Support for Ed25519, **Ed448**, ECDSA, and BLS (BLS12-381) algorithms for secure message signing and verification.
-- **Hashing Functions**: Implements SHA-256, SHA-384, SHA-512, and BLAKE2b hashing algorithms.
+- **Hashing Functions**: Implements SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-512, BLAKE2b, and BLAKE3 hashing algorithms.
 - **Key Management**: Secure generation, storage, loading, and rotation of cryptographic keys.
 - **Secret Sharing**: Implementation of Shamir's Secret Sharing scheme for splitting and reconstructing secrets.
 - **Password-Authenticated Key Exchange (PAKE)**: SPAKE2 protocol implementation for secure password-based key exchange.
@@ -278,6 +278,27 @@ from cryptography_suite import initialize_signal_session
 sender, receiver = initialize_signal_session()
 msg = sender.encrypt(b"hi")
 print(receiver.decrypt(msg))
+```
+
+## Hashing
+
+Generate message digests with standard algorithms.
+
+```python
+from cryptography_suite.hashing import (
+    sha256_hash,
+    sha3_256_hash,
+    sha3_512_hash,
+    blake2b_hash,
+    blake3_hash,
+)
+
+data = "The quick brown fox jumps over the lazy dog"
+print(sha256_hash(data))
+print(sha3_256_hash(data))
+print(sha3_512_hash(data))
+print(blake2b_hash(data))
+print(blake3_hash(data))
 ```
 
 ---

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -89,7 +89,10 @@ from .hashing import (
     sha384_hash,
     sha256_hash,
     sha512_hash,
+    sha3_256_hash,
+    sha3_512_hash,
     blake2b_hash,
+    blake3_hash,
 )
 from .protocols import (
     generate_aes_key,
@@ -214,7 +217,10 @@ __all__ = [
     "sha384_hash",
     "sha256_hash",
     "sha512_hash",
+    "sha3_256_hash",
+    "sha3_512_hash",
     "blake2b_hash",
+    "blake3_hash",
     # Key Management
     "generate_aes_key",
     "rotate_aes_key",

--- a/cryptography_suite/hashing/__init__.py
+++ b/cryptography_suite/hashing/__init__.py
@@ -1,4 +1,5 @@
 from cryptography.hazmat.primitives import hashes
+from blake3 import blake3
 
 from ..symmetric.kdf import (  # noqa: F401
     derive_key_scrypt,
@@ -36,6 +37,20 @@ def sha512_hash(data: str) -> str:
     return digest.finalize().hex()
 
 
+def sha3_256_hash(data: str) -> str:
+    """Generates a SHA3-256 hash of the given data."""
+    digest = hashes.Hash(hashes.SHA3_256())
+    digest.update(data.encode())
+    return digest.finalize().hex()
+
+
+def sha3_512_hash(data: str) -> str:
+    """Generates a SHA3-512 hash of the given data."""
+    digest = hashes.Hash(hashes.SHA3_512())
+    digest.update(data.encode())
+    return digest.finalize().hex()
+
+
 def blake2b_hash(data: str) -> str:
     """
     Generates a BLAKE2b hash of the given data.
@@ -43,3 +58,8 @@ def blake2b_hash(data: str) -> str:
     digest = hashes.Hash(hashes.BLAKE2b(64))
     digest.update(data.encode())
     return digest.finalize().hex()
+
+
+def blake3_hash(data: str) -> str:
+    """Generates a BLAKE3 hash of the given data."""
+    return blake3(data.encode()).hexdigest()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "cryptography>=44.0.0",
     "py_ecc",
     "spake2",
+    "blake3",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cryptography>=44.0.0
 pqcrypto
 py_ecc
 spake2
+blake3

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -4,7 +4,10 @@ from cryptography_suite.hashing import (
     sha256_hash,
     sha384_hash,
     sha512_hash,
+    sha3_256_hash,
+    sha3_512_hash,
     blake2b_hash,
+    blake3_hash,
     derive_key_scrypt,
     derive_key_pbkdf2,
     verify_derived_key_scrypt,
@@ -44,6 +47,31 @@ class TestHashing(unittest.TestCase):
         digest = blake2b_hash(self.data)
         self.assertIsInstance(digest, str)
         self.assertEqual(len(digest), 128)  # BLAKE2b default digest size is 64 bytes
+
+    def test_sha3_256_hash_vector(self):
+        """Test SHA3-256 against a known vector."""
+        digest = sha3_256_hash("The quick brown fox jumps over the lazy dog")
+        self.assertEqual(
+            digest,
+            "69070dda01975c8c120c3aada1b282394e7f032fa9cf32f4cb2259a0897dfc04",
+        )
+
+    def test_sha3_512_hash_vector(self):
+        """Test SHA3-512 against a known vector."""
+        digest = sha3_512_hash("The quick brown fox jumps over the lazy dog")
+        self.assertEqual(
+            digest,
+            "01dedd5de4ef14642445ba5f5b97c15e47b9ad931326e4b0727cd94cefc44fff"
+            "23f07bf543139939b49128caf436dc1bdee54fcb24023a08d9403f9b4bf0d450",
+        )
+
+    def test_blake3_hash_vector(self):
+        """Test BLAKE3 against a known vector."""
+        digest = blake3_hash("The quick brown fox jumps over the lazy dog")
+        self.assertEqual(
+            digest,
+            "2f1514181aadccd913abd94cfa592701a5686ab23f8df1dff1b74710febc6d4a",
+        )
 
     def test_derive_key_scrypt(self):
         """Test key derivation using Scrypt."""


### PR DESCRIPTION
## Summary
- support SHA3 and BLAKE3 algorithms
- document them in README
- add hashing tests with known vectors
- update package dependencies

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`
