### PR TITLE
Finalize X3DH v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [2.0.2] - 2025-07-26
+### Added
+- Signed prekey verification during X3DH session setup.
+- Optional one-time prekey support with debug logging of DH steps.
+
 ## [2.0.1] - 2025-07-25
 ### Fixed
 - Auto-padding for base32 secrets in OTP to prevent Incorrect padding error

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,16 @@
+# Release Notes - Cryptography Suite 2.0.2
+
+Cryptography Suite 2.0.2 introduces improvements to the X3DH key agreement.
+
+## Highlights
+
+- **Signed Prekey Verification** ensures that session setup fails when the
+  signature on the sender's prekey is invalid.
+- **Optional One-Time Prekeys** are now mixed into the shared secret when
+  provided, with each DH step logged when ``VERBOSE_MODE`` is enabled.
+
+---
+
 # Release Notes - Cryptography Suite 2.0.1
 
 Cryptography Suite 2.0.1 is a maintenance release focused on reliability improvements and documentation updates.

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -13,7 +13,7 @@ from .errors import (
 )
 
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 # Asymmetric primitives ------------------------------------------------------
 from .asymmetric import (

--- a/cryptography_suite/protocols/__init__.py
+++ b/cryptography_suite/protocols/__init__.py
@@ -8,6 +8,7 @@ from .signal import (
     SignalReceiver,
     initialize_signal_session,
 )
+from .signal.init_session import verify_signed_prekey
 from .key_management import (
     generate_aes_key,
     rotate_aes_key,
@@ -32,6 +33,7 @@ __all__ = [
     "SignalSender",
     "SignalReceiver",
     "initialize_signal_session",
+    "verify_signed_prekey",
     "generate_aes_key",
     "rotate_aes_key",
     "secure_save_key_to_file",

--- a/cryptography_suite/protocols/signal/init_session.py
+++ b/cryptography_suite/protocols/signal/init_session.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from ...asymmetric.signatures import verify_signature
+from ...errors import SignatureVerificationError
+
+
+def verify_signed_prekey(
+    signed_prekey: bytes,
+    signature: bytes,
+    identity_key: ed25519.Ed25519PublicKey,
+) -> None:
+    """Verify that *signed_prekey* was signed with *identity_key*."""
+
+    if not verify_signature(signed_prekey, signature, identity_key):
+        raise SignatureVerificationError("Invalid signed_prekey signature")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ documentation for details.
    :caption: Contents:
 
    architecture.md
+   protocols.md
    security.rst
    api/modules
 

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -1,0 +1,10 @@
+# Protocol Notes
+
+The suite provides a light-weight X3DH implementation used for Signal-like sessions.
+During session setup the receiver verifies that the sender's signed prekey is
+signed with the sender's identity key. A failed verification raises
+`SignatureVerificationError`.
+
+One-time prekeys are optional. When present they are mixed into the Diffie–Hellman
+chain as `dh4 = DH(IK_B, OPK_A)`. Each step of the chain (`dh1`, `dh2`, `dh3`, `dh4`)
+is logged with `verbose_print` when `VERBOSE_MODE` is enabled.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cryptography-suite"
-version = "2.0.1"
+version = "2.0.2"
 description = "A comprehensive and secure cryptographic toolkit."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_x3dh.py
+++ b/tests/test_x3dh.py
@@ -1,0 +1,41 @@
+import unittest
+from cryptography_suite.protocols import initialize_signal_session
+from cryptography_suite.protocols.signal import x3dh_initiator, x3dh_responder
+from cryptography_suite.asymmetric import generate_x25519_keypair
+from cryptography_suite.errors import SignatureVerificationError
+
+
+class TestX3DH(unittest.TestCase):
+    def test_invalid_signed_prekey(self):
+        sender, receiver = initialize_signal_session()
+        bundle = list(sender.handshake_bundle)
+        bundle[3] = b"bad"  # corrupt signature
+        with self.assertRaises(SignatureVerificationError):
+            receiver.initialize_session(*bundle)
+
+    def test_one_time_prekey_usage(self):
+        ik_a_priv, _ = generate_x25519_keypair()
+        ik_b_priv, ik_b_pub = generate_x25519_keypair()
+        spk_b_priv, spk_b_pub = generate_x25519_keypair()
+        ek_a_priv, ek_a_pub = generate_x25519_keypair()
+        opk_a_priv, opk_a_pub = generate_x25519_keypair()
+
+        secret1 = x3dh_initiator(
+            ik_a_priv,
+            ek_a_priv,
+            ik_b_pub,
+            spk_b_pub,
+            opk_priv=opk_a_priv,
+        )
+        secret2 = x3dh_responder(
+            ik_b_priv,
+            spk_b_priv,
+            ik_a_priv.public_key(),
+            ek_a_pub,
+            opk_a_pub,
+        )
+        self.assertEqual(secret1, secret2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- bump version to 2.0.2
- implement optional one-time prekey use in X3DH
- verify signed prekey signatures during session setup
- expose `verify_signed_prekey` helper
- document protocol behaviour
- add regression tests for X3DH

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884fc890e78832a9ebf47ca7362c6ce