### PR TITLE
Add hybrid RSA/ECIES AES encryption

### DIFF
--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -12,132 +12,131 @@ from .errors import (
 
 __version__ = "2.0.0"
 
-# Symmetric primitives -------------------------------------------------------
-from .symmetric import (
-    aes_encrypt,
-    aes_decrypt,
-    chacha20_encrypt,
-    chacha20_decrypt,
-    scrypt_encrypt,
-    scrypt_decrypt,
-    argon2_encrypt,
-    argon2_decrypt,
-    pbkdf2_encrypt,
-    pbkdf2_decrypt,
-    encrypt_file,
-    decrypt_file,
-    ascon_encrypt,
-    ascon_decrypt,
-    derive_key_scrypt,
-    derive_key_pbkdf2,
-    derive_key_argon2,
-    verify_derived_key_scrypt,
-    verify_derived_key_pbkdf2,
-    generate_salt,
-)
-
 # Asymmetric primitives ------------------------------------------------------
 from .asymmetric import (
+    derive_x448_shared_key,
+    derive_x25519_shared_key,
+    ec_decrypt,
+    ec_encrypt,
+    generate_ec_keypair,
     generate_rsa_keypair,
-    rsa_encrypt,
-    rsa_decrypt,
-    serialize_private_key,
-    serialize_public_key,
+    generate_x448_keypair,
+    generate_x25519_keypair,
     load_private_key,
     load_public_key,
-    generate_x25519_keypair,
-    derive_x25519_shared_key,
-    generate_x448_keypair,
-    derive_x448_shared_key,
-    generate_ec_keypair,
-    ec_encrypt,
-    ec_decrypt,
-)
-from .asymmetric.signatures import (
-    generate_ed25519_keypair,
-    generate_ed448_keypair,
-    sign_message,
-    sign_message_ed448,
-    verify_signature,
-    verify_signature_ed448,
-    serialize_ed25519_private_key,
-    serialize_ed25519_public_key,
-    load_ed25519_private_key,
-    load_ed25519_public_key,
-    generate_ecdsa_keypair,
-    sign_message_ecdsa,
-    verify_signature_ecdsa,
-    serialize_ecdsa_private_key,
-    serialize_ecdsa_public_key,
-    load_ecdsa_private_key,
-    load_ecdsa_public_key,
+    rsa_decrypt,
+    rsa_encrypt,
+    serialize_private_key,
+    serialize_public_key,
 )
 from .asymmetric.bls import (
-    generate_bls_keypair,
-    bls_sign,
-    bls_verify,
     bls_aggregate,
     bls_aggregate_verify,
+    bls_sign,
+    bls_verify,
+    generate_bls_keypair,
+)
+from .asymmetric.signatures import (
+    generate_ecdsa_keypair,
+    generate_ed448_keypair,
+    generate_ed25519_keypair,
+    load_ecdsa_private_key,
+    load_ecdsa_public_key,
+    load_ed25519_private_key,
+    load_ed25519_public_key,
+    serialize_ecdsa_private_key,
+    serialize_ecdsa_public_key,
+    serialize_ed25519_private_key,
+    serialize_ed25519_public_key,
+    sign_message,
+    sign_message_ecdsa,
+    sign_message_ed448,
+    verify_signature,
+    verify_signature_ecdsa,
+    verify_signature_ed448,
+)
+from .hybrid import hybrid_decrypt, hybrid_encrypt
+
+# Symmetric primitives -------------------------------------------------------
+from .symmetric import (
+    aes_decrypt,
+    aes_encrypt,
+    argon2_decrypt,
+    argon2_encrypt,
+    ascon_decrypt,
+    ascon_encrypt,
+    chacha20_decrypt,
+    chacha20_encrypt,
+    decrypt_file,
+    derive_key_argon2,
+    derive_key_pbkdf2,
+    derive_key_scrypt,
+    encrypt_file,
+    generate_salt,
+    pbkdf2_decrypt,
+    pbkdf2_encrypt,
+    scrypt_decrypt,
+    scrypt_encrypt,
+    verify_derived_key_pbkdf2,
+    verify_derived_key_scrypt,
 )
 
 # Post-quantum cryptography --------------------------------------------------
 try:  # pragma: no cover - optional dependency
-    from .pqc import (
-        generate_kyber_keypair,
-        kyber_encapsulate,
-        kyber_decapsulate,
-        kyber_encrypt,
-        kyber_decrypt,
-        generate_dilithium_keypair,
+    from .pqc import (  # noqa: F401
+        PQCRYPTO_AVAILABLE,
         dilithium_sign,
         dilithium_verify,
-        PQCRYPTO_AVAILABLE,
-    )  # noqa: F401
+        generate_dilithium_keypair,
+        generate_kyber_keypair,
+        kyber_decapsulate,
+        kyber_decrypt,
+        kyber_encapsulate,
+        kyber_encrypt,
+    )
 except Exception:  # pragma: no cover - fallback when pqcrypto is missing
     PQCRYPTO_AVAILABLE = False
 
 # Hashing and utilities ------------------------------------------------------
 from .hashing import (
-    sha384_hash,
-    sha256_hash,
-    sha512_hash,
-    sha3_256_hash,
-    sha3_512_hash,
     blake2b_hash,
     blake3_hash,
     blake3_hash_v2,
+    sha3_256_hash,
+    sha3_512_hash,
+    sha256_hash,
+    sha384_hash,
+    sha512_hash,
 )
 from .protocols import (
-    generate_aes_key,
-    rotate_aes_key,
-    secure_save_key_to_file,
-    load_private_key_from_file,
-    load_public_key_from_file,
-    key_exists,
-    generate_rsa_keypair_and_save,
-    generate_ec_keypair_and_save,
-    create_shares,
-    reconstruct_secret,
+    SignalReceiver,
+    SignalSender,
     SPAKE2Client,
     SPAKE2Server,
-    generate_totp,
-    verify_totp,
+    create_shares,
+    generate_aes_key,
+    generate_ec_keypair_and_save,
     generate_hotp,
-    verify_hotp,
-    SignalSender,
-    SignalReceiver,
+    generate_rsa_keypair_and_save,
+    generate_totp,
     initialize_signal_session,
+    key_exists,
+    load_private_key_from_file,
+    load_public_key_from_file,
+    reconstruct_secret,
+    rotate_aes_key,
+    secure_save_key_to_file,
+    verify_hotp,
+    verify_totp,
 )
 
 # Optional homomorphic encryption -------------------------------------------
 try:  # pragma: no cover - optional dependency
-    from .homomorphic import (
-        keygen as fhe_keygen,
-        encrypt as fhe_encrypt,
-        decrypt as fhe_decrypt,
-        add as fhe_add,
-        multiply as fhe_multiply,
-    )  # noqa: F401
+    from .homomorphic import add as fhe_add
+    from .homomorphic import decrypt as fhe_decrypt
+    from .homomorphic import encrypt as fhe_encrypt
+    from .homomorphic import keygen as fhe_keygen  # noqa: F401
+    from .homomorphic import multiply as fhe_multiply
 
     FHE_AVAILABLE = True
 except Exception:  # pragma: no cover - handle missing Pyfhel
@@ -146,6 +145,7 @@ except Exception:  # pragma: no cover - handle missing Pyfhel
 # Zero-knowledge proofs ------------------------------------------------------
 try:  # pragma: no cover - optional dependency
     from .zk import bulletproof
+
     BULLETPROOF_AVAILABLE = True
 except Exception:  # pragma: no cover - handle missing dependency
     bulletproof = None
@@ -153,17 +153,18 @@ except Exception:  # pragma: no cover - handle missing dependency
 
 try:  # pragma: no cover - optional dependency
     from .zk import zksnark
+
     ZKSNARK_AVAILABLE = getattr(zksnark, "ZKSNARK_AVAILABLE", False)
 except Exception:  # pragma: no cover - handle missing dependency
     zksnark = None
     ZKSNARK_AVAILABLE = False
 
 from .utils import (
-    base62_encode,
-    base62_decode,
-    secure_zero,
-    generate_secure_random_string,
     KeyVault,
+    base62_decode,
+    base62_encode,
+    generate_secure_random_string,
+    secure_zero,
 )
 
 __all__ = [
@@ -203,6 +204,8 @@ __all__ = [
     "generate_ec_keypair",
     "ec_encrypt",
     "ec_decrypt",
+    "hybrid_encrypt",
+    "hybrid_decrypt",
     # Signatures
     "generate_ed25519_keypair",
     "generate_ed448_keypair",

--- a/cryptography_suite/hybrid.py
+++ b/cryptography_suite/hybrid.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import base64
+from os import urandom
+from typing import Any, Dict
+
+from cryptography.hazmat.primitives.asymmetric import rsa, x25519
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from .asymmetric import ec_decrypt, ec_encrypt, rsa_decrypt, rsa_encrypt
+from .errors import DecryptionError, EncryptionError
+
+
+def hybrid_encrypt(message: bytes, public_key: Any) -> Dict[str, str]:
+    """Encrypt ``message`` using hybrid RSA/ECIES + AES-GCM.
+
+    The AES key is randomly generated and encrypted with the recipient's
+    public key. The message itself is encrypted with AES-GCM.
+    """
+    if not message:
+        raise EncryptionError("Message cannot be empty.")
+
+    if isinstance(public_key, rsa.RSAPublicKey):
+        key_encrypt = lambda k: rsa_encrypt(k, public_key)
+    elif isinstance(public_key, x25519.X25519PublicKey):
+        key_encrypt = lambda k: ec_encrypt(k, public_key)
+    else:
+        raise TypeError("Unsupported public key type.")
+
+    aes_key = urandom(32)
+    aesgcm = AESGCM(aes_key)
+    nonce = urandom(12)
+    enc = aesgcm.encrypt(nonce, message, None)
+    ciphertext = enc[:-16]
+    tag = enc[-16:]
+
+    encrypted_key = key_encrypt(aes_key)
+
+    return {
+        "encrypted_key": encrypted_key,
+        "nonce": base64.b64encode(nonce).decode(),
+        "ciphertext": base64.b64encode(ciphertext).decode(),
+        "tag": base64.b64encode(tag).decode(),
+    }
+
+
+def hybrid_decrypt(private_key: Any, data: Dict[str, str]) -> bytes:
+    """Decrypt data produced by :func:`hybrid_encrypt`."""
+
+    for field in ("encrypted_key", "nonce", "ciphertext", "tag"):
+        if field not in data:
+            raise DecryptionError("Invalid encrypted payload.")
+
+    enc_key = data["encrypted_key"]
+    nonce_b64 = data["nonce"]
+    ct_b64 = data["ciphertext"]
+    tag_b64 = data["tag"]
+
+    if isinstance(private_key, rsa.RSAPrivateKey):
+        aes_key = rsa_decrypt(enc_key, private_key)
+    elif isinstance(private_key, x25519.X25519PrivateKey):
+        aes_key = ec_decrypt(enc_key, private_key)
+    else:
+        raise TypeError("Unsupported private key type.")
+
+    try:
+        nonce = base64.b64decode(nonce_b64)
+        ciphertext = base64.b64decode(ct_b64)
+        tag = base64.b64decode(tag_b64)
+    except Exception as exc:  # pragma: no cover - defensive parsing
+        raise DecryptionError(f"Invalid encoded data: {exc}") from exc
+
+    aesgcm = AESGCM(aes_key)
+    try:
+        return aesgcm.decrypt(nonce, ciphertext + tag, None)
+    except Exception as exc:  # pragma: no cover - high-level error handling
+        raise DecryptionError(f"Decryption failed: {exc}") from exc
+
+
+__all__ = ["hybrid_encrypt", "hybrid_decrypt"]

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -1,0 +1,47 @@
+import base64
+import unittest
+
+from cryptography_suite import hybrid_decrypt, hybrid_encrypt
+from cryptography_suite.asymmetric import generate_rsa_keypair, generate_x25519_keypair
+from cryptography_suite.errors import CryptographySuiteError
+
+
+class TestHybrid(unittest.TestCase):
+    def test_hybrid_rsa_roundtrip(self):
+        priv, pub = generate_rsa_keypair()
+        msg = b"hybrid"
+        data = hybrid_encrypt(msg, pub)
+        self.assertIsInstance(data, dict)
+        pt = hybrid_decrypt(priv, data)
+        self.assertEqual(pt, msg)
+
+    def test_hybrid_ecies_roundtrip(self):
+        priv, pub = generate_x25519_keypair()
+        msg = b"ecies"
+        data = hybrid_encrypt(msg, pub)
+        self.assertIn("encrypted_key", data)
+        self.assertEqual(hybrid_decrypt(priv, data), msg)
+
+    def test_hybrid_encrypt_empty_message(self):
+        _, pub = generate_rsa_keypair()
+        with self.assertRaises(CryptographySuiteError):
+            hybrid_encrypt(b"", pub)
+
+    def test_hybrid_decrypt_wrong_key(self):
+        priv, pub = generate_rsa_keypair()
+        wrong_priv, _ = generate_rsa_keypair()
+        data = hybrid_encrypt(b"msg", pub)
+        with self.assertRaises(CryptographySuiteError):
+            hybrid_decrypt(wrong_priv, data)
+
+    def test_hybrid_decrypt_tampered_ciphertext(self):
+        priv, pub = generate_x25519_keypair()
+        data = hybrid_encrypt(b"msg", pub)
+        ct = base64.b64decode(data["ciphertext"])
+        data["ciphertext"] = base64.b64encode(ct[:-1] + bytes([ct[-1] ^ 1])).decode()
+        with self.assertRaises(CryptographySuiteError):
+            hybrid_decrypt(priv, data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `hybrid_encrypt`/`hybrid_decrypt` for hybrid RSA or ECIES encryption with AES-GCM
- expose new APIs through package exports
- add unit tests for the new functionality

## Testing
- `black cryptography_suite/hybrid.py cryptography_suite/__init__.py tests/test_hybrid.py`
- `isort cryptography_suite/hybrid.py cryptography_suite/__init__.py tests/test_hybrid.py`
- `isort --check cryptography_suite/hybrid.py cryptography_suite/__init__.py tests/test_hybrid.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ffc1e9ca8832a8db1eec1bd274b8a