### PR TITLE
Add X.509 certificate utilities

### DIFF
--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -183,6 +183,7 @@ from .utils import (
     decode_encrypted_message,
 )
 from .audit import audit_log, set_audit_logger
+from .x509 import generate_csr, self_sign_certificate, load_certificate
 
 __all__ = [
     # Encryption
@@ -297,6 +298,9 @@ __all__ = [
     "encode_encrypted_message",
     "decode_encrypted_message",
     "KeyManager",
+    "generate_csr",
+    "self_sign_certificate",
+    "load_certificate",
     "audit_log",
     "set_audit_logger",
     # Signal Protocol

--- a/cryptography_suite/x509.py
+++ b/cryptography_suite/x509.py
@@ -1,0 +1,106 @@
+from datetime import datetime, timedelta
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.x509.oid import NameOID
+
+from .errors import CryptographySuiteError
+
+__all__ = [
+    "generate_csr",
+    "self_sign_certificate",
+    "load_certificate",
+]
+
+
+def generate_csr(common_name: str, private_key) -> bytes:
+    """Generate a Certificate Signing Request (CSR).
+
+    Parameters
+    ----------
+    common_name : str
+        The Common Name to include in the CSR.
+    private_key : Any
+        Private key used to sign the CSR.
+
+    Returns
+    -------
+    bytes
+        The PEM-encoded CSR.
+    """
+    try:
+        if not common_name or private_key is None:
+            raise ValueError("Invalid parameters")
+        subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+        builder = x509.CertificateSigningRequestBuilder().subject_name(subject)
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(common_name)]),
+            critical=False,
+        )
+        csr = builder.sign(private_key, hashes.SHA256())
+        return csr.public_bytes(serialization.Encoding.PEM)
+    except Exception as exc:  # pragma: no cover - high level
+        raise CryptographySuiteError(f"Failed to generate CSR: {exc}") from exc
+
+
+def self_sign_certificate(common_name: str, private_key, days_valid: int = 365) -> bytes:
+    """Generate a self-signed X.509 certificate.
+
+    Parameters
+    ----------
+    common_name : str
+        Common Name for the certificate.
+    private_key : Any
+        Private key to sign the certificate with.
+    days_valid : int, optional
+        Number of days the certificate is valid for. Defaults to ``365``.
+
+    Returns
+    -------
+    bytes
+        The PEM-encoded certificate.
+    """
+    try:
+        if not common_name or private_key is None:
+            raise ValueError("Invalid parameters")
+        subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+        now = datetime.utcnow()
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(subject)
+            .public_key(private_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=days_valid))
+        )
+        builder = builder.add_extension(
+            x509.BasicConstraints(ca=True, path_length=None), critical=True
+        )
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(common_name)]), critical=False
+        )
+        cert = builder.sign(private_key, hashes.SHA256())
+        return cert.public_bytes(serialization.Encoding.PEM)
+    except Exception as exc:  # pragma: no cover - high level
+        raise CryptographySuiteError(f"Failed to generate certificate: {exc}") from exc
+
+
+def load_certificate(pem_data: bytes) -> x509.Certificate:
+    """Load a PEM encoded certificate.
+
+    Parameters
+    ----------
+    pem_data : bytes
+        The PEM-encoded certificate data.
+
+    Returns
+    -------
+    cryptography.x509.Certificate
+        Parsed certificate object.
+    """
+    try:
+        return x509.load_pem_x509_certificate(pem_data)
+    except Exception as exc:  # pragma: no cover - high level
+        raise CryptographySuiteError(f"Failed to load certificate: {exc}") from exc
+

--- a/cryptography_suite/x509.py
+++ b/cryptography_suite/x509.py
@@ -103,4 +103,3 @@ def load_certificate(pem_data: bytes) -> x509.Certificate:
         return x509.load_pem_x509_certificate(pem_data)
     except Exception as exc:  # pragma: no cover - high level
         raise CryptographySuiteError(f"Failed to load certificate: {exc}") from exc
-

--- a/tests/test_root_exports.py
+++ b/tests/test_root_exports.py
@@ -12,3 +12,6 @@ def test_root_exports_available():
     assert callable(cs.pem_to_json)
     assert callable(cs.encode_encrypted_message)
     assert callable(cs.decode_encrypted_message)
+    assert callable(cs.generate_csr)
+    assert callable(cs.self_sign_certificate)
+    assert callable(cs.load_certificate)

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -1,0 +1,37 @@
+import unittest
+from cryptography import x509
+
+from cryptography_suite.x509 import generate_csr, self_sign_certificate, load_certificate
+from cryptography_suite.asymmetric import generate_rsa_keypair
+
+
+class TestX509(unittest.TestCase):
+    def test_generate_csr_and_load_certificate(self):
+        priv, _ = generate_rsa_keypair()
+        csr_pem = generate_csr("example.com", priv)
+        self.assertIsInstance(csr_pem, bytes)
+        csr = x509.load_pem_x509_csr(csr_pem)
+        self.assertEqual(
+            csr.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)[0].value,
+            "example.com",
+        )
+
+        cert_pem = self_sign_certificate("example.com", priv, days_valid=1)
+        self.assertIsInstance(cert_pem, bytes)
+        cert = load_certificate(cert_pem)
+        self.assertIsInstance(cert, x509.Certificate)
+        self.assertEqual(cert.subject, cert.issuer)
+        self.assertEqual(
+            cert.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)[0].value,
+            "example.com",
+        )
+
+    def test_load_certificate_invalid(self):
+        from cryptography_suite.errors import CryptographySuiteError
+
+        with self.assertRaises(CryptographySuiteError):
+            load_certificate(b"invalid")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add CSR and self-signed certificate helpers
- expose new functions from package root
- test new X.509 utilities and ensure they are exported

## Testing
- `pytest -q`
