### PR TITLE
Add pluggable keystore framework

### DIFF
--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -29,7 +29,6 @@ from .zk.bulletproof import (
     BULLETPROOF_AVAILABLE,
 )
 from .crypto_backends import available_backends
-from .keystores import load_plugins  # ensure plugins can be loaded in CLI
 
 try:
     from . import zksnark

--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -29,6 +29,7 @@ from .zk.bulletproof import (
     BULLETPROOF_AVAILABLE,
 )
 from .crypto_backends import available_backends
+from .keystores import load_plugins  # ensure plugins can be loaded in CLI
 
 try:
     from . import zksnark
@@ -237,6 +238,44 @@ def backends_cli(argv: list[str] | None = None) -> None:
             print(name)
 
 
+def keystore_cli(argv: list[str] | None = None) -> None:
+    """Manage registered keystores."""
+
+    from .keystores import load_plugins, list_keystores, get_keystore
+
+    parser = argparse.ArgumentParser(description="Keystore management")
+    sub = parser.add_subparsers(dest="action", required=True)
+    sub.add_parser("list", help="List available keystores")
+    sub.add_parser("test", help="Test keystore connectivity")
+    mig = sub.add_parser("migrate", help="Migrate keys between keystores")
+    mig.add_argument("--from", dest="src", required=True)
+    mig.add_argument("--to", dest="dst", required=True)
+    args = parser.parse_args(argv)
+
+    load_plugins()
+
+    if args.action == "list":
+        for name in list_keystores():
+            print(name)
+    elif args.action == "test":
+        for name in list_keystores():
+            cls = get_keystore(name)
+            try:
+                ok = cls().test_connection()
+            except Exception:
+                ok = False
+            print(f"{name}: {'ok' if ok else 'fail'}")
+    else:  # migrate
+        src_cls = get_keystore(args.src)
+        dst_cls = get_keystore(args.dst)
+        src = src_cls()
+        dst = dst_cls()
+        if hasattr(src, "export_all_to"):
+            src.export_all_to(dst)  # type: ignore[attr-defined]
+        else:
+            print(f"Migration from {args.src} to {args.dst} not implemented")
+
+
 def export_cli(argv: list[str] | None = None) -> None:
     """Export a pipeline definition to a formal verification model."""
 
@@ -355,6 +394,13 @@ def main(argv: list[str] | None = None) -> None:
     )
     back_parser.add_argument("action", choices=["list"], nargs="?")
 
+    ks_parser = sub.add_parser(
+        "keystore", help="Manage keystores", description=keystore_cli.__doc__
+    )
+    ks_parser.add_argument("action", choices=["list", "test", "migrate"])
+    ks_parser.add_argument("--from", dest="src")
+    ks_parser.add_argument("--to", dest="dst")
+
     args = parser.parse_args(argv)
 
     if args.cmd == "keygen":
@@ -378,6 +424,13 @@ def main(argv: list[str] | None = None) -> None:
         if args.output:
             argv2.extend(["--output", args.output])
         gen_cli(argv2)
+    elif args.cmd == "keystore":
+        argv2 = [args.action]
+        if args.src:
+            argv2.extend(["--from", args.src])
+        if args.dst:
+            argv2.extend(["--to", args.dst])
+        keystore_cli(argv2)
     elif args.cmd == "backends":
         action_args: list[str] = []
         if args.action:

--- a/cryptography_suite/keystores/__init__.py
+++ b/cryptography_suite/keystores/__init__.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import pkgutil
+import pathlib
+from importlib import metadata
+from typing import Dict, Type
+
+from .base import KeyStore
+
+_REGISTRY: Dict[str, Type[KeyStore]] = {}
+
+
+def register_keystore(name: str):
+    """Class decorator to register keystore implementations."""
+
+    def decorator(cls: Type[KeyStore]) -> Type[KeyStore]:
+        _REGISTRY[name] = cls
+        return cls
+
+    return decorator
+
+
+def list_keystores() -> list[str]:
+    return list(_REGISTRY.keys())
+
+
+def get_keystore(name: str) -> Type[KeyStore]:
+    return _REGISTRY[name]
+
+
+def load_plugins(directory: str | None = None) -> None:
+    """Import available keystore plugins."""
+
+    # built-in plugins in this package
+    pkg = __name__
+    for _, modname, _ in pkgutil.iter_modules(__path__):
+        if modname.startswith('_') or modname in {"base"}:
+            continue
+        importlib.import_module(f"{pkg}.{modname}")
+
+    # external plugins from path
+    if directory is None:
+        directory = str(pathlib.Path.cwd() / "keystores")
+    dpath = pathlib.Path(directory)
+    if dpath.is_dir():
+        for file in dpath.glob("*.py"):
+            spec = importlib.util.spec_from_file_location(
+                f"ext_keystore_{file.stem}", file
+            )
+            if spec and spec.loader:
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+
+    # entry points
+    try:
+        for ep in metadata.entry_points(group="cryptosuite.keystores"):
+            ep.load()
+    except Exception:
+        pass
+
+__all__ = [
+    "KeyStore",
+    "register_keystore",
+    "list_keystores",
+    "get_keystore",
+    "load_plugins",
+]

--- a/cryptography_suite/keystores/__init__.py
+++ b/cryptography_suite/keystores/__init__.py
@@ -60,6 +60,7 @@ def load_plugins(directory: str | None = None) -> None:
     except Exception:
         pass
 
+
 __all__ = [
     "KeyStore",
     "register_keystore",

--- a/cryptography_suite/keystores/base.py
+++ b/cryptography_suite/keystores/base.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class KeyStore(Protocol):
+    """Common interface for key store backends."""
+
+    name: str
+
+    def list_keys(self) -> list[str]:
+        """Return available key identifiers."""
+
+    def test_connection(self) -> bool:
+        """Check backend availability."""
+
+    def sign(self, key_id: str, data: bytes) -> bytes:
+        """Sign ``data`` using ``key_id``."""
+
+    def decrypt(self, key_id: str, data: bytes) -> bytes:
+        """Decrypt ``data`` using ``key_id``."""
+
+    def unwrap(self, key_id: str, wrapped_key: bytes) -> bytes:
+        """Unwrap ``wrapped_key`` using ``key_id``."""

--- a/cryptography_suite/keystores/base.py
+++ b/cryptography_suite/keystores/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from typing import Protocol, runtime_checkable
 
 

--- a/cryptography_suite/keystores/local.py
+++ b/cryptography_suite/keystores/local.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from . import register_keystore
+from .base import KeyStore
+from ..audit import audit_log
+from ..asymmetric import load_private_key, rsa_decrypt
+from ..asymmetric.signatures import sign_message
+
+
+@register_keystore("local")
+class LocalKeyStore:
+    """File-based keystore for development and testing."""
+
+    name = "local"
+
+    def __init__(self, directory: str = "keys") -> None:
+        self.dir = Path(directory)
+        self.dir.mkdir(exist_ok=True)
+
+    def list_keys(self) -> List[str]:
+        return [p.stem for p in self.dir.glob("*.pem")]
+
+    def test_connection(self) -> bool:
+        return True
+
+    @audit_log
+    def sign(self, key_id: str, data: bytes) -> bytes:
+        key_path = self.dir / f"{key_id}.pem"
+        if not key_path.exists():
+            raise FileNotFoundError(key_path)
+        with open(key_path, "rb") as f:
+            priv = load_private_key(f.read(), None)
+        return sign_message(data, priv, raw_output=True)
+
+    @audit_log
+    def decrypt(self, key_id: str, data: bytes) -> bytes:
+        key_path = self.dir / f"{key_id}.pem"
+        if not key_path.exists():
+            raise FileNotFoundError(key_path)
+        with open(key_path, "rb") as f:
+            priv = load_private_key(f.read(), None)
+        return rsa_decrypt(data, priv)
+
+    @audit_log
+    def unwrap(self, key_id: str, wrapped_key: bytes) -> bytes:
+        return self.decrypt(key_id, wrapped_key)

--- a/cryptography_suite/keystores/local.py
+++ b/cryptography_suite/keystores/local.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import List
 
 from . import register_keystore
-from .base import KeyStore
 from ..audit import audit_log
 from ..asymmetric import load_private_key, rsa_decrypt
 from ..asymmetric.signatures import sign_message

--- a/cryptography_suite/keystores/mock_hsm.py
+++ b/cryptography_suite/keystores/mock_hsm.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import List
 
 from . import register_keystore
-from .base import KeyStore
 from ..audit import audit_log
 
 

--- a/cryptography_suite/keystores/mock_hsm.py
+++ b/cryptography_suite/keystores/mock_hsm.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import List
+
+from . import register_keystore
+from .base import KeyStore
+from ..audit import audit_log
+
+
+@register_keystore("mock_hsm")
+class MockHSMKeyStore:
+    """In-memory keystore emulating an HSM for testing."""
+
+    name = "mock_hsm"
+
+    def __init__(self) -> None:
+        self._keys: dict[str, bytes] = {"test": b"secret"}
+
+    def list_keys(self) -> List[str]:
+        return list(self._keys.keys())
+
+    def test_connection(self) -> bool:
+        return True
+
+    @audit_log
+    def sign(self, key_id: str, data: bytes) -> bytes:
+        key = self._keys.get(key_id)
+        if key is None:
+            raise FileNotFoundError(key_id)
+        return data + key  # fake signature
+
+    @audit_log
+    def decrypt(self, key_id: str, data: bytes) -> bytes:
+        key = self._keys.get(key_id)
+        if key is None:
+            raise FileNotFoundError(key_id)
+        return data.replace(key, b"")
+
+    @audit_log
+    def unwrap(self, key_id: str, wrapped_key: bytes) -> bytes:
+        return wrapped_key[::-1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ PyYAML
 rich
 ipywidgets
 networkx
+jinja2

--- a/tests/test_keystore_plugins.py
+++ b/tests/test_keystore_plugins.py
@@ -1,0 +1,28 @@
+from cryptography_suite.keystores import load_plugins, list_keystores, get_keystore
+from cryptography_suite.cli import keystore_cli
+from cryptography_suite.audit import InMemoryAuditLogger, set_audit_logger
+
+
+def test_keystore_loader():
+    load_plugins()
+    assert "local" in list_keystores()
+    cls = get_keystore("local")
+    ks = cls()
+    assert ks.test_connection()
+
+
+def test_keystore_cli_list(capsys):
+    load_plugins()
+    keystore_cli(["list"])
+    out = capsys.readouterr().out
+    assert "local" in out
+
+
+def test_mock_hsm_audit():
+    load_plugins()
+    log = InMemoryAuditLogger()
+    set_audit_logger(log)
+    ks = get_keystore("mock_hsm")()
+    ks.sign("test", b"data")
+    set_audit_logger(None)
+    assert log.logs[0]["operation"] == "sign"


### PR DESCRIPTION
## Summary
- implement keystore plugin architecture
- add local and mock HSM keystore backends
- expose `keystore` CLI commands
- audit keystore operations
- test keystore loading and CLI

## Testing
- `pytest tests/test_keystore_plugins.py -q`
- `pytest -q`
