### PR TITLE
Add SPHINCS+ signature wrappers

### DIFF
--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -95,14 +95,18 @@ from .symmetric import (
 try:  # pragma: no cover - optional dependency
     from .pqc import (  # noqa: F401
         PQCRYPTO_AVAILABLE,
+        SPHINCS_AVAILABLE,
         dilithium_sign,
         dilithium_verify,
         generate_dilithium_keypair,
+        generate_sphincs_keypair,
         generate_kyber_keypair,
         kyber_decapsulate,
         kyber_decrypt,
         kyber_encapsulate,
         kyber_encrypt,
+        sphincs_sign,
+        sphincs_verify,
     )
 except Exception:  # pragma: no cover - fallback when pqcrypto is missing
     PQCRYPTO_AVAILABLE = False
@@ -329,6 +333,9 @@ if PQCRYPTO_AVAILABLE:
             "generate_dilithium_keypair",
             "dilithium_sign",
             "dilithium_verify",
+            "generate_sphincs_keypair",
+            "sphincs_sign",
+            "sphincs_verify",
         ]
     )
 

--- a/tests/test_pqc.py
+++ b/tests/test_pqc.py
@@ -2,12 +2,16 @@ import unittest
 
 from cryptography_suite.pqc import (
     PQCRYPTO_AVAILABLE,
+    SPHINCS_AVAILABLE,
     generate_kyber_keypair,
     kyber_encrypt,
     kyber_decrypt,
     generate_dilithium_keypair,
     dilithium_sign,
     dilithium_verify,
+    generate_sphincs_keypair,
+    sphincs_sign,
+    sphincs_verify,
 )
 
 
@@ -30,6 +34,23 @@ class TestPQC(unittest.TestCase):
         sig = dilithium_sign(sk, msg)
         self.assertIsInstance(sig, str)
         self.assertTrue(dilithium_verify(pk, msg, sig))
+
+    @unittest.skipUnless(SPHINCS_AVAILABLE, "SPHINCS+ not available")
+    def test_sphincs_signature(self):
+        pk, sk = generate_sphincs_keypair()
+        msg = b"sphincs test"
+        sig = sphincs_sign(sk, msg)
+        self.assertIsInstance(sig, bytes)
+        self.assertTrue(sphincs_verify(pk, msg, sig))
+
+    @unittest.skipUnless(SPHINCS_AVAILABLE, "SPHINCS+ not available")
+    def test_sphincs_negative(self):
+        pk, sk = generate_sphincs_keypair()
+        msg = b"hello"
+        sig = sphincs_sign(sk, msg)
+        self.assertFalse(sphincs_verify(pk, b"bye", sig))
+        pk2, _ = generate_sphincs_keypair()
+        self.assertFalse(sphincs_verify(pk2, msg, sig))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add SPHINCS+ support via pqcrypto
- expose new SPHINCS+ functions from package init
- implement SPHINCS+ signature helpers
- test SPHINCS+ operations

## Testing
- `pytest -q tests/test_pqc.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880648018a8832a845278bd5238ba18