### PR TITLE
Add PEM serialization utilities

### DIFF
--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -175,6 +175,8 @@ from .utils import (
     base62_encode,
     generate_secure_random_string,
     secure_zero,
+    to_pem,
+    from_pem,
 )
 from .audit import audit_log, set_audit_logger
 
@@ -284,6 +286,8 @@ __all__ = [
     "secure_zero",
     "generate_secure_random_string",
     "KeyVault",
+    "to_pem",
+    "from_pem",
     "KeyManager",
     "audit_log",
     "set_audit_logger",

--- a/tests/test_root_exports.py
+++ b/tests/test_root_exports.py
@@ -2,7 +2,10 @@ import cryptography_suite as cs
 
 # Basic smoke test ensuring key functions are exposed at package level
 
+
 def test_root_exports_available():
     assert callable(cs.aes_encrypt)
     assert callable(cs.rsa_encrypt)
     assert callable(cs.KeyVault)
+    assert callable(cs.to_pem)
+    assert callable(cs.from_pem)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,12 @@ from cryptography_suite.utils import (
     secure_zero,
     generate_secure_random_string,
     KeyVault,
+    to_pem,
+    from_pem,
 )
+from cryptography_suite.asymmetric import generate_rsa_keypair
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography_suite.errors import DecryptionError
 
 
 class TestUtils(unittest.TestCase):
@@ -45,6 +50,23 @@ class TestUtils(unittest.TestCase):
             self.assertIsInstance(key, bytearray)
             self.assertEqual(bytes(key), data)
         self.assertTrue(all(b == 0 for b in key))
+
+    def test_to_pem_and_from_pem(self):
+        """Round trip conversion to and from PEM."""
+        priv, pub = generate_rsa_keypair()
+        priv_pem = to_pem(priv)
+        pub_pem = to_pem(pub)
+        self.assertIsInstance(priv_pem, str)
+        self.assertIsInstance(pub_pem, str)
+        loaded_priv = from_pem(priv_pem)
+        loaded_pub = from_pem(pub_pem)
+        self.assertIsInstance(loaded_priv, rsa.RSAPrivateKey)
+        self.assertIsInstance(loaded_pub, rsa.RSAPublicKey)
+
+    def test_from_pem_invalid(self):
+        """Invalid PEM data should raise DecryptionError."""
+        with self.assertRaises(DecryptionError):
+            from_pem("NOT A VALID PEM")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `to_pem` and `from_pem` helpers for PEM conversion
- export new helpers in package init
- test new helper functions and root export list

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68802a183d5c832ab340e99ef115c1ac