### PR TITLE
Add skeleton generator CLI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 mypy pylint bandit vulture
-          pip install -e .
+          pip install -e .[dev]
       - name: Run flake8
         run: flake8
       - name: Run mypy

--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -279,6 +279,20 @@ def export_cli(argv: list[str] | None = None) -> None:
         print(pipe.to_tamarin())
 
 
+def gen_cli(argv: list[str] | None = None) -> None:
+    """Generate application skeletons from a pipeline."""
+
+    parser = argparse.ArgumentParser(description=gen_cli.__doc__)
+    parser.add_argument("--target", choices=["fastapi", "flask", "node"], required=True)
+    parser.add_argument("--pipeline", required=True, help="Pipeline YAML file")
+    parser.add_argument("--output", help="Output directory")
+    args = parser.parse_args(argv)
+
+    from .codegen import generate
+
+    generate(args.target, args.pipeline, args.output)
+
+
 def main(argv: list[str] | None = None) -> None:
     """Unified command line interface for the cryptography suite."""
 
@@ -329,6 +343,13 @@ def main(argv: list[str] | None = None) -> None:
     export_parser.add_argument("--format", choices=["proverif", "tamarin"], default="proverif")
     export_parser.add_argument("--track", action="append", default=[], help="Secret names to monitor")
 
+    gen_parser = sub.add_parser(
+        "gen", help="Generate application skeleton", description=gen_cli.__doc__
+    )
+    gen_parser.add_argument("--target", choices=["fastapi", "flask", "node"], required=True)
+    gen_parser.add_argument("--pipeline", required=True)
+    gen_parser.add_argument("--output")
+
     back_parser = sub.add_parser(
         "backends", help="Manage crypto backends", description=backends_cli.__doc__
     )
@@ -352,6 +373,11 @@ def main(argv: list[str] | None = None) -> None:
         for sec in args.track:
             argv2.extend(["--track", sec])
         export_cli(argv2)
+    elif args.cmd == "gen":
+        argv2 = [f"--target={args.target}", f"--pipeline={args.pipeline}"]
+        if args.output:
+            argv2.extend(["--output", args.output])
+        gen_cli(argv2)
     elif args.cmd == "backends":
         action_args: list[str] = []
         if args.action:

--- a/cryptography_suite/codegen/__init__.py
+++ b/cryptography_suite/codegen/__init__.py
@@ -1,0 +1,41 @@
+"""Code generation utilities for cryptosuite."""
+from __future__ import annotations
+
+from importlib import resources
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+
+def generate(target: str, pipeline_file: str, out_dir: str | None = None) -> Path:
+    """Generate an application skeleton for the given target."""
+    out_path = Path(out_dir or f"generated_{target}")
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    with open(pipeline_file, "r", encoding="utf-8") as fh:
+        steps: Iterable[str] = yaml.safe_load(fh) or []
+
+    # Load templates
+    with resources.path(__name__, "templates") as tpl_dir:
+        env = Environment(loader=FileSystemLoader(str(tpl_dir)))
+        if target == "fastapi":
+            template = env.get_template("fastapi/app.py.j2")
+            fname = "app.py"
+        elif target == "flask":
+            template = env.get_template("flask/app.py.j2")
+            fname = "app.py"
+        elif target == "node":
+            template = env.get_template("node/app.ts.j2")
+            fname = "app.ts"
+        else:
+            raise ValueError(f"Unknown target {target}")
+
+        rendered = template.render(steps=list(steps))
+        (out_path / fname).write_text(rendered, encoding="utf-8")
+
+        readme_tpl = env.get_template("README.md.j2")
+        (out_path / "README.md").write_text(readme_tpl.render(), encoding="utf-8")
+
+    return out_path

--- a/cryptography_suite/codegen/templates/README.md.j2
+++ b/cryptography_suite/codegen/templates/README.md.j2
@@ -1,0 +1,7 @@
+# Generated Skeleton
+
+This project was generated from a pipeline definition.
+
+## Running
+
+See `app.py` or `app.ts` for the entry point. Install dependencies and run your chosen server.

--- a/cryptography_suite/codegen/templates/fastapi/app.py.j2
+++ b/cryptography_suite/codegen/templates/fastapi/app.py.j2
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="Crypto Pipeline")
+
+class Input(BaseModel):
+    data: str
+
+@app.post("/run")
+def run(data: Input):
+    value = data.data
+{% for step in steps %}
+    # {{ step }}
+    value = {{ step }}(value)
+{% endfor %}
+    return {"result": value}

--- a/cryptography_suite/codegen/templates/flask/app.py.j2
+++ b/cryptography_suite/codegen/templates/flask/app.py.j2
@@ -1,0 +1,12 @@
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+@app.route('/run', methods=['POST'])
+def run():
+    value = request.json.get('data', '')
+{% for step in steps %}
+    # {{ step }}
+    value = {{ step }}(value)
+{% endfor %}
+    return jsonify(result=value)

--- a/cryptography_suite/codegen/templates/node/app.ts.j2
+++ b/cryptography_suite/codegen/templates/node/app.ts.j2
@@ -1,0 +1,16 @@
+import express from 'express'
+import bodyParser from 'body-parser'
+
+const app = express()
+app.use(bodyParser.json())
+
+app.post('/run', (req, res) => {
+  let value = req.body.data as string
+{% for step in steps %}
+  // {{ step }}
+  value = {{ step }}(value)
+{% endfor %}
+  res.json({ result: value })
+})
+
+export default app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "pynacl",
     "pycryptodome"
     , "PyYAML"
+    , "Jinja2"
 ]
 
 [project.optional-dependencies]
@@ -76,6 +77,7 @@ exclude = ["tests*", "docs*", "examples*", "demo*"]
 
 [tool.setuptools.package-data]
 "cryptography_suite" = ["py.typed"]
+"cryptography_suite.codegen" = ["templates/**"]
 
 [tool.black]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
 pqc = ["pqcrypto"]
 fhe = ["Pyfhel"]
 zk = ["pybulletproofs", "PySNARK"]
-dev = ["pytest", "pytest-cov", "coverage", "coveralls", "mypy"]
+dev = ["pytest", "pytest-cov", "coverage", "coveralls", "mypy", "types-PyYAML"]
 async = ["aiofiles"]
 docs = ["sphinx", "furo", "myst-parser", "sphinxcontrib-mermaid"]
 

--- a/tests/test_cli_gen.py
+++ b/tests/test_cli_gen.py
@@ -1,0 +1,22 @@
+import importlib
+import cryptography_suite.cli as cli
+
+
+def reload_cli():
+    importlib.reload(cli)
+    return cli
+
+
+def test_gen_cli_fastapi(tmp_path):
+    c = reload_cli()
+    pipeline = tmp_path / "pipe.yaml"
+    pipeline.write_text("- StepA\n- StepB\n")
+    out_dir = tmp_path / "gen"
+    c.gen_cli([
+        "--target", "fastapi",
+        "--pipeline", str(pipeline),
+        "--output", str(out_dir),
+    ])
+    assert (out_dir / "app.py").exists()
+    assert (out_dir / "README.md").exists()
+


### PR DESCRIPTION
## Summary
- add Jinja2 templates and simple generator module
- extend CLI with `gen` command to produce FastAPI/Flask/Node skeletons
- include templates as package data and add Jinja2 dependency
- test CLI generation

## Testing
- `pip install -e .`
- `pytest -q`
