### PR TITLE
Clean up unused imports and add vulture whitelist

### DIFF
--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -11,7 +11,7 @@ from .errors import (
     ProtocolError,
     SignatureVerificationError,
 )
-from .debug import VERBOSE_MODE, verbose_print
+
 
 __version__ = "2.0.0"
 
@@ -67,14 +67,10 @@ from .symmetric import (
     aes_encrypt,
     argon2_decrypt,
     argon2_encrypt,
-    ascon_decrypt,
-    ascon_encrypt,
     chacha20_decrypt,
     chacha20_encrypt,
     chacha20_stream_encrypt,
     chacha20_stream_decrypt,
-    salsa20_encrypt,
-    salsa20_decrypt,
     xchacha_encrypt,
     xchacha_decrypt,
     encrypt_file_async,
@@ -85,7 +81,6 @@ from .symmetric import (
     derive_key_scrypt,
     derive_hkdf,
     kdf_pbkdf2,
-    derive_pbkdf2,
     encrypt_file,
     generate_salt,
     pbkdf2_decrypt,
@@ -166,11 +161,11 @@ from .x509 import generate_csr, self_sign_certificate, load_certificate
 
 # Optional homomorphic encryption -------------------------------------------
 try:  # pragma: no cover - optional dependency
-    from .homomorphic import add as fhe_add
-    from .homomorphic import decrypt as fhe_decrypt
-    from .homomorphic import encrypt as fhe_encrypt
+    from .homomorphic import add as fhe_add  # noqa: F401
+    from .homomorphic import decrypt as fhe_decrypt  # noqa: F401
+    from .homomorphic import encrypt as fhe_encrypt  # noqa: F401
     from .homomorphic import keygen as fhe_keygen  # noqa: F401
-    from .homomorphic import multiply as fhe_multiply
+    from .homomorphic import multiply as fhe_multiply  # noqa: F401
 
     FHE_AVAILABLE = True
 except Exception:  # pragma: no cover - handle missing Pyfhel

--- a/cryptography_suite/symmetric/__init__.py
+++ b/cryptography_suite/symmetric/__init__.py
@@ -26,7 +26,6 @@ from .stream import (
     chacha20_stream_encrypt,
     chacha20_stream_decrypt,
 )
-from .ascon import encrypt as _ascon_encrypt, decrypt as _ascon_decrypt
 from .kdf import (
     derive_key_scrypt,
     verify_derived_key_scrypt,
@@ -44,8 +43,6 @@ derive_pbkdf2 = _derive_pbkdf2
 # re-export deprecated ciphers
 salsa20_encrypt = _salsa20_encrypt
 salsa20_decrypt = _salsa20_decrypt
-ascon_encrypt = _ascon_encrypt
-ascon_decrypt = _ascon_decrypt
 
 __all__ = [
     "aes_encrypt",

--- a/tools/vulture_whitelist.py
+++ b/tools/vulture_whitelist.py
@@ -1,0 +1,30 @@
+from cryptography_suite.cli import bulletproof_cli, zksnark_cli, file_cli
+from cryptography_suite.pqc import (
+    kyber_encrypt,
+    kyber_decrypt,
+    dilithium_sign,
+    dilithium_verify,
+    sphincs_sign,
+    sphincs_verify,
+)
+from cryptography_suite.protocols.key_management import KeyManager
+from cryptography_suite.protocols.pake import SPAKE2Client, SPAKE2Server
+
+# Mark symbols used via tests or reflection
+used = [
+    bulletproof_cli,
+    zksnark_cli,
+    file_cli,
+    kyber_encrypt,
+    kyber_decrypt,
+    dilithium_sign,
+    dilithium_verify,
+    sphincs_sign,
+    sphincs_verify,
+    KeyManager.rotate_keys,
+    SPAKE2Client.generate_message,
+    SPAKE2Client.compute_shared_key,
+    SPAKE2Client.get_shared_key,
+    SPAKE2Server.generate_message,
+    SPAKE2Server.compute_shared_key,
+]


### PR DESCRIPTION
## Summary
- remove unused cipher aliases
- remove unused imports from package
- add vulture whitelist for test-only functions

## Testing
- `pytest -q`
- `python -m build`
- `cryptography-suite --help`
