### PR TITLE
Fix docs build by installing myst-parser

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install sphinx furo
+          pip install sphinx furo myst-parser
       - name: Build docs
         working-directory: docs
         run: make html


### PR DESCRIPTION
## Summary
- install `myst-parser` during documentation workflow

## Testing
- `make -C docs html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688234e44388832aa0cdaec5b38c87db