### PR TITLE
Add CLI entry and base64 signatures

### DIFF
--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -1,8 +1,23 @@
 """Command line utilities for zero-knowledge proofs."""
+
 from __future__ import annotations
 
 import argparse
 from .errors import MissingDependencyError, DecryptionError
+from .protocols import generate_totp
+from .hashing import (
+    sha3_256_hash,
+    sha3_512_hash,
+    blake2b_hash,
+    blake3_hash,
+)
+from .pqc import (
+    generate_kyber_keypair,
+    generate_dilithium_keypair,
+    generate_sphincs_keypair,
+    PQCRYPTO_AVAILABLE,
+)
+from .protocols.key_management import KeyManager
 
 from .zk.bulletproof import prove as bp_prove, verify as bp_verify, setup as bp_setup
 
@@ -42,9 +57,7 @@ def zksnark_cli(argv: list[str] | None = None) -> None:
 def file_cli(argv: list[str] | None = None) -> None:
     """Encrypt or decrypt files using AES-GCM."""
 
-    parser = argparse.ArgumentParser(
-        description="Encrypt or decrypt files"
-    )
+    parser = argparse.ArgumentParser(description="Encrypt or decrypt files")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     enc_parser = subparsers.add_parser("encrypt", help="Encrypt a file")
@@ -109,3 +122,149 @@ def _handle_cli_error(exc: Exception) -> None:
         print("Password is incorrect or file corrupted.")
     else:
         print(f"Error: {exc}")
+
+
+def keygen_cli(argv: list[str] | None = None) -> None:
+    """Generate RSA or post-quantum key pairs."""
+
+    parser = argparse.ArgumentParser(description=keygen_cli.__doc__)
+    sub = parser.add_subparsers(dest="scheme", required=True)
+
+    rsa_p = sub.add_parser("rsa", help="Generate an RSA key pair")
+    rsa_p.add_argument("--private", required=True, help="Private key path")
+    rsa_p.add_argument("--public", required=True, help="Public key path")
+    rsa_p.add_argument("--password", required=True, help="Password for private key")
+
+    if PQCRYPTO_AVAILABLE:
+        sub.add_parser("dilithium", help="Generate a Dilithium key pair")
+        sub.add_parser("kyber", help="Generate a Kyber key pair")
+        if generate_sphincs_keypair:
+            sub.add_parser("sphincs", help="Generate a SPHINCS+ key pair")
+
+    args = parser.parse_args(argv)
+
+    if args.scheme == "rsa":
+        km = KeyManager()
+        km.generate_rsa_keypair_and_save(args.private, args.public, args.password)
+        print(f"RSA keys saved to {args.private} and {args.public}")
+    else:
+        if args.scheme == "dilithium":
+            pk, sk = generate_dilithium_keypair()
+        elif args.scheme == "kyber":
+            pk, sk = generate_kyber_keypair()
+        else:
+            pk, sk = generate_sphincs_keypair()
+        print(pk.hex())
+        print(sk.hex())
+
+
+def hash_cli(argv: list[str] | None = None) -> None:
+    """Digest a file using various hashing algorithms."""
+
+    parser = argparse.ArgumentParser(description=hash_cli.__doc__)
+    parser.add_argument("file", help="File to hash")
+    parser.add_argument(
+        "--algorithm",
+        choices=["sha3-256", "sha3-512", "blake2b", "blake3"],
+        default="sha3-256",
+    )
+    args = parser.parse_args(argv)
+
+    with open(args.file, "rb") as f:
+        data = f.read().decode("utf-8", errors="ignore")
+
+    if args.algorithm == "sha3-256":
+        digest = sha3_256_hash(data)
+    elif args.algorithm == "sha3-512":
+        digest = sha3_512_hash(data)
+    elif args.algorithm == "blake2b":
+        digest = blake2b_hash(data)
+    else:
+        digest = blake3_hash(data)
+
+    print(digest)
+
+
+def otp_cli(argv: list[str] | None = None) -> None:
+    """Generate a time-based OTP code for a secret."""
+
+    parser = argparse.ArgumentParser(description=otp_cli.__doc__)
+    parser.add_argument("--secret", required=True, help="Base32 encoded secret")
+    parser.add_argument("--interval", type=int, default=30)
+    parser.add_argument("--digits", type=int, default=6)
+    parser.add_argument(
+        "--algorithm",
+        choices=["sha1", "sha256", "sha512"],
+        default="sha1",
+    )
+    args = parser.parse_args(argv)
+
+    code = generate_totp(
+        args.secret,
+        interval=args.interval,
+        digits=args.digits,
+        algorithm=args.algorithm,
+    )
+    print(code)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Unified command line interface for the cryptography suite."""
+
+    parser = argparse.ArgumentParser(description=main.__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    keygen_parser = sub.add_parser(
+        "keygen", help="Generate key pairs", description=keygen_cli.__doc__
+    )
+    keygen_parser.add_argument(
+        "scheme", choices=["rsa", "dilithium", "kyber", "sphincs"], help="Key scheme"
+    )
+    keygen_parser.add_argument("--private", help="Private key path")
+    keygen_parser.add_argument("--public", help="Public key path")
+    keygen_parser.add_argument("--password", help="Private key password")
+
+    hash_parser = sub.add_parser(
+        "hash", help="Hash a file", description=hash_cli.__doc__
+    )
+    hash_parser.add_argument("file")
+    hash_parser.add_argument(
+        "--algorithm",
+        choices=["sha3-256", "sha3-512", "blake2b", "blake3"],
+        default="sha3-256",
+    )
+
+    otp_parser = sub.add_parser(
+        "otp", help="Generate a TOTP", description=otp_cli.__doc__
+    )
+    otp_parser.add_argument("--secret", required=True)
+    otp_parser.add_argument("--interval", type=int, default=30)
+    otp_parser.add_argument("--digits", type=int, default=6)
+    otp_parser.add_argument(
+        "--algorithm",
+        choices=["sha1", "sha256", "sha512"],
+        default="sha1",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "keygen":
+        argv2: list[str] = [args.scheme]
+        if args.private:
+            argv2.extend(["--private", args.private])
+        if args.public:
+            argv2.extend(["--public", args.public])
+        if args.password:
+            argv2.extend(["--password", args.password])
+        keygen_cli(argv2)
+    elif args.cmd == "hash":
+        hash_cli([args.file, f"--algorithm={args.algorithm}"])
+    else:
+        otp_cli(
+            [
+                f"--secret={args.secret}",
+                f"--interval={args.interval}",
+                f"--digits={args.digits}",
+                f"--algorithm={args.algorithm}",
+            ]
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ async = ["aiofiles"]
 cryptosuite-bulletproof = "cryptography_suite.cli:bulletproof_cli"
 cryptosuite-zksnark = "cryptography_suite.cli:zksnark_cli"
 cryptosuite-file = "cryptography_suite.cli:file_cli"
+cryptography-suite = "cryptography_suite.cli:main"
 
 [tool.black]
 line-length = 88

--- a/tests/test_bls.py
+++ b/tests/test_bls.py
@@ -17,6 +17,7 @@ class TestBLS(unittest.TestCase):
     def test_sign_and_verify(self):
         sk, pk = generate_bls_keypair()
         signature = bls_sign(self.message1, sk)
+        self.assertIsInstance(signature, str)
         self.assertTrue(bls_verify(self.message1, signature, pk))
 
     def test_sign_with_empty_message(self):
@@ -66,7 +67,10 @@ class TestBLS(unittest.TestCase):
         self.assertEqual(pk, expected_pk)
 
         sig = bls_sign(b"hello world", sk)
-        self.assertEqual(sig, expected_sig)
+        self.assertEqual(
+            sig,
+            "oAjH3yFrdcdJfb3hDSGI+2uUP5mbZU34KgZMEHI7kkmT2dSTPEZw5+LlNt3Ie5p6Dg+Oz1+u2+2l7i6nvuQGX0rv7Y9NZlVp7GNrBPNv9v2FP2YoPUE4Q3Yay9plL9Q9",
+        )
         self.assertTrue(bls_verify(b"hello world", sig, pk))
 
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,0 +1,50 @@
+import importlib
+import cryptography_suite.cli as cli
+
+
+def reload_cli():
+    importlib.reload(cli)
+    return cli
+
+
+def test_main_keygen_rsa(monkeypatch, capsys):
+    cli = reload_cli()
+    called = {}
+
+    class KM:
+        def generate_rsa_keypair_and_save(self, priv, pub, pwd):
+            called["args"] = (priv, pub, pwd)
+
+    monkeypatch.setattr(cli, "KeyManager", lambda: KM())
+    cli.main(
+        [
+            "keygen",
+            "rsa",
+            "--private",
+            "priv.pem",
+            "--public",
+            "pub.pem",
+            "--password",
+            "pw",
+        ]
+    )
+    assert called["args"] == ("priv.pem", "pub.pem", "pw")
+    assert "RSA keys saved" in capsys.readouterr().out
+
+
+def test_main_hash(tmp_path, capsys):
+    cli = reload_cli()
+    file = tmp_path / "f.txt"
+    file.write_text("hello")
+    cli.main(["hash", str(file), "--algorithm", "blake3"])
+    out = capsys.readouterr().out.strip()
+    from cryptography_suite.hashing import blake3_hash
+
+    assert out == blake3_hash("hello")
+
+
+def test_main_otp(monkeypatch, capsys):
+    cli = reload_cli()
+    monkeypatch.setattr(cli, "generate_totp", lambda *a, **k: "123")
+    cli.main(["otp", "--secret", "abcd"])
+    assert capsys.readouterr().out.strip() == "123"

--- a/tests/test_pqc.py
+++ b/tests/test_pqc.py
@@ -40,7 +40,7 @@ class TestPQC(unittest.TestCase):
         pk, sk = generate_sphincs_keypair()
         msg = b"sphincs test"
         sig = sphincs_sign(sk, msg)
-        self.assertIsInstance(sig, bytes)
+        self.assertIsInstance(sig, str)
         self.assertTrue(sphincs_verify(pk, msg, sig))
 
     @unittest.skipUnless(SPHINCS_AVAILABLE, "SPHINCS+ not available")

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -32,6 +32,7 @@ class TestSignatures(unittest.TestCase):
         """Test Ed25519 signature generation and verification."""
         private_key, public_key = generate_ed25519_keypair()
         signature = sign_message(self.message, private_key)
+        self.assertIsInstance(signature, str)
         is_valid = verify_signature(self.message, signature, public_key)
         self.assertTrue(is_valid)
 
@@ -64,6 +65,7 @@ class TestSignatures(unittest.TestCase):
         """Test Ed448 signature generation and verification."""
         private_key, public_key = generate_ed448_keypair()
         signature = sign_message_ed448(self.message, private_key)
+        self.assertIsInstance(signature, str)
         is_valid = verify_signature_ed448(self.message, signature, public_key)
         self.assertTrue(is_valid)
 
@@ -85,6 +87,7 @@ class TestSignatures(unittest.TestCase):
         """Test ECDSA signature generation and verification."""
         private_key, public_key = generate_ecdsa_keypair()
         signature = sign_message_ecdsa(self.message, private_key)
+        self.assertIsInstance(signature, str)
         is_valid = verify_signature_ecdsa(self.message, signature, public_key)
         self.assertTrue(is_valid)
 
@@ -180,7 +183,7 @@ class TestSignatures(unittest.TestCase):
         """Test signing message with empty message using Ed25519."""
         private_key, _ = generate_ed25519_keypair()
         with self.assertRaises(CryptographySuiteError) as context:
-            sign_message(b'', private_key)
+            sign_message(b"", private_key)
         self.assertEqual(str(context.exception), "Message cannot be empty.")
 
     def test_sign_message_with_invalid_private_key(self):
@@ -194,7 +197,7 @@ class TestSignatures(unittest.TestCase):
         """Test signing message with empty message using ECDSA."""
         private_key, _ = generate_ecdsa_keypair()
         with self.assertRaises(CryptographySuiteError) as context:
-            sign_message_ecdsa(b'', private_key)
+            sign_message_ecdsa(b"", private_key)
         self.assertEqual(str(context.exception), "Message cannot be empty.")
 
     def test_sign_message_ecdsa_with_invalid_private_key(self):


### PR DESCRIPTION
## Summary
- add `cryptography-suite` CLI entrypoint with `keygen`, `hash`, and `otp` subcommands
- return Base64 by default for signature functions with optional raw bytes
- allow verification functions to accept Base64 strings
- support Base64 for BLS aggregation helpers
- update tests for new interfaces

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881ab286c18832abf206c833726d6d8