### PR TITLE
Add file encryption CLI

### DIFF
--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -37,3 +37,64 @@ def zksnark_cli(argv: list[str] | None = None) -> None:
     hash_hex, proof_path = zksnark.prove(args.preimage.encode())
     valid = zksnark.verify(hash_hex, proof_path)
     print(f"Hash: {hash_hex}\nProof valid: {valid}")
+
+
+def file_cli(argv: list[str] | None = None) -> None:
+    """Encrypt or decrypt files using AES-GCM."""
+
+    parser = argparse.ArgumentParser(
+        description="Encrypt or decrypt files"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    enc_parser = subparsers.add_parser("encrypt", help="Encrypt a file")
+    enc_parser.add_argument(
+        "--in",
+        dest="input_file",
+        required=True,
+        help="Path to the input file",
+    )
+    enc_parser.add_argument(
+        "--out",
+        dest="output_file",
+        required=True,
+        help="Path for the encrypted file",
+    )
+    enc_parser.add_argument(
+        "--password",
+        required=True,
+        help="Password to derive encryption key",
+    )
+
+    dec_parser = subparsers.add_parser("decrypt", help="Decrypt a file")
+    dec_parser.add_argument(
+        "--in",
+        dest="input_file",
+        required=True,
+        help="Path to the encrypted file",
+    )
+    dec_parser.add_argument(
+        "--out",
+        dest="output_file",
+        required=True,
+        help="Destination for the decrypted file",
+    )
+    dec_parser.add_argument(
+        "--password",
+        required=True,
+        help="Password used during encryption",
+    )
+
+    args = parser.parse_args(argv)
+
+    from .symmetric import encrypt_file, decrypt_file
+
+    try:
+        if args.command == "encrypt":
+            encrypt_file(args.input_file, args.output_file, args.password)
+            print(f"Encrypted file written to {args.output_file}")
+        else:
+            decrypt_file(args.input_file, args.output_file, args.password)
+            print(f"Decrypted file written to {args.output_file}")
+    except Exception as exc:  # pragma: no cover - high-level error reporting
+        print(f"Error: {exc}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = ["pytest", "pytest-cov", "coverage", "coveralls"]
 [project.scripts]
 cryptosuite-bulletproof = "cryptography_suite.cli:bulletproof_cli"
 cryptosuite-zksnark = "cryptography_suite.cli:zksnark_cli"
+cryptosuite-file = "cryptography_suite.cli:file_cli"
 
 [tool.black]
 line-length = 88

--- a/tests/test_cli_file.py
+++ b/tests/test_cli_file.py
@@ -1,0 +1,57 @@
+import importlib
+import pytest
+
+import cryptography_suite.cli as cli
+import cryptography_suite.symmetric as symmetric
+
+
+def reload_cli():
+    importlib.reload(cli)
+    return cli
+
+
+def test_file_cli_encrypt(monkeypatch, capsys):
+    cli = reload_cli()
+    called = {}
+
+    def stub(inp, outp, pwd):
+        called['args'] = (inp, outp, pwd)
+
+    monkeypatch.setattr(symmetric, 'encrypt_file', stub)
+    cli.file_cli(['encrypt', '--in', 'plain.txt', '--out', 'enc.bin', '--password', 'pw'])
+    assert called['args'] == ('plain.txt', 'enc.bin', 'pw')
+    out = capsys.readouterr().out
+    assert 'Encrypted file written to enc.bin' in out
+
+
+def test_file_cli_decrypt(monkeypatch, capsys):
+    cli = reload_cli()
+    called = {}
+
+    def stub_dec(inp, outp, pwd):
+        called['args'] = (inp, outp, pwd)
+
+    monkeypatch.setattr(symmetric, 'decrypt_file', stub_dec)
+    cli.file_cli(['decrypt', '--in', 'enc.bin', '--out', 'plain.txt', '--password', 'pw'])
+    assert called['args'] == ('enc.bin', 'plain.txt', 'pw')
+    out = capsys.readouterr().out
+    assert 'Decrypted file written to plain.txt' in out
+
+
+def test_file_cli_error(monkeypatch, capsys):
+    cli = reload_cli()
+
+    def bad(*args, **kwargs):
+        raise IOError('bad')
+
+    monkeypatch.setattr(symmetric, 'encrypt_file', bad)
+    cli.file_cli(['encrypt', '--in', 'a', '--out', 'b', '--password', 'pw'])
+    out = capsys.readouterr().out
+    assert 'Error:' in out
+
+
+def test_file_cli_invalid(monkeypatch):
+    cli = reload_cli()
+    with pytest.raises(SystemExit):
+        cli.file_cli(['encrypt'])
+


### PR DESCRIPTION
## Summary
- add `file_cli` command in `cryptography_suite.cli`
- expose new command as `cryptosuite-file`
- test the new CLI helper for encrypting and decrypting files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68805dbea7f8832aace1ccf60be73193