### PR TITLE
Release 2.0.1 with OTP auto padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [2.0.1] - 2025-07-25
+### Fixed
+- Auto-padding for base32 secrets in OTP to prevent Incorrect padding error
+- Improved handling of lowercase and unpadded OTP secrets
+### Added
+- Tests for real-world OTP misuse and malformed inputs
+
 ## [2.0.0] - 2025-07-24
 ### Added
 - SPAKE2 password-authenticated key exchange implementation.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ cryptography-suite decrypt --file encrypted.bin --out output.txt
 - **Audit Logging**: Decorators and helpers for encrypted audit trails.
 - **KeyVault Management**: Context manager to safely handle in-memory keys.
 - **Password-Authenticated Key Exchange (PAKE)**: SPAKE2 protocol implementation for secure password-based key exchange.
-- **One-Time Passwords (OTP)**: HOTP and TOTP algorithms for generating and verifying one-time passwords.
+ - **One-Time Passwords (OTP)**: HOTP and TOTP algorithms for generating and verifying one-time passwords.
+   > ⚠️ Secrets used for OTP (TOTP/HOTP) will now be auto-padded to prevent base32 decoding issues. No manual padding is required.
 - **Utility Functions**: Includes Base62 encoding/decoding, secure random string generation, and memory zeroing.
 - **Homomorphic Encryption**: Wrapper around Pyfhel supporting CKKS and BFV schemes.
 - **Zero-Knowledge Proofs**: Bulletproof range proofs and zk-SNARK preimage proofs (optional dependencies).

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -13,7 +13,7 @@ from .errors import (
 )
 
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 # Asymmetric primitives ------------------------------------------------------
 from .asymmetric import (

--- a/cryptography_suite/protocols/otp.py
+++ b/cryptography_suite/protocols/otp.py
@@ -7,12 +7,21 @@ from typing import Optional
 from ..errors import ProtocolError
 
 
+def _pad_base32(secret: str) -> str:
+    """Return a base32 string padded for decoding."""
+    secret = secret.upper()
+    missing = len(secret) % 8
+    if missing:
+        secret += "=" * (8 - missing)
+    return secret
+
+
 def generate_hotp(secret: str, counter: int, digits: int = 6, algorithm: str = 'sha1') -> str:
     """
     Generates an HOTP code based on a shared secret and counter.
     """
     try:
-        key = base64.b32decode(secret.upper(), casefold=True)
+        key = base64.b32decode(_pad_base32(secret), casefold=True)
     except Exception as e:
         raise ProtocolError(f"Invalid secret: {e}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cryptography-suite"
-version = "2.0.0"
+version = "2.0.1"
 description = "A comprehensive and secure cryptographic toolkit."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -79,3 +79,17 @@ class TestOTP(unittest.TestCase):
         ts = 1000000000
         code = generate_totp(self.secret, timestamp=ts)
         self.assertTrue(verify_totp(code, self.secret, timestamp=ts))
+
+    def test_totp_with_missing_padding(self):
+        secret = base64.b32encode(b'123456789').decode('utf-8').rstrip('=')
+        code = generate_totp(secret)
+        self.assertTrue(verify_totp(code, secret))
+
+    def test_totp_with_lowercase_secret(self):
+        secret = self.secret.lower()
+        code = generate_totp(secret)
+        self.assertTrue(verify_totp(code, secret))
+
+    def test_totp_invalid_secret_should_raise(self):
+        with self.assertRaises(CryptographySuiteError):
+            generate_totp('%%%%')


### PR DESCRIPTION
## Summary
- fix OTP secret padding with helper `_pad_base32`
- handle lowercase & unpadded secrets in HOTP/TOTP
- add tests for real-world OTP issues
- document auto padding in README
- update CHANGELOG and bump version to 2.0.1

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ImportError during collection)*
