### PR TITLE
Expose PQC encapsulation at package root

### DIFF
--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -74,6 +74,8 @@ from .asymmetric.bls import (
 try:  # pragma: no cover - optional dependency
     from .pqc import (
         generate_kyber_keypair,
+        kyber_encapsulate,
+        kyber_decapsulate,
         kyber_encrypt,
         kyber_decrypt,
         generate_dilithium_keypair,
@@ -259,6 +261,8 @@ if PQCRYPTO_AVAILABLE:
     __all__.extend(
         [
             "generate_kyber_keypair",
+            "kyber_encapsulate",
+            "kyber_decapsulate",
             "kyber_encrypt",
             "kyber_decrypt",
             "generate_dilithium_keypair",

--- a/tests/test_root_exports.py
+++ b/tests/test_root_exports.py
@@ -1,0 +1,7 @@
+import cryptography_suite as cs
+
+# Basic smoke test ensuring key functions are exposed at package level
+
+def test_root_exports_available():
+    assert callable(cs.aes_encrypt)
+    assert callable(cs.rsa_encrypt)


### PR DESCRIPTION
## Summary
- expose `kyber_encapsulate` and `kyber_decapsulate` via `cryptography_suite`
- add regression test ensuring package-level export of core functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa41f6c30832a948221bb946a977b