### PR TITLE
Introduce basic backend framework

### DIFF
--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -15,6 +15,10 @@ from .errors import (
 
 __version__ = "2.0.2"
 
+# Backend registry -----------------------------------------------------------------
+from .crypto_backends import available_backends, use_backend  # noqa: E402
+from .crypto_backends import pyca_backend  # noqa: F401  - registers default backend
+
 # Asymmetric primitives ------------------------------------------------------
 from .asymmetric import (
     derive_x448_shared_key,
@@ -324,6 +328,8 @@ __all__ = [
     "SignatureVerificationError",
     "MissingDependencyError",
     "ProtocolError",
+    "available_backends",
+    "use_backend",
 ]
 
 # Conditional exports -------------------------------------------------------

--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -28,6 +28,7 @@ from .zk.bulletproof import (
     setup as bp_setup,
     BULLETPROOF_AVAILABLE,
 )
+from .crypto_backends import available_backends
 
 try:
     from . import zksnark
@@ -223,6 +224,19 @@ def otp_cli(argv: list[str] | None = None) -> None:
     print(code)
 
 
+def backends_cli(argv: list[str] | None = None) -> None:
+    """Manage registered crypto backends."""
+
+    parser = argparse.ArgumentParser(description="Backend management")
+    sub = parser.add_subparsers(dest="action", required=True)
+    sub.add_parser("list", help="List available backends")
+    args = parser.parse_args(argv)
+
+    if args.action == "list":
+        for name in available_backends():
+            print(name)
+
+
 def main(argv: list[str] | None = None) -> None:
     """Unified command line interface for the cryptography suite."""
 
@@ -266,6 +280,11 @@ def main(argv: list[str] | None = None) -> None:
         default="sha1",
     )
 
+    back_parser = sub.add_parser(
+        "backends", help="Manage crypto backends", description=backends_cli.__doc__
+    )
+    back_parser.add_argument("action", choices=["list"], nargs="?")
+
     args = parser.parse_args(argv)
 
     if args.cmd == "keygen":
@@ -279,6 +298,11 @@ def main(argv: list[str] | None = None) -> None:
         keygen_cli(argv2)
     elif args.cmd == "hash":
         hash_cli([args.file, f"--algorithm={args.algorithm}"])
+    elif args.cmd == "backends":
+        action_args: list[str] = []
+        if args.action:
+            action_args.append(args.action)
+        backends_cli(action_args)
     else:
         otp_cli(
             [

--- a/cryptography_suite/crypto_backends/__init__.py
+++ b/cryptography_suite/crypto_backends/__init__.py
@@ -46,7 +46,7 @@ def get_backend() -> Any:
 
 
 # register built-in backends
-from . import pyca_backend  # noqa: F401
+from . import pyca_backend  # noqa: F401,E402
 
 __all__ = [
     "register_backend",
@@ -54,4 +54,3 @@ __all__ = [
     "use_backend",
     "get_backend",
 ]
-

--- a/cryptography_suite/crypto_backends/__init__.py
+++ b/cryptography_suite/crypto_backends/__init__.py
@@ -1,0 +1,57 @@
+"""Backend abstraction layer for cryptography-suite."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Type, Optional, Any
+
+
+_backend_registry: Dict[str, Type[Any]] = {}
+_current_backend: Optional[Any] = None
+
+
+def register_backend(name: str) -> Callable[[Type[Any]], Type[Any]]:
+    """Class decorator to register a backend implementation."""
+
+    def decorator(cls: Type[Any]) -> Type[Any]:
+        _backend_registry[name] = cls
+        return cls
+
+    return decorator
+
+
+def available_backends() -> list[str]:
+    return list(_backend_registry.keys())
+
+
+def use_backend(name: str) -> None:
+    """Select the backend to use at runtime."""
+    global _current_backend
+    try:
+        backend_cls = _backend_registry[name]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unknown backend: {name}") from exc
+    _current_backend = backend_cls()
+
+
+def get_backend() -> Any:
+    """Return the currently selected backend instance."""
+    if _current_backend is None:
+        # default to first registered backend
+        if not _backend_registry:
+            raise RuntimeError("No backends registered")
+        name = next(iter(_backend_registry))
+        use_backend(name)
+    assert _current_backend is not None
+    return _current_backend
+
+
+# register built-in backends
+from . import pyca_backend  # noqa: F401
+
+__all__ = [
+    "register_backend",
+    "available_backends",
+    "use_backend",
+    "get_backend",
+]
+

--- a/cryptography_suite/crypto_backends/abc.py
+++ b/cryptography_suite/crypto_backends/abc.py
@@ -1,0 +1,39 @@
+"""Abstract base classes for cryptographic primitives."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class AEAD(ABC):
+    """Authenticated encryption with associated data interface."""
+
+    @abstractmethod
+    def encrypt(
+        self,
+        plaintext: bytes,
+        key: bytes,
+        nonce: bytes,
+        *,
+        associated_data: bytes | None = None,
+    ) -> bytes:
+        """Encrypt ``plaintext`` using AEAD."""
+
+    @abstractmethod
+    def decrypt(
+        self,
+        ciphertext: bytes,
+        key: bytes,
+        nonce: bytes,
+        *,
+        associated_data: bytes | None = None,
+    ) -> bytes:
+        """Decrypt ciphertext encrypted with AEAD."""
+
+
+class KDF(ABC):
+    """Key derivation function interface."""
+
+    @abstractmethod
+    def derive(self, password: str, salt: bytes, *, length: int) -> bytes:
+        """Derive a key from ``password`` and ``salt``."""

--- a/cryptography_suite/crypto_backends/pyca_backend.py
+++ b/cryptography_suite/crypto_backends/pyca_backend.py
@@ -1,0 +1,49 @@
+"""PyCA based backend implementation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .abc import AEAD, KDF
+from . import register_backend
+from ..aead import chacha20_encrypt_aead, chacha20_decrypt_aead
+from ..symmetric import derive_key_pbkdf2
+
+
+@register_backend("pyca")
+class PyCABackend:
+    """Backend powered by the ``cryptography`` package."""
+
+    class AEADImpl(AEAD):
+        def encrypt(
+            self,
+            plaintext: bytes,
+            key: bytes,
+            nonce: bytes,
+            *,
+            associated_data: bytes | None = None,
+        ) -> bytes:
+            return chacha20_encrypt_aead(
+                plaintext, key, nonce, associated_data=associated_data
+            )
+
+        def decrypt(
+            self,
+            ciphertext: bytes,
+            key: bytes,
+            nonce: bytes,
+            *,
+            associated_data: bytes | None = None,
+        ) -> bytes:
+            return chacha20_decrypt_aead(
+                ciphertext, key, nonce, associated_data=associated_data
+            )
+
+    class KDFImpl(KDF):
+        def derive(self, password: str, salt: bytes, *, length: int) -> bytes:
+            return derive_key_pbkdf2(password, salt, key_size=length)
+
+    def __init__(self) -> None:
+        self.aead: AEAD = PyCABackend.AEADImpl()
+        self.kdf: KDF = PyCABackend.KDFImpl()
+

--- a/cryptography_suite/crypto_backends/pyca_backend.py
+++ b/cryptography_suite/crypto_backends/pyca_backend.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from .abc import AEAD, KDF
 from . import register_backend
 from ..aead import chacha20_encrypt_aead, chacha20_decrypt_aead
@@ -46,4 +44,3 @@ class PyCABackend:
     def __init__(self) -> None:
         self.aead: AEAD = PyCABackend.AEADImpl()
         self.kdf: KDF = PyCABackend.KDFImpl()
-

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,21 @@
+import importlib
+
+import cryptography_suite.crypto_backends as backends
+import cryptography_suite.crypto_backends.pyca_backend as pyca_backend
+
+
+def test_available_backends_contains_pyca():
+    assert "pyca" in backends.available_backends()
+
+
+def test_use_backend_runtime_switch():
+    class Dummy:
+        def __init__(self) -> None:
+            self.value = 1
+
+    backends.register_backend("dummy")(Dummy)
+    backends.use_backend("dummy")
+    b = backends.get_backend()
+    assert isinstance(b, Dummy)
+    assert b.value == 1
+    backends.use_backend("pyca")

--- a/tests/test_cli_backends.py
+++ b/tests/test_cli_backends.py
@@ -1,0 +1,6 @@
+def test_backends_cli_list(capsys):
+    from cryptography_suite.cli import backends_cli
+
+    backends_cli(["list"])
+    out = capsys.readouterr().out
+    assert "pyca" in out


### PR DESCRIPTION
## Summary
- add new `crypto_backends` package with registry and abstract base classes
- implement `PyCABackend` and register it by default
- expose backend selection via CLI (`cryptography-suite backends list`)
- document backend APIs in `__all__`
- test runtime backend switching and CLI

## Testing
- `pytest tests/test_backends.py tests/test_cli_backends.py -q`
