### PR TITLE
Use dataclass for hybrid encryption payload

### DIFF
--- a/cryptography_suite/hybrid.py
+++ b/cryptography_suite/hybrid.py
@@ -8,6 +8,9 @@ from typing import Any, Dict
 from cryptography.hazmat.primitives.asymmetric import rsa, x25519
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
+from .asymmetric import ec_decrypt, ec_encrypt, rsa_decrypt, rsa_encrypt
+from .errors import DecryptionError, EncryptionError
+
 
 @dataclass
 class EncryptedHybridMessage:
@@ -17,9 +20,6 @@ class EncryptedHybridMessage:
     nonce: bytes
     ciphertext: bytes
     tag: bytes
-
-from .asymmetric import ec_decrypt, ec_encrypt, rsa_decrypt, rsa_encrypt
-from .errors import DecryptionError, EncryptionError
 
 
 def hybrid_encrypt(

--- a/cryptography_suite/hybrid.py
+++ b/cryptography_suite/hybrid.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
 import base64
+from dataclasses import dataclass
 from os import urandom
 from typing import Any, Dict
 
 from cryptography.hazmat.primitives.asymmetric import rsa, x25519
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+
+@dataclass
+class EncryptedHybridMessage:
+    """Container for a hybrid encrypted message."""
+
+    encrypted_key: bytes
+    nonce: bytes
+    ciphertext: bytes
+    tag: bytes
 
 from .asymmetric import ec_decrypt, ec_encrypt, rsa_decrypt, rsa_encrypt
 from .errors import DecryptionError, EncryptionError
@@ -16,7 +27,7 @@ def hybrid_encrypt(
     public_key: Any,
     *,
     raw_output: bool = False,
-) -> Dict[str, str | bytes]:
+) -> EncryptedHybridMessage:
     """Encrypt ``message`` using hybrid RSA/ECIES + AES-GCM.
 
     The AES key is randomly generated and encrypted with the recipient's
@@ -28,9 +39,9 @@ def hybrid_encrypt(
     aes_key = urandom(32)
 
     if isinstance(public_key, rsa.RSAPublicKey):
-        encrypted_key = rsa_encrypt(aes_key, public_key, raw_output=raw_output)
+        encrypted_key = rsa_encrypt(aes_key, public_key, raw_output=True)
     elif isinstance(public_key, x25519.X25519PublicKey):
-        encrypted_key = ec_encrypt(aes_key, public_key, raw_output=raw_output)
+        encrypted_key = ec_encrypt(aes_key, public_key, raw_output=True)
     else:
         raise TypeError("Unsupported public key type.")
 
@@ -40,35 +51,56 @@ def hybrid_encrypt(
     ciphertext = enc[:-16]
     tag = enc[-16:]
 
-    if raw_output:
-        return {
-            "encrypted_key": encrypted_key,
-            "nonce": nonce,
-            "ciphertext": ciphertext,
-            "tag": tag,
-        }
-
-    return {
-        "encrypted_key": encrypted_key
-        if isinstance(encrypted_key, str)
-        else base64.b64encode(encrypted_key).decode(),
-        "nonce": base64.b64encode(nonce).decode(),
-        "ciphertext": base64.b64encode(ciphertext).decode(),
-        "tag": base64.b64encode(tag).decode(),
-    }
+    return EncryptedHybridMessage(
+        encrypted_key=encrypted_key,
+        nonce=nonce,
+        ciphertext=ciphertext,
+        tag=tag,
+    )
 
 
-def hybrid_decrypt(private_key: Any, data: Dict[str, str | bytes]) -> bytes:
+def hybrid_decrypt(
+    private_key: Any,
+    data: EncryptedHybridMessage | Dict[str, str | bytes] | str,
+) -> bytes:
     """Decrypt data produced by :func:`hybrid_encrypt`."""
 
-    for field in ("encrypted_key", "nonce", "ciphertext", "tag"):
-        if field not in data:
-            raise DecryptionError("Invalid encrypted payload.")
+    if isinstance(data, str):
+        from .utils import decode_encrypted_message
 
-    enc_key = data["encrypted_key"]
-    nonce_data = data["nonce"]
-    ct_data = data["ciphertext"]
-    tag_data = data["tag"]
+        data = decode_encrypted_message(data)
+
+    if isinstance(data, EncryptedHybridMessage):
+        enc_key = data.encrypted_key
+        nonce = data.nonce
+        ciphertext = data.ciphertext
+        tag = data.tag
+    elif isinstance(data, dict):
+        for field in ("encrypted_key", "nonce", "ciphertext", "tag"):
+            if field not in data:
+                raise DecryptionError("Invalid encrypted payload.")
+
+        enc_key = data["encrypted_key"]
+        nonce_data = data["nonce"]
+        ct_data = data["ciphertext"]
+        tag_data = data["tag"]
+
+        try:
+            nonce = (
+                base64.b64decode(nonce_data)
+                if isinstance(nonce_data, str)
+                else nonce_data
+            )
+            ciphertext = (
+                base64.b64decode(ct_data)
+                if isinstance(ct_data, str)
+                else ct_data
+            )
+            tag = base64.b64decode(tag_data) if isinstance(tag_data, str) else tag_data
+        except Exception as exc:  # pragma: no cover - defensive parsing
+            raise DecryptionError(f"Invalid encoded data: {exc}") from exc
+    else:
+        raise DecryptionError("Invalid encrypted payload.")
 
     if isinstance(private_key, rsa.RSAPrivateKey):
         aes_key = rsa_decrypt(enc_key, private_key)
@@ -77,13 +109,6 @@ def hybrid_decrypt(private_key: Any, data: Dict[str, str | bytes]) -> bytes:
     else:
         raise TypeError("Unsupported private key type.")
 
-    try:
-        nonce = base64.b64decode(nonce_data) if isinstance(nonce_data, str) else nonce_data
-        ciphertext = base64.b64decode(ct_data) if isinstance(ct_data, str) else ct_data
-        tag = base64.b64decode(tag_data) if isinstance(tag_data, str) else tag_data
-    except Exception as exc:  # pragma: no cover - defensive parsing
-        raise DecryptionError(f"Invalid encoded data: {exc}") from exc
-
     aesgcm = AESGCM(aes_key)
     try:
         return aesgcm.decrypt(nonce, ciphertext + tag, None)
@@ -91,4 +116,4 @@ def hybrid_decrypt(private_key: Any, data: Dict[str, str | bytes]) -> bytes:
         raise DecryptionError(f"Decryption failed: {exc}") from exc
 
 
-__all__ = ["hybrid_encrypt", "hybrid_decrypt"]
+__all__ = ["EncryptedHybridMessage", "hybrid_encrypt", "hybrid_decrypt"]

--- a/cryptography_suite/utils.py
+++ b/cryptography_suite/utils.py
@@ -180,4 +180,12 @@ def decode_encrypted_message(data: str):
     except Exception:
         pass
 
+    try:
+        from .hybrid import EncryptedHybridMessage
+
+        if set(out.keys()) == {"encrypted_key", "nonce", "ciphertext", "tag"}:
+            return EncryptedHybridMessage(**out)
+    except Exception:
+        pass
+
     return out

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from cryptography_suite.utils import (
     decode_encrypted_message,
 )
 from cryptography_suite.asymmetric import generate_rsa_keypair
+from cryptography_suite.hybrid import EncryptedHybridMessage
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography_suite.errors import DecryptionError
 
@@ -80,6 +81,18 @@ class TestUtils(unittest.TestCase):
         encoded = encode_encrypted_message(msg)
         decoded = decode_encrypted_message(encoded)
         self.assertEqual(decoded["ciphertext"], b"a")
+
+    def test_encode_decode_hybrid_dataclass(self):
+        msg = EncryptedHybridMessage(
+            encrypted_key=b"k",
+            nonce=b"n",
+            ciphertext=b"c",
+            tag=b"t",
+        )
+        encoded = encode_encrypted_message(msg)
+        decoded = decode_encrypted_message(encoded)
+        self.assertIsInstance(decoded, EncryptedHybridMessage)
+        self.assertEqual(decoded.nonce, b"n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- introduce `EncryptedHybridMessage` dataclass
- return `EncryptedHybridMessage` from `hybrid_encrypt`
- allow `hybrid_decrypt` to accept dataclass, dict, or encoded string
- make utils decode aware of `EncryptedHybridMessage`
- test dataclass workflow

## Testing
- `python -m pytest tests/test_hybrid.py::TestHybrid::test_hybrid_rsa_roundtrip -q`
- `python -m pytest -q`
