### PR TITLE
Finalize X3DH verification

### DIFF
--- a/cryptography_suite/protocols/signal/__init__.py
+++ b/cryptography_suite/protocols/signal/__init__.py
@@ -12,6 +12,7 @@ from cryptography.hazmat.primitives import serialization
 from ...errors import ProtocolError, SignatureVerificationError
 from ...debug import verbose_print
 from ...asymmetric.signatures import sign_message, verify_signature
+from .init_session import verify_signed_prekey
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
@@ -305,9 +306,10 @@ class SignalReceiver:
     ) -> None:
         """Complete the handshake using the sender's public keys."""
 
-        id_verify = ed25519.Ed25519PublicKey.from_public_bytes(sender_signing_pub or sender_identity_pub)
-        if not verify_signature(sender_signed_prekey, prekey_signature, id_verify):
-            raise SignatureVerificationError("Invalid signed_prekey signature")
+        id_verify = ed25519.Ed25519PublicKey.from_public_bytes(
+            sender_signing_pub or sender_identity_pub
+        )
+        verify_signed_prekey(sender_signed_prekey, prekey_signature, id_verify)
 
         sid_pub = x25519.X25519PublicKey.from_public_bytes(sender_identity_pub)
         seph_pub = x25519.X25519PublicKey.from_public_bytes(sender_eph_pub)

--- a/cryptography_suite/protocols/signal/__init__.py
+++ b/cryptography_suite/protocols/signal/__init__.py
@@ -9,9 +9,9 @@ from typing import Tuple
 from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.primitives.asymmetric import x25519, ed25519
 from cryptography.hazmat.primitives import serialization
-from ...errors import ProtocolError, SignatureVerificationError
+from ...errors import ProtocolError
 from ...debug import verbose_print
-from ...asymmetric.signatures import sign_message, verify_signature
+from ...asymmetric.signatures import sign_message
 from .init_session import verify_signed_prekey
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -1,9 +1,10 @@
 # Protocol Notes
 
-The suite provides a light-weight X3DH implementation used for Signal-like sessions.
-During session setup the receiver verifies that the sender's signed prekey is
-signed with the sender's identity key. A failed verification raises
-`SignatureVerificationError`.
+The suite provides a light-weight X3DH implementation used for Signal-like
+sessions. During session setup the receiver verifies that the sender's
+``signed_prekey`` is signed with the sender's identity key using the helper
+``verify_signed_prekey``. A failed verification raises
+``SignatureVerificationError``.
 
 One-time prekeys are optional. When present they are mixed into the Diffie–Hellman
 chain as `dh4 = DH(IK_B, OPK_A)`. Each step of the chain (`dh1`, `dh2`, `dh3`, `dh4`)


### PR DESCRIPTION
## Summary
- use dedicated `verify_signed_prekey` helper when validating the sender's signed prekey
- clarify protocol documentation
- call helper from `SignalReceiver.initialize_session`
- document helper usage

## Testing
- `pytest tests/test_x3dh.py -q`
