### PR TITLE
Update module layout for v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ Ciphertext and related binary outputs are returned as Base64 strings by
 default. Pass ``raw_output=True`` to obtain raw bytes instead.
 
 ```python
-from cryptography_suite import ec_encrypt
 from cryptography_suite.asymmetric import (
+    ec_encrypt,
     generate_rsa_keypair,
     rsa_encrypt,
     rsa_decrypt,
@@ -182,7 +182,7 @@ json_pub: str = pem_to_json(public_key)
 ### Key Exchange
 
 ```python
-from cryptography_suite import (
+from cryptography_suite.asymmetric import (
     generate_x25519_keypair,
     derive_x25519_shared_key,
     generate_x448_keypair,
@@ -210,7 +210,7 @@ print(
 Sign and verify messages using Ed25519, Ed448 or BLS.
 
 ```python
-from cryptography_suite.signatures import (
+from cryptography_suite.asymmetric.signatures import (
     generate_ed25519_keypair,
     generate_ed448_keypair,
     sign_message,
@@ -242,7 +242,7 @@ print(bls_verify(b"Authenticate this message", bls_sig, bls_pk))
 Split and reconstruct secrets using Shamir's Secret Sharing.
 
 ```python
-from cryptography_suite.secret_sharing import create_shares, reconstruct_secret
+from cryptography_suite.protocols import create_shares, reconstruct_secret
 
 secret: int = 1234567890
 threshold: int = 3
@@ -288,7 +288,7 @@ Prove knowledge of a SHA-256 preimage without revealing it. These
 functions require the optional `PySNARK` dependency.
 
 ```python
-from cryptography_suite import zksnark
+from cryptography_suite.zk import zksnark
 
 zksnark.setup()
 hash_hex: str
@@ -327,7 +327,7 @@ Combine asymmetric keys with AES-GCM for efficient encryption. See
 [`tests/test_hybrid.py`](tests/test_hybrid.py).
 
 ```python
-from cryptography_suite import hybrid_encrypt, hybrid_decrypt
+from cryptography_suite.hybrid import hybrid_encrypt, hybrid_decrypt
 from cryptography_suite.asymmetric import generate_rsa_keypair
 
 priv, pub = generate_rsa_keypair()
@@ -374,7 +374,7 @@ with KeyVault(key_material) as buf:
 ### SPAKE2 Key Exchange
 
 ```python
-from cryptography_suite import SPAKE2Client, SPAKE2Server
+from cryptography_suite.protocols import SPAKE2Client, SPAKE2Server
 
 c = SPAKE2Client("pw")
 s = SPAKE2Server("pw")
@@ -387,7 +387,7 @@ Requires the optional `spake2` package.
 ### ECIES Encryption
 
 ```python
-from cryptography_suite import ec_encrypt, ec_decrypt, generate_x25519_keypair
+from cryptography_suite.asymmetric import ec_encrypt, ec_decrypt, generate_x25519_keypair
 
 priv, pub = generate_x25519_keypair()
 # ``cipher`` is Base64 encoded by default. Use ``raw_output=True`` for bytes.
@@ -398,7 +398,7 @@ print(ec_decrypt(cipher, priv))
 ### Signal Protocol Messaging
 
 ```python
-from cryptography_suite import initialize_signal_session
+from cryptography_suite.protocols import initialize_signal_session
 
 sender, receiver = initialize_signal_session()
 msg: bytes = sender.encrypt(b"hi")
@@ -499,23 +499,26 @@ plaintext = rsa_decrypt(ciphertext, private_key)
 cryptography-suite/
 ├── cryptography_suite/
 │   ├── __init__.py
+│   ├── asymmetric/
 │   ├── audit.py
 │   ├── cli.py
 │   ├── debug.py
 │   ├── errors.py
-│   ├── hybrid.py
+│   ├── hashing/
 │   ├── homomorphic.py
-│   ├── protocols/
+│   ├── hybrid.py
 │   ├── pqc/
+│   ├── protocols/
+│   │   ├── __init__.py
+│   │   ├── key_management.py
+│   │   ├── otp.py
+│   │   ├── pake.py
+│   │   ├── secret_sharing.py
+│   │   └── signal/
 │   ├── symmetric/
-│   ├── asymmetric/
-│   ├── zk/
-│   ├── hashing.py
-│   ├── key_management.py
-│   ├── otp.py
-│   ├── pake.py
-│   ├── secret_sharing.py
-│   └── utils.py
+│   ├── utils.py
+│   ├── x509.py
+│   └── zk/
 ├── tests/
 │   ├── test_audit.py
 │   ├── test_hybrid.py

--- a/cryptography_suite/hybrid.py
+++ b/cryptography_suite/hybrid.py
@@ -6,7 +6,7 @@ from os import urandom
 from typing import Mapping, TYPE_CHECKING, cast
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
-    from .protocols.signal_protocol import EncryptedMessage
+    from .protocols.signal import EncryptedMessage
 
 from cryptography.hazmat.primitives.asymmetric import rsa, x25519
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM

--- a/cryptography_suite/protocols/__init__.py
+++ b/cryptography_suite/protocols/__init__.py
@@ -3,7 +3,7 @@
 from .otp import generate_totp, verify_totp, generate_hotp, verify_hotp
 from .secret_sharing import create_shares, reconstruct_secret
 from .pake import SPAKE2Client, SPAKE2Server
-from .signal_protocol import (
+from .signal import (
     SignalSender,
     SignalReceiver,
     initialize_signal_session,

--- a/cryptography_suite/protocols/key_management.py
+++ b/cryptography_suite/protocols/key_management.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from os import path
@@ -79,7 +80,17 @@ def generate_rsa_keypair_and_save(
     password: str,
     key_size: int = 4096,
 ):
-    """Legacy wrapper for :class:`KeyManager` RSA key generation."""
+    """Legacy wrapper for :class:`KeyManager` RSA key generation.
+
+    .. deprecated:: 2.0.0
+       Use :class:`KeyManager.generate_rsa_keypair_and_save` instead.
+    """
+
+    warnings.warn(
+        "generate_rsa_keypair_and_save is deprecated; use KeyManager.generate_rsa_keypair_and_save",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     km = KeyManager()
     return km.generate_rsa_keypair_and_save(
         private_key_path, public_key_path, password, key_size

--- a/cryptography_suite/protocols/signal/__init__.py
+++ b/cryptography_suite/protocols/signal/__init__.py
@@ -9,7 +9,7 @@ from typing import Tuple
 from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.primitives.asymmetric import x25519
 from cryptography.hazmat.primitives import serialization
-from ..errors import ProtocolError
+from ...errors import ProtocolError
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 

--- a/cryptography_suite/utils.py
+++ b/cryptography_suite/utils.py
@@ -16,7 +16,7 @@ from cryptography.hazmat.primitives.asymmetric import (
 from .hybrid import EncryptedHybridMessage
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
-    from .protocols.signal_protocol import EncryptedMessage
+    from .protocols.signal import EncryptedMessage
 
 BASE62_ALPHABET = string.digits + string.ascii_letters
 
@@ -225,7 +225,7 @@ def decode_encrypted_message(
     }
 
     try:  # Return EncryptedMessage if fields match
-        from .protocols.signal_protocol import EncryptedMessage
+        from .protocols.signal import EncryptedMessage
 
         if set(out.keys()) == {"dh_public", "nonce", "ciphertext"}:
             return EncryptedMessage(**out)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,20 @@
+# Package Architecture
+
+```mermaid
+graph TD
+    CS[cryptography_suite]
+    CS --> asymmetric
+    CS --> symmetric
+    CS --> hashing
+    CS --> pqc
+    CS --> protocols
+    CS --> zk
+    CS --> utils
+    CS --> x509
+    CS --> hybrid
+    protocols --> key_management
+    protocols --> otp
+    protocols --> pake
+    protocols --> secret_sharing
+    protocols --> signal
+```

--- a/example_usage.py
+++ b/example_usage.py
@@ -5,6 +5,7 @@ This script demonstrates the usage of various cryptographic functions
 provided by the library, including encryption, decryption, key management,
 digital signatures, hashing, secret sharing, PAKE, and OTP.
 """
+
 import base64
 import os
 from time import sleep
@@ -41,9 +42,9 @@ from cryptography_suite import (
     # Key Management
     generate_aes_key,
     rotate_aes_key,
-    generate_rsa_keypair_and_save,
     load_private_key_from_file,
     load_public_key_from_file,
+    KeyManager,
     # Secret Sharing
     create_shares,
     reconstruct_secret,
@@ -61,6 +62,7 @@ from cryptography_suite import (
     generate_secure_random_string,
 )
 
+
 def main():
     # Symmetric Encryption Example
     print("=== Symmetric Encryption ===")
@@ -68,8 +70,8 @@ def main():
     symmetric_password = "strong_password"
 
     # AES Encryption with Scrypt KDF
-    encrypted_aes = aes_encrypt(plaintext, symmetric_password, kdf='scrypt')
-    decrypted_aes = aes_decrypt(encrypted_aes, symmetric_password, kdf='scrypt')
+    encrypted_aes = aes_encrypt(plaintext, symmetric_password, kdf="scrypt")
+    decrypted_aes = aes_decrypt(encrypted_aes, symmetric_password, kdf="scrypt")
     print(f"AES Encrypted: {encrypted_aes}")
     print(f"AES Decrypted: {decrypted_aes}")
 
@@ -177,7 +179,7 @@ def main():
 
     # One-Time Passwords (OTP)
     print("\n=== One-Time Passwords ===")
-    otp_secret = base64.b32encode(os.urandom(10)).decode('utf-8')
+    otp_secret = base64.b32encode(os.urandom(10)).decode("utf-8")
     totp_code = generate_totp(otp_secret)
     print(f"Generated TOTP Code: {totp_code}")
     is_valid_totp = verify_totp(totp_code, otp_secret)
@@ -207,7 +209,8 @@ def main():
     private_key_path = "rsa_private.pem"
     public_key_path = "rsa_public.pem"
 
-    generate_rsa_keypair_and_save(private_key_path, public_key_path, key_password)
+    km = KeyManager()
+    km.generate_rsa_keypair_and_save(private_key_path, public_key_path, key_password)
     loaded_private_key = load_private_key_from_file(private_key_path, key_password)
     loaded_public_key = load_public_key_from_file(public_key_path)
     print("RSA keys generated, saved, and loaded from files successfully.")
@@ -240,6 +243,7 @@ def main():
         print("Decrypted Product:", fhe_decrypt(fhe, fhe_multiply(fhe, c1, c2)))
     except ImportError:
         print("Pyfhel not installed; skipping homomorphic encryption demo.")
+
 
 if __name__ == "__main__":
     main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ ignore_errors = True
 [mypy-cryptography_suite.protocols.pake]
 ignore_errors = True
 
-[mypy-cryptography_suite.protocols.signal_protocol]
+[mypy-cryptography_suite.protocols.signal.*]
 ignore_errors = True
 
 [mypy-cryptography_suite.pqc.*]

--- a/tests/test_key_management.py
+++ b/tests/test_key_management.py
@@ -12,7 +12,6 @@ from cryptography_suite.protocols import (
     load_private_key_from_file,
     load_public_key_from_file,
     key_exists,
-    generate_rsa_keypair_and_save,
     generate_ec_keypair_and_save,
     KeyManager,
 )
@@ -97,7 +96,7 @@ class TestKeyManagement(unittest.TestCase):
     def test_key_exists_function(self):
         """Test key_exists function."""
         self.assertFalse(key_exists(self.private_key_path))
-        open(self.private_key_path, 'a').close()
+        open(self.private_key_path, "a").close()
         self.assertTrue(key_exists(self.private_key_path))
 
     def test_generate_ec_keypair_and_save_with_invalid_curve(self):
@@ -107,7 +106,7 @@ class TestKeyManagement(unittest.TestCase):
                 self.private_key_path,
                 self.public_key_path,
                 self.password,
-                curve="invalid_curve"
+                curve="invalid_curve",
             )
 
 


### PR DESCRIPTION
## Summary
- move Signal implementation into `protocols.signal` subpackage
- deprecate `generate_rsa_keypair_and_save`
- refresh README examples and structure overview
- add architecture diagram in docs

## Testing
- `pip install -e .`
- `pytest -q`
