### PR TITLE
Update coverage configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
-source = cryptography_suite
+source =
+    cryptography_suite
 
 [report]
 omit =
@@ -8,5 +9,5 @@ omit =
 
 [paths]
 source =
-    cryptography_suite/
-    */site-packages/
+    cryptography_suite
+    */site-packages/cryptography_suite


### PR DESCRIPTION
## Summary
- configure coverage to measure only the `cryptography_suite` package
- exclude the `tests/` directory from reports
- keep branch coverage and path mappings for CI tools

## Testing
- `pytest --cov=cryptography_suite --cov-config=.coveragerc`
