### PR TITLE
Fix missing mermaid dependency for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,8 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
-          pip install sphinx furo myst-parser
+          pip install -e ".[docs]"
       - name: Build docs
         working-directory: docs
         run: make html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,12 @@ fhe = ["Pyfhel"]
 zk = ["pybulletproofs", "PySNARK"]
 dev = ["pytest", "pytest-cov", "coverage", "coveralls"]
 async = ["aiofiles"]
+docs = [
+    "sphinx",
+    "furo",
+    "myst-parser",
+    "sphinxcontrib-mermaid",
+]
 
 [project.scripts]
 cryptosuite-bulletproof = "cryptography_suite.cli:bulletproof_cli"


### PR DESCRIPTION
## Summary
- add optional `docs` dependencies including `sphinxcontrib-mermaid`
- install docs extras in the docs workflow so `make html` succeeds

## Testing
- `pytest tests/test_package_init.py tests/test_root_exports.py -q`
- `cd docs && make html`
