### PR TITLE
Optimize secure memory and async RSA generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ print(f"Encrypted: {encrypted_message}")
 decrypted_message: bytes = rsa_decrypt(encrypted_message, private_key)
 print(f"Decrypted: {decrypted_message}")
 
+# Non-blocking key generation using a ThreadPoolExecutor. The call returns a
+# ``Future`` which resolves to ``(private_key, public_key)``.
+from cryptography_suite.asymmetric import generate_rsa_keypair_async
+
+future = generate_rsa_keypair_async(key_size=2048)
+private_async, public_async = future.result()
+
 # Serializing keys
 from cryptography_suite.utils import to_pem, from_pem, pem_to_json
 

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -23,6 +23,7 @@ from .asymmetric import (
     ec_encrypt,
     generate_ec_keypair,
     generate_rsa_keypair,
+    generate_rsa_keypair_async,
     generate_x448_keypair,
     generate_x25519_keypair,
     load_private_key,
@@ -232,6 +233,7 @@ __all__ = [
     "generate_salt",
     # Asymmetric
     "generate_rsa_keypair",
+    "generate_rsa_keypair_async",
     "rsa_encrypt",
     "rsa_decrypt",
     "serialize_private_key",

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -150,6 +150,22 @@ from .protocols import (
     KeyManager,
 )
 
+# Core utilities -------------------------------------------------------------
+from .utils import (
+    KeyVault,
+    base62_decode,
+    base62_encode,
+    generate_secure_random_string,
+    secure_zero,
+    to_pem,
+    from_pem,
+    pem_to_json,
+    encode_encrypted_message,
+    decode_encrypted_message,
+)
+from .audit import audit_log, set_audit_logger
+from .x509 import generate_csr, self_sign_certificate, load_certificate
+
 # Optional homomorphic encryption -------------------------------------------
 try:  # pragma: no cover - optional dependency
     from .homomorphic import add as fhe_add
@@ -182,21 +198,6 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - handle missing dependency
     zksnark = None
     ZKSNARK_AVAILABLE = False
-
-from .utils import (
-    KeyVault,
-    base62_decode,
-    base62_encode,
-    generate_secure_random_string,
-    secure_zero,
-    to_pem,
-    from_pem,
-    pem_to_json,
-    encode_encrypted_message,
-    decode_encrypted_message,
-)
-from .audit import audit_log, set_audit_logger
-from .x509 import generate_csr, self_sign_certificate, load_certificate
 
 __all__ = [
     # Encryption

--- a/cryptography_suite/symmetric/kdf.py
+++ b/cryptography_suite/symmetric/kdf.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from os import urandom
+from os import urandom, getenv
 
 from cryptography.exceptions import InvalidKey
 from cryptography.hazmat.backends import default_backend
@@ -20,9 +20,11 @@ SCRYPT_N = 2 ** 14
 SCRYPT_R = 8
 SCRYPT_P = 1
 PBKDF2_ITERATIONS = 100_000
-ARGON2_MEMORY_COST = 65536  # 64 MiB
-ARGON2_TIME_COST = 3
-ARGON2_PARALLELISM = 1
+# Argon2 parameters can be tuned via environment variables to balance
+# security and performance.
+ARGON2_MEMORY_COST = int(getenv("CRYPTOSUITE_ARGON2_MEMORY_COST", "65536"))
+ARGON2_TIME_COST = int(getenv("CRYPTOSUITE_ARGON2_TIME_COST", "3"))
+ARGON2_PARALLELISM = int(getenv("CRYPTOSUITE_ARGON2_PARALLELISM", "1"))
 
 
 def generate_salt(size: int = SALT_SIZE) -> bytes:
@@ -98,7 +100,11 @@ def derive_key_argon2(
     time_cost: int = ARGON2_TIME_COST,
     parallelism: int = ARGON2_PARALLELISM,
 ) -> bytes:
-    """Derive a key using Argon2id."""
+    """Derive a key using Argon2id.
+
+    The cost parameters default to module constants which may be overridden via
+    the ``CRYPTOSUITE_ARGON2_*`` environment variables.
+    """
     if not password:
         raise KeyDerivationError("Password cannot be empty.")
     kdf = Argon2id(

--- a/cryptography_suite/utils.py
+++ b/cryptography_suite/utils.py
@@ -50,12 +50,17 @@ def base62_decode(data: str) -> bytes:
     return value.to_bytes(byte_length, byteorder="big")
 
 
-def secure_zero(data: bytearray):
-    """
-    Overwrites the contents of a bytearray with zeros to clear sensitive data from memory.
-    """
-    for i in range(len(data)):
-        data[i] = 0
+def secure_zero(data: bytearray) -> None:
+    """Overwrite ``data`` with zeros in-place."""
+
+    if not isinstance(data, bytearray):
+        raise TypeError("secure_zero expects a bytearray")
+
+    # Use a memoryview for efficient bulk assignment without Python loops.
+    view = memoryview(data)
+    view[:] = b"\x00" * len(data)
+    if hasattr(view, "release"):
+        view.release()
 
 
 def generate_secure_random_string(length: int = 32) -> str:

--- a/tests/test_kdf_functions.py
+++ b/tests/test_kdf_functions.py
@@ -30,6 +30,24 @@ class TestKdfFunctions(unittest.TestCase):
         out3 = kdf_pbkdf2(password, salt, 2000, 32)
         self.assertNotEqual(out1, out3)
 
+    def test_argon2_env_overrides(self):
+        import os, importlib
+
+        os.environ["CRYPTOSUITE_ARGON2_MEMORY_COST"] = "32768"
+        os.environ["CRYPTOSUITE_ARGON2_TIME_COST"] = "2"
+
+        import cryptography_suite.symmetric.kdf as kdf
+        importlib.reload(kdf)
+
+        self.assertEqual(kdf.ARGON2_MEMORY_COST, 32768)
+        self.assertEqual(kdf.ARGON2_TIME_COST, 2)
+        key = kdf.derive_key_argon2("pw", b"a" * 16)
+        self.assertEqual(len(key), 32)
+
+        os.environ.pop("CRYPTOSUITE_ARGON2_MEMORY_COST")
+        os.environ.pop("CRYPTOSUITE_ARGON2_TIME_COST")
+        importlib.reload(kdf)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- optimize `secure_zero` using memoryview
- add `generate_rsa_keypair_async` with optional executor and callback
- allow Argon2 parameters to be configured via env vars
- document async RSA in README
- test async key generation and Argon2 env overrides

## Testing
- `pytest -q`
