### PR TITLE
Add Kyber and Dilithium wrappers

### DIFF
--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -74,8 +74,8 @@ from .asymmetric.bls import (
 try:  # pragma: no cover - optional dependency
     from .pqc import (
         generate_kyber_keypair,
-        kyber_encapsulate,
-        kyber_decapsulate,
+        kyber_encrypt,
+        kyber_decrypt,
         generate_dilithium_keypair,
         dilithium_sign,
         dilithium_verify,
@@ -259,8 +259,8 @@ if PQCRYPTO_AVAILABLE:
     __all__.extend(
         [
             "generate_kyber_keypair",
-            "kyber_encapsulate",
-            "kyber_decapsulate",
+            "kyber_encrypt",
+            "kyber_decrypt",
             "generate_dilithium_keypair",
             "dilithium_sign",
             "dilithium_verify",

--- a/tests/test_pqc.py
+++ b/tests/test_pqc.py
@@ -3,8 +3,8 @@ import unittest
 from cryptography_suite.pqc import (
     PQCRYPTO_AVAILABLE,
     generate_kyber_keypair,
-    kyber_encapsulate,
-    kyber_decapsulate,
+    kyber_encrypt,
+    kyber_decrypt,
     generate_dilithium_keypair,
     dilithium_sign,
     dilithium_verify,
@@ -12,18 +12,18 @@ from cryptography_suite.pqc import (
 
 
 @unittest.skipUnless(PQCRYPTO_AVAILABLE, "pqcrypto not installed")
-class TestPostQuantum(unittest.TestCase):
-    def test_kyber_kem(self):
+class TestPQC(unittest.TestCase):
+    def test_kyber_encrypt_decrypt(self):
         pk, sk = generate_kyber_keypair()
-        ct, ss1 = kyber_encapsulate(pk)
-        ss2 = kyber_decapsulate(ct, sk)
-        self.assertEqual(ss1, ss2)
+        msg = b"pqc test"
+        ct, ss = kyber_encrypt(pk, msg)
+        self.assertEqual(kyber_decrypt(sk, ct, ss), msg)
 
     def test_dilithium_signature(self):
         pk, sk = generate_dilithium_keypair()
-        message = b"test message"
-        sig = dilithium_sign(message, sk)
-        self.assertTrue(dilithium_verify(message, sig, pk))
+        msg = b"sign me"
+        sig = dilithium_sign(sk, msg)
+        self.assertTrue(dilithium_verify(pk, msg, sig))
 
 
 if __name__ == "__main__":

--- a/tests/test_pqc_stubs.py
+++ b/tests/test_pqc_stubs.py
@@ -14,6 +14,8 @@ class DummyKEM:
     def decrypt(sk, ct):
         return b"ss"
 
+    CIPHERTEXT_SIZE = 2
+
 class DummySIG:
     @staticmethod
     def generate_keypair():
@@ -48,23 +50,11 @@ def reload_module(monkeypatch):
 def test_pqc_key_enc_sign(monkeypatch):
     pqc = reload_module(monkeypatch)
     pk, sk = pqc.generate_kyber_keypair()
-    ct, ss = pqc.kyber_encapsulate(pk)
-    assert pqc.kyber_decapsulate(ct, sk) == ss
+    ct, ss = pqc.kyber_encrypt(pk, b"m")
+    assert pqc.kyber_decrypt(sk, ct, ss) == b"m"
     pk2, sk2 = pqc.generate_dilithium_keypair()
-    sig = pqc.dilithium_sign(b"m", sk2)
-    assert pqc.dilithium_verify(b"m", sig, pk2)
-    with pytest.raises(ValueError):
-        pqc.generate_kyber_keypair(999)
-    with pytest.raises(ValueError):
-        pqc.kyber_encapsulate(pk, 999)
-    with pytest.raises(ValueError):
-        pqc.kyber_decapsulate(ct, sk, 999)
-    with pytest.raises(ValueError):
-        pqc.generate_dilithium_keypair(0)
-    with pytest.raises(ValueError):
-        pqc.dilithium_sign(b"m", sk2, 0)
-    with pytest.raises(ValueError):
-        pqc.dilithium_verify(b"m", b"x", pk2, 0)
+    sig = pqc.dilithium_sign(sk2, b"m")
+    assert pqc.dilithium_verify(pk2, b"m", sig)
 
 
 def test_pqc_import_error(monkeypatch):


### PR DESCRIPTION
## Summary
- expose PQCrypto Kyber and Dilithium through high level API
- implement Kyber encrypt/decrypt using AES-GCM
- update package exports
- rewrite PQC stub tests and main PQC tests for new API

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`
