### PR TITLE
Standardize backend selection API

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,10 @@ pipeline-driven workflows. Major enhancements include:
 Example pipeline configuration:
 
 ```python
-from cryptography_suite import select_backend
-from cryptography_suite.crypto_backends import cryptography_backend
+from cryptography_suite import use_backend
 from cryptography_suite.pipeline import Pipeline, AESGCMEncrypt, AESGCMDecrypt
 
-select_backend(cryptography_backend())
+use_backend("pyca")
 
 p = Pipeline() >> AESGCMEncrypt(password="pass") >> AESGCMDecrypt(password="pass")
 assert p.run(b"data") == b"data"
@@ -697,7 +696,7 @@ cryptography-suite/
 
 Version 3.0.0 introduces several breaking changes. To upgrade from 2.x:
 
-- **Backend Selection Required** via ``select_backend``.
+- **Backend Selection Required** via ``use_backend``.
 - **Pipeline API** replaces chained helper calls.
 - **KeyManager Interfaces Updated** for persistent key handling.
 - **Deprecated Helpers Removed** in favor of pipeline stages.

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -63,7 +63,7 @@ from .asymmetric.signatures import (
 
 # Backend registry -----------------------------------------------------------------
 from .crypto_backends import pyca_backend  # noqa: F401  - registers default backend
-from .crypto_backends import available_backends, use_backend  # noqa: E402
+from .crypto_backends import available_backends, use_backend, select_backend  # noqa: E402
 from .hybrid import HybridEncryptor, hybrid_decrypt, hybrid_encrypt
 
 # Symmetric primitives -------------------------------------------------------
@@ -342,6 +342,7 @@ __all__ = [
     "ProtocolError",
     "available_backends",
     "use_backend",
+    "select_backend",
 ]
 
 # Conditional exports -------------------------------------------------------

--- a/cryptography_suite/crypto_backends/__init__.py
+++ b/cryptography_suite/crypto_backends/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Callable, Dict, Type, Optional, Any
+import warnings
 
 
 _backend_registry: Dict[str, Type[Any]] = {}
@@ -24,13 +25,32 @@ def available_backends() -> list[str]:
 
 
 def use_backend(name: str) -> None:
-    """Select the backend to use at runtime."""
+    """Select the backend to use at runtime.
+
+    Example
+    -------
+
+    >>> from cryptography_suite.crypto_backends import use_backend
+    >>> use_backend("pyca")
+    >>> use_backend("sodium")  # doctest: +SKIP
+    >>> use_backend("rust")    # doctest: +SKIP
+    """
     global _current_backend
     try:
         backend_cls = _backend_registry[name]
     except KeyError as exc:  # pragma: no cover - defensive
         raise ValueError(f"Unknown backend: {name}") from exc
     _current_backend = backend_cls()
+
+
+def select_backend(name: str) -> None:
+    """Deprecated alias for :func:`use_backend`."""
+    warnings.warn(
+        "select_backend is deprecated; use use_backend instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    use_backend(name)
 
 
 def get_backend() -> Any:
@@ -52,5 +72,6 @@ __all__ = [
     "register_backend",
     "available_backends",
     "use_backend",
+    "select_backend",
     "get_backend",
 ]

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -5,3 +5,13 @@ API Reference
     :members:
     :undoc-members:
     :show-inheritance:
+
+Selecting a backend
+-------------------
+
+.. doctest::
+
+    >>> from cryptography_suite.crypto_backends import use_backend
+    >>> use_backend("pyca")
+    >>> use_backend("sodium")  # doctest: +SKIP
+    >>> use_backend("rust")    # doctest: +SKIP

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'myst_parser',
     'sphinxcontrib.mermaid',
+    'sphinx.ext.doctest',
 ]
 
 # Paths that contain templates here, relative to this directory.

--- a/docs/migration_3.0.md
+++ b/docs/migration_3.0.md
@@ -6,8 +6,8 @@ accordingly.
 
 ## Breaking Changes
 
-- **Backend Selection** is now mandatory via `select_backend`. The default
-  `cryptography` backend can be enabled with `select_backend(cryptography_backend())`.
+- **Backend Selection** is now mandatory via `use_backend`. The default
+  `cryptography` backend can be enabled with `use_backend("pyca")`.
 - **Pipeline API** replaces ad-hoc helper chains. Compose operations using the
   `Pipeline` class.
 - **Key Management Interfaces** have changed. Use `KeyManager` for all
@@ -25,11 +25,10 @@ accordingly.
 ## Example
 
 ```python
-from cryptography_suite import Pipeline, select_backend
-from cryptography_suite.crypto_backends import cryptography_backend
+from cryptography_suite import Pipeline, use_backend
 from cryptography_suite.pipeline import AESGCMEncrypt, AESGCMDecrypt
 
-select_backend(cryptography_backend())
+use_backend("pyca")
 
 encrypt = AESGCMEncrypt(password="pass")
 decrypt = AESGCMDecrypt(password="pass")

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,4 +1,5 @@
 import importlib
+import pytest
 
 import cryptography_suite.crypto_backends as backends
 import cryptography_suite.crypto_backends.pyca_backend as pyca_backend
@@ -18,4 +19,15 @@ def test_use_backend_runtime_switch():
     b = backends.get_backend()
     assert isinstance(b, Dummy)
     assert b.value == 1
+    backends.use_backend("pyca")
+
+
+def test_select_backend_alias():
+    class Dummy2:
+        pass
+
+    backends.register_backend("dummy2")(Dummy2)
+    with pytest.deprecated_call():
+        backends.select_backend("dummy2")
+    assert isinstance(backends.get_backend(), Dummy2)
     backends.use_backend("pyca")


### PR DESCRIPTION
## Summary
- add deprecated `select_backend` alias
- update README and migration guide for new function name
- document runtime backend selection in API docs
- enable doctest extension for docs
- test the alias functionality

## Testing
- `sphinx-build -b html docs docs/_build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885afee9818832a84ac1d227b8c662e