### PR TITLE
Refactor key management API

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,13 +474,14 @@ with KeyVault(key_material) as buf:
 
 ### KeyManager File Handling
 
-Persist RSA keys to disk with the high-level ``KeyManager`` helper.
+Persist key pairs to disk with the high-level ``KeyManager`` helper.
 
 ```python
 from cryptography_suite.protocols import KeyManager
 
 km = KeyManager()
-km.generate_rsa_keypair_and_save("priv.pem", "pub.pem", "password")
+km.generate_rsa_keypair_and_save("rsa_priv.pem", "rsa_pub.pem", "password")
+km.generate_ec_keypair_and_save("ec_priv.pem", "ec_pub.pem", "password")
 ```
 
 ## Advanced Protocols

--- a/docs/migration_3.0.md
+++ b/docs/migration_3.0.md
@@ -12,6 +12,16 @@ accordingly.
   `Pipeline` class.
 - **Key Management Interfaces** have changed. Use `KeyManager` for all
   persistent key operations.
+
+  Old helpers like ``generate_rsa_keypair_and_save`` and
+  ``generate_ec_keypair_and_save`` are deprecated. Convert code such as::
+
+      generate_ec_keypair_and_save("priv.pem", "pub.pem", "pw")
+
+  to::
+
+      km = KeyManager()
+      km.generate_ec_keypair_and_save("priv.pem", "pub.pem", "pw")
 - **Deprecated Functions Removed.** Legacy helpers marked deprecated in 2.x have
   been deleted.
 

--- a/example_usage.py
+++ b/example_usage.py
@@ -208,9 +208,12 @@ def main():
     print("\n=== Key Management ===")
     private_key_path = "rsa_private.pem"
     public_key_path = "rsa_public.pem"
+    ec_private = "ec_private.pem"
+    ec_public = "ec_public.pem"
 
     km = KeyManager()
     km.generate_rsa_keypair_and_save(private_key_path, public_key_path, key_password)
+    km.generate_ec_keypair_and_save(ec_private, ec_public, key_password)
     loaded_private_key = load_private_key_from_file(private_key_path, key_password)
     loaded_public_key = load_public_key_from_file(public_key_path)
     print("RSA keys generated, saved, and loaded from files successfully.")
@@ -218,6 +221,8 @@ def main():
     # Clean up key files
     os.remove(private_key_path)
     os.remove(public_key_path)
+    os.remove(ec_private)
+    os.remove(ec_public)
 
     # Rotate AES Key
     aes_key = generate_aes_key()

--- a/tests/test_key_management.py
+++ b/tests/test_key_management.py
@@ -12,7 +12,6 @@ from cryptography_suite.protocols import (
     load_private_key_from_file,
     load_public_key_from_file,
     key_exists,
-    generate_ec_keypair_and_save,
     KeyManager,
 )
 
@@ -58,7 +57,7 @@ class TestKeyManagement(unittest.TestCase):
 
     def test_secure_save_and_load_ec_keys(self):
         """Test generating, saving, and loading EC keys."""
-        generate_ec_keypair_and_save(
+        self.km.generate_ec_keypair_and_save(
             self.private_key_path, self.public_key_path, self.password
         )
         self.assertTrue(key_exists(self.private_key_path))
@@ -102,12 +101,37 @@ class TestKeyManagement(unittest.TestCase):
     def test_generate_ec_keypair_and_save_with_invalid_curve(self):
         """Test generating EC key pair with invalid curve."""
         with self.assertRaises(TypeError):
-            generate_ec_keypair_and_save(
+            self.km.generate_ec_keypair_and_save(
                 self.private_key_path,
                 self.public_key_path,
                 self.password,
                 curve="invalid_curve",
             )
+
+    def test_generate_ed25519_and_ed448_keypair_and_save(self):
+        """Generate and load EdDSA key pairs using KeyManager."""
+        ed_priv = "ed_priv.pem"
+        ed_pub = "ed_pub.pem"
+        ed448_priv = "ed448_priv.pem"
+        ed448_pub = "ed448_pub.pem"
+
+        try:
+            self.km.generate_ed25519_keypair_and_save(ed_priv, ed_pub, self.password)
+            self.km.generate_ed448_keypair_and_save(ed448_priv, ed448_pub, self.password)
+
+            priv = load_private_key_from_file(ed_priv, self.password)
+            pub = load_public_key_from_file(ed_pub)
+            self.assertIsNotNone(priv)
+            self.assertIsNotNone(pub)
+
+            priv2 = load_private_key_from_file(ed448_priv, self.password)
+            pub2 = load_public_key_from_file(ed448_pub)
+            self.assertIsNotNone(priv2)
+            self.assertIsNotNone(pub2)
+        finally:
+            for f in (ed_priv, ed_pub, ed448_priv, ed448_pub):
+                if os.path.exists(f):
+                    os.remove(f)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- deprecate `generate_ec_keypair_and_save`
- add `KeyManager.generate_ec_keypair_and_save`
- provide Ed25519/Ed448 helpers on `KeyManager`
- update docs and examples to use the new methods
- extend key management tests

## Testing
- `pytest tests/test_key_management.py tests/test_signatures.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b29bb5f4832abba6b90402550a66