### PR TITLE
Add audit logging decorator

### DIFF
--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -175,6 +175,7 @@ from .utils import (
     generate_secure_random_string,
     secure_zero,
 )
+from .audit import audit_log, set_audit_logger
 
 __all__ = [
     # Encryption
@@ -283,6 +284,8 @@ __all__ = [
     "generate_secure_random_string",
     "KeyVault",
     "KeyManager",
+    "audit_log",
+    "set_audit_logger",
     # Signal Protocol
     "SignalSender",
     "SignalReceiver",

--- a/cryptography_suite/audit.py
+++ b/cryptography_suite/audit.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Callable, Protocol
+
+from cryptography.fernet import Fernet
+
+
+class AuditLogger(Protocol):
+    """Protocol for audit loggers."""
+
+    def log(self, operation: str, status: str) -> None:
+        ...
+
+
+class InMemoryAuditLogger:
+    """Store audit logs in memory."""
+
+    def __init__(self) -> None:
+        self.logs: list[dict[str, str]] = []
+
+    def log(self, operation: str, status: str) -> None:
+        entry = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "operation": operation,
+            "status": status,
+        }
+        self.logs.append(entry)
+
+
+class EncryptedFileAuditLogger:
+    """Write audit logs to an encrypted file using Fernet."""
+
+    def __init__(self, file_path: str, key: bytes) -> None:
+        self.file_path = file_path
+        self.fernet = Fernet(key)
+
+    def log(self, operation: str, status: str) -> None:
+        entry = f"{datetime.utcnow().isoformat()}|{operation}|{status}"
+        data = self.fernet.encrypt(entry.encode())
+        with open(self.file_path, "ab") as f:
+            f.write(data + b"\n")
+
+
+_AUDIT_LOGGER: AuditLogger | None = None
+
+
+def set_audit_logger(
+    logger: AuditLogger | None = None,
+    *,
+    log_file: str | None = None,
+    key: bytes | None = None,
+) -> None:
+    """Configure the audit logger.
+
+    Passing ``logger`` sets a custom logger instance. Alternatively ``log_file``
+    and ``key`` can be provided to enable encrypted file logging. Passing
+    ``None`` disables auditing.
+    """
+    global _AUDIT_LOGGER
+
+    if logger is not None:
+        _AUDIT_LOGGER = logger
+    elif log_file is not None:
+        if key is None:
+            raise ValueError("Key required for encrypted file logging")
+        _AUDIT_LOGGER = EncryptedFileAuditLogger(log_file, key)
+    else:
+        _AUDIT_LOGGER = None
+
+
+def _get_audit_logger() -> AuditLogger | None:
+    if _AUDIT_LOGGER is not None:
+        return _AUDIT_LOGGER
+    if os.getenv("AUDIT_MODE"):
+        _set_default_logger()
+        return _AUDIT_LOGGER
+    return None
+
+
+def _set_default_logger() -> None:
+    global _AUDIT_LOGGER
+    if _AUDIT_LOGGER is not None:
+        return
+    file_path = os.getenv("AUDIT_LOG_FILE")
+    if file_path:
+        key = os.getenv("AUDIT_LOG_KEY")
+        if not key:
+            raise ValueError("AUDIT_LOG_KEY must be set when using AUDIT_LOG_FILE")
+        _AUDIT_LOGGER = EncryptedFileAuditLogger(file_path, key.encode())
+    else:
+        _AUDIT_LOGGER = InMemoryAuditLogger()
+
+
+def audit_log(func: Callable) -> Callable:
+    """Decorator to log cryptographic operations."""
+
+    def wrapper(*args, **kwargs):
+        logger = _get_audit_logger()
+        try:
+            result = func(*args, **kwargs)
+            if logger is not None:
+                logger.log(func.__name__, "success")
+            return result
+        except Exception:
+            if logger is not None:
+                logger.log(func.__name__, "failure")
+            raise
+
+    return wrapper

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,74 @@
+import os
+import unittest
+
+from cryptography.fernet import Fernet
+
+import cryptography_suite.audit as audit
+from cryptography_suite.audit import audit_log, set_audit_logger, InMemoryAuditLogger
+
+
+class TestAuditLogging(unittest.TestCase):
+    def tearDown(self):
+        # Clean up any global logger and environment variables
+        set_audit_logger(None)
+        os.environ.pop("AUDIT_MODE", None)
+        os.environ.pop("AUDIT_LOG_FILE", None)
+        os.environ.pop("AUDIT_LOG_KEY", None)
+
+    def test_memory_logging_success_and_failure(self):
+        logger = InMemoryAuditLogger()
+        set_audit_logger(logger)
+
+        @audit_log
+        def ok(x):
+            return x * 2
+
+        @audit_log
+        def bad():
+            raise ValueError("boom")
+
+        self.assertEqual(ok(2), 4)
+        with self.assertRaises(ValueError):
+            bad()
+
+        self.assertEqual(len(logger.logs), 2)
+        self.assertEqual(logger.logs[0]["operation"], "ok")
+        self.assertEqual(logger.logs[0]["status"], "success")
+        self.assertEqual(logger.logs[1]["status"], "failure")
+
+    def test_audit_mode_env_variable(self):
+        os.environ["AUDIT_MODE"] = "1"
+
+        # No explicit logger set. Should create default InMemoryAuditLogger.
+        @audit_log
+        def sample():
+            return "test"
+
+        sample()
+        self.assertIsInstance(audit._AUDIT_LOGGER, audit.InMemoryAuditLogger)
+        self.assertEqual(len(audit._AUDIT_LOGGER.logs), 1)
+        self.assertEqual(audit._AUDIT_LOGGER.logs[0]["status"], "success")
+
+    def test_encrypted_file_logging(self):
+        key = Fernet.generate_key()
+        log_path = "audit.log"
+        set_audit_logger(log_file=log_path, key=key)
+
+        @audit_log
+        def action():
+            return 1
+
+        action()
+        set_audit_logger(None)
+
+        with open(log_path, "rb") as f:
+            line = f.readline().strip()
+        os.remove(log_path)
+
+        entry = Fernet(key).decrypt(line).decode()
+        self.assertIn("action", entry)
+        self.assertIn("success", entry)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new `audit_log` decorator with in-memory and encrypted file logging
- allow enabling via `set_audit_logger()` or `AUDIT_MODE` env variable
- export decorator and logger configuration
- test audit logging behavior

## Testing
- `pytest -q`
- `pytest tests/test_audit.py -q`
