### PR TITLE
Normalize asymmetric outputs to Base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ decrypt_file("secret.enc", "secret.out", password)
 
 Generate RSA key pairs and perform encryption/decryption.
 
+Ciphertext and related binary outputs are returned as Base64 strings by
+default. Pass ``raw_output=True`` to obtain raw bytes instead.
+
 ```python
 from cryptography_suite import ec_encrypt
 from cryptography_suite.asymmetric import (
@@ -120,7 +123,7 @@ private_key, public_key = generate_rsa_keypair()
 
 message = b"Secure Data Transfer"
 
-# Encrypt the message
+# Encrypt the message (Base64 encoded by default)
 encrypted_message = rsa_encrypt(message, public_key)
 print(f"Encrypted: {encrypted_message}")
 
@@ -266,6 +269,7 @@ Requires the optional `spake2` package.
 from cryptography_suite import ec_encrypt, ec_decrypt, generate_x25519_keypair
 
 priv, pub = generate_x25519_keypair()
+# ``cipher`` is Base64 encoded by default. Use ``raw_output=True`` for bytes.
 cipher = ec_encrypt(b"secret", pub)
 print(ec_decrypt(cipher, priv))
 ```

--- a/tests/test_asymmetric.py
+++ b/tests/test_asymmetric.py
@@ -1,4 +1,5 @@
 import unittest
+import base64
 from cryptography_suite.asymmetric import (
     generate_rsa_keypair,
     rsa_encrypt,
@@ -29,6 +30,7 @@ class TestAsymmetric(unittest.TestCase):
         """Test RSA encryption and decryption."""
         private_key, public_key = generate_rsa_keypair()
         ciphertext = rsa_encrypt(self.message, public_key)
+        self.assertIsInstance(ciphertext, str)
         plaintext = rsa_decrypt(ciphertext, private_key)
         self.assertEqual(self.message, plaintext)
 
@@ -243,6 +245,7 @@ class TestAsymmetric(unittest.TestCase):
         priv, pub = generate_x25519_keypair()
         data = b"Top secret"
         ct = ec_encrypt(data, pub)
+        self.assertIsInstance(ct, str)
         pt = ec_decrypt(ct, priv)
         self.assertEqual(data, pt)
 
@@ -258,9 +261,11 @@ class TestAsymmetric(unittest.TestCase):
         """Tampering with ciphertext must raise an error."""
         priv, pub = generate_x25519_keypair()
         ct = ec_encrypt(self.message, pub)
-        tampered = ct[:-1] + bytes([ct[-1] ^ 0x01])
+        raw = base64.b64decode(ct)
+        tampered = raw[:-1] + bytes([raw[-1] ^ 0x01])
+        tampered_b64 = base64.b64encode(tampered).decode()
         with self.assertRaises(CryptographySuiteError):
-            ec_decrypt(tampered, priv)
+            ec_decrypt(tampered_b64, priv)
 
 
 if __name__ == "__main__":

--- a/tests/test_interfaces_full.py
+++ b/tests/test_interfaces_full.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 import types
+import base64
 
 import pytest
 from cryptography_suite.errors import DecryptionError
@@ -96,6 +97,7 @@ def test_ecies_roundtrip():
     priv, pub = generate_x25519_keypair()
     msg = b"top"
     ct = ec_encrypt(msg, pub)
+    assert isinstance(ct, str)
     assert ec_decrypt(ct, priv) == msg
 
 
@@ -110,9 +112,11 @@ def test_ecies_wrong_key():
 def test_ecies_tamper(monkeypatch):
     priv, pub = generate_x25519_keypair()
     ct = ec_encrypt(b"msg", pub)
-    tampered = ct[:-1] + bytes([ct[-1] ^ 1])
+    raw = base64.b64decode(ct)
+    tampered = raw[:-1] + bytes([raw[-1] ^ 1])
+    tampered_b64 = base64.b64encode(tampered).decode()
     with pytest.raises(DecryptionError):
-        ec_decrypt(tampered, priv)
+        ec_decrypt(tampered_b64, priv)
 
 
 def test_ecies_deterministic(monkeypatch):

--- a/tests/test_pqc.py
+++ b/tests/test_pqc.py
@@ -17,12 +17,15 @@ class TestPQC(unittest.TestCase):
         pk, sk = generate_kyber_keypair()
         msg = b"pqc test"
         ct, ss = kyber_encrypt(pk, msg)
+        self.assertIsInstance(ct, str)
+        self.assertIsInstance(ss, str)
         self.assertEqual(kyber_decrypt(sk, ct, ss), msg)
 
     def test_dilithium_signature(self):
         pk, sk = generate_dilithium_keypair()
         msg = b"sign me"
         sig = dilithium_sign(sk, msg)
+        self.assertIsInstance(sig, str)
         self.assertTrue(dilithium_verify(pk, msg, sig))
 
 

--- a/tests/test_pqc_stubs.py
+++ b/tests/test_pqc_stubs.py
@@ -51,9 +51,12 @@ def test_pqc_key_enc_sign(monkeypatch):
     pqc = reload_module(monkeypatch)
     pk, sk = pqc.generate_kyber_keypair()
     ct, ss = pqc.kyber_encrypt(pk, b"m")
+    assert isinstance(ct, str)
+    assert isinstance(ss, str)
     assert pqc.kyber_decrypt(sk, ct, ss) == b"m"
     pk2, sk2 = pqc.generate_dilithium_keypair()
     sig = pqc.dilithium_sign(sk2, b"m")
+    assert isinstance(sig, str)
     assert pqc.dilithium_verify(pk2, b"m", sig)
 
 


### PR DESCRIPTION
## Summary
- return Base64 strings from `rsa_encrypt` and `ec_encrypt`
- allow opt-out via `raw_output=True`
- decode Base64 automatically in decrypt/verify routines
- expose the same behaviour for Kyber/Dilithium PQC helpers
- document the new behaviour and update tests

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687feab12968832a83c95870ae1205a9