### PR TITLE
Ensure version flag and docs show new APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,13 +328,14 @@ Combine asymmetric keys with AES-GCM for efficient encryption. See
 [`tests/test_hybrid.py`](tests/test_hybrid.py).
 
 ```python
-from cryptography_suite.hybrid import hybrid_encrypt, hybrid_decrypt
+from cryptography_suite.hybrid import HybridEncryptor
 from cryptography_suite.asymmetric import generate_rsa_keypair
 
+encryptor = HybridEncryptor()
 priv, pub = generate_rsa_keypair()
 payload = b"hybrid message"
-encrypted = hybrid_encrypt(payload, pub)
-decrypted = hybrid_decrypt(priv, encrypted)
+encrypted = encryptor.encrypt(payload, pub)
+decrypted = encryptor.decrypt(priv, encrypted)
 
 from cryptography_suite.utils import encode_encrypted_message, decode_encrypted_message
 
@@ -368,6 +369,17 @@ from cryptography_suite.utils import KeyVault
 key_material = b"supersecretkey"
 with KeyVault(key_material) as buf:
     use_key(buf)
+```
+
+### KeyManager File Handling
+
+Persist RSA keys to disk with the high-level ``KeyManager`` helper.
+
+```python
+from cryptography_suite.protocols import KeyManager
+
+km = KeyManager()
+km.generate_rsa_keypair_and_save("priv.pem", "pub.pem", "password")
 ```
 
 ## Advanced Protocols

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -59,7 +59,7 @@ from .asymmetric.signatures import (
     verify_signature_ecdsa,
     verify_signature_ed448,
 )
-from .hybrid import hybrid_decrypt, hybrid_encrypt
+from .hybrid import hybrid_decrypt, hybrid_encrypt, HybridEncryptor
 
 # Symmetric primitives -------------------------------------------------------
 from .symmetric import (
@@ -238,6 +238,7 @@ __all__ = [
     "ec_decrypt",
     "hybrid_encrypt",
     "hybrid_decrypt",
+    "HybridEncryptor",
     # Signatures
     "generate_ed25519_keypair",
     "generate_ed448_keypair",

--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from . import __version__
+
 import argparse
 from .errors import MissingDependencyError, DecryptionError
 from .protocols import generate_totp
@@ -213,6 +215,11 @@ def main(argv: list[str] | None = None) -> None:
     """Unified command line interface for the cryptography suite."""
 
     parser = argparse.ArgumentParser(description=main.__doc__)
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     keygen_parser = sub.add_parser(

--- a/cryptography_suite/hybrid.py
+++ b/cryptography_suite/hybrid.py
@@ -26,6 +26,33 @@ class EncryptedHybridMessage:
     tag: bytes
 
 
+class HybridEncryptor:
+    """Object-oriented helper for hybrid encryption."""
+
+    def encrypt(
+        self,
+        message: bytes,
+        public_key: rsa.RSAPublicKey | x25519.X25519PublicKey,
+        *,
+        raw_output: bool = False,
+    ) -> EncryptedHybridMessage:
+        """Encrypt ``message`` using :func:`hybrid_encrypt`."""
+
+        return hybrid_encrypt(message, public_key, raw_output=raw_output)
+
+    def decrypt(
+        self,
+        private_key: rsa.RSAPrivateKey | x25519.X25519PrivateKey,
+        data: EncryptedHybridMessage
+        | Mapping[str, str | bytes]
+        | str
+        | "EncryptedMessage",
+    ) -> bytes:
+        """Decrypt data produced by :meth:`encrypt`."""
+
+        return hybrid_decrypt(private_key, data)
+
+
 def hybrid_encrypt(
     message: bytes,
     public_key: rsa.RSAPublicKey | x25519.X25519PublicKey,
@@ -122,4 +149,9 @@ def hybrid_decrypt(
             raise DecryptionError(f"Decryption failed: {exc}") from exc
 
 
-__all__ = ["EncryptedHybridMessage", "hybrid_encrypt", "hybrid_decrypt"]
+__all__ = [
+    "EncryptedHybridMessage",
+    "hybrid_encrypt",
+    "hybrid_decrypt",
+    "HybridEncryptor",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,3 +50,6 @@ ignore_missing_imports = True
 
 [mypy-blake3]
 ignore_missing_imports = True
+
+[metadata]
+version = 2.0.0


### PR DESCRIPTION
## Summary
- expose `--version` flag in CLI using `__version__`
- keep version in setup.cfg metadata
- document new `HybridEncryptor` class in README
- add KeyManager example

## Testing
- `pip install -e .[dev]`
- `pytest -q`
- `cryptography-suite --version`
