### PR TITLE
Enhance encryption helpers and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ print(f"Encrypted: {encrypted_message}")
 
 decrypted_message: bytes = rsa_decrypt(encrypted_message, private_key)
 print(f"Decrypted: {decrypted_message}")
+
+# Serializing keys
+from cryptography_suite.utils import to_pem, from_pem, pem_to_json
+
+pem_priv: str = to_pem(private_key)
+loaded_priv = from_pem(pem_priv)
+json_pub: str = pem_to_json(public_key)
 ```
 
 ### Key Exchange
@@ -305,6 +312,11 @@ priv, pub = generate_rsa_keypair()
 payload = b"hybrid message"
 encrypted = hybrid_encrypt(payload, pub)
 decrypted = hybrid_decrypt(priv, encrypted)
+
+from cryptography_suite.utils import encode_encrypted_message, decode_encrypted_message
+
+blob: str = encode_encrypted_message(encrypted)
+parsed = decode_encrypted_message(blob)
 ```
 
 ### XChaCha20-Poly1305

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -177,6 +177,9 @@ from .utils import (
     secure_zero,
     to_pem,
     from_pem,
+    pem_to_json,
+    encode_encrypted_message,
+    decode_encrypted_message,
 )
 from .audit import audit_log, set_audit_logger
 
@@ -288,6 +291,9 @@ __all__ = [
     "KeyVault",
     "to_pem",
     "from_pem",
+    "pem_to_json",
+    "encode_encrypted_message",
+    "decode_encrypted_message",
     "KeyManager",
     "audit_log",
     "set_audit_logger",

--- a/tests/test_root_exports.py
+++ b/tests/test_root_exports.py
@@ -9,3 +9,6 @@ def test_root_exports_available():
     assert callable(cs.KeyVault)
     assert callable(cs.to_pem)
     assert callable(cs.from_pem)
+    assert callable(cs.pem_to_json)
+    assert callable(cs.encode_encrypted_message)
+    assert callable(cs.decode_encrypted_message)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,9 @@ from cryptography_suite.utils import (
     KeyVault,
     to_pem,
     from_pem,
+    pem_to_json,
+    encode_encrypted_message,
+    decode_encrypted_message,
 )
 from cryptography_suite.asymmetric import generate_rsa_keypair
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -67,6 +70,16 @@ class TestUtils(unittest.TestCase):
         """Invalid PEM data should raise DecryptionError."""
         with self.assertRaises(DecryptionError):
             from_pem("NOT A VALID PEM")
+
+    def test_pem_to_json_and_decode_message(self):
+        _, pub = generate_rsa_keypair()
+        json_blob = pem_to_json(pub)
+        self.assertIn("pem", json_blob)
+
+        msg = {"ciphertext": b"a", "nonce": b"b"}
+        encoded = encode_encrypted_message(msg)
+        decoded = decode_encrypted_message(encoded)
+        self.assertEqual(decoded["ciphertext"], b"a")
 
 
 if __name__ == "__main__":

--- a/tests/test_xchacha.py
+++ b/tests/test_xchacha.py
@@ -35,7 +35,7 @@ class TestXChaCha20(unittest.TestCase):
         message = b"Secret"
         enc = xchacha_encrypt(message, key, nonce)
         with self.assertRaises(DecryptionError):
-            xchacha_decrypt(enc["ciphertext"], os.urandom(32), nonce)
+            xchacha_decrypt(enc["ciphertext"], os.urandom(32), enc["nonce"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support raw bytes with `raw_output` across AES, ChaCha20 and hybrid
- Base64 encode XChaCha20 data and add flexible decrypt
- expose PEM conversion helpers with JSON and encrypted message utilities
- provide encode/decode helpers for Signal and hybrid messages
- document new helper usage in README
- update unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688046482688832aa9a8c7bbc60e6567