### PR TITLE
chore: deprecate insecure functions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,6 +35,8 @@ jobs:
         run: bandit -r cryptography_suite --exit-zero || true
       - name: Run vulture
         run: vulture cryptography_suite tests || true
+      - name: Check deprecated exports
+        run: python tools/check_deprecated_exports.py
 
   doctest:
     name: README Doctest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Deprecated
+- `derive_pbkdf2` alias in `symmetric.kdf` (use `kdf_pbkdf2`; will be removed in v4.0.0).
+- Legacy helpers `generate_rsa_keypair_and_save` and `generate_ec_keypair_and_save`
+  (use `KeyManager` methods; will be removed in v4.0.0).
+- Insecure ciphers `salsa20_encrypt`/`salsa20_decrypt` and experimental `ascon.encrypt`/`ascon.decrypt`
+  (use `chacha20_stream_encrypt` or authenticated ciphers like `aes_encrypt`).
+
+These functions remain temporarily for backward compatibility but emit
+`DeprecationWarning` on use.
+
 ## [3.0.0] - 2025-08-30
 ### Major Changes
 - Backend-Agnostic Core (Crypto Abstraction Layer)

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ cryptosuite-fuzz --runs 1000
 - **Hybrid Encryption**: Combine RSA/ECIES with AES-GCM for performance and security.
 - **Post-Quantum Cryptography**: Kyber key encapsulation and Dilithium signatures for quantum-safe workflows.
 - **XChaCha20-Poly1305**: Modern stream cipher support when ``cryptography`` exposes ``XChaCha20Poly1305``.
-- **Salsa20 and Ascon**: Provided for reference only. **Not recommended for production** and no longer exported via ``__all__``.
+- **Salsa20 and Ascon**: Deprecated and provided for reference only. **Not recommended for production**, removed from public imports, and scheduled for removal in v4.0.0. Use ``chacha20_stream_encrypt`` or authenticated ciphers like ``aes_encrypt`` instead.
 - **Audit Logging**: Decorators and helpers for encrypted audit trails.
 - **KeyVault Management**: Context manager to safely handle in-memory keys.
 - **Password-Authenticated Key Exchange (PAKE)**: SPAKE2 protocol implementation for secure password-based key exchange.
@@ -178,8 +178,9 @@ cryptosuite-fuzz --runs 1000
 
 ## ⚠️ Security Considerations
 
-- **Insecure Ciphers**: Functions such as `salsa20_encrypt` and `chacha20_stream_encrypt`
+- **Insecure Ciphers**: Functions such as `chacha20_stream_encrypt`
   do not provide authentication and should only be used for educational purposes.
+  The deprecated `salsa20_encrypt` will be removed in v4.0.0.
 - **Verbose Mode**: Enabling `VERBOSE_MODE` leaks sensitive information to stdout; never
   enable it in production.
 - **Private Key Protection**: Always supply a password when saving private keys to PEM
@@ -689,9 +690,10 @@ cryptography-suite/
   ``level`` parameter (512/768/1024). ``kyber_decrypt`` now computes the shared
   secret automatically when omitted.
 - **Key Management**: ``KeyManager`` now provides ``generate_rsa_keypair_and_save``.
-  The standalone ``generate_rsa_keypair_and_save`` helper is deprecated.
-- **KDF Naming**: ``derive_pbkdf2`` has been renamed to ``kdf_pbkdf2`` and the old
-  name is deprecated.
+  The standalone ``generate_rsa_keypair_and_save`` helper is deprecated and will
+  be removed in v4.0.0.
+- **KDF Naming**: ``derive_pbkdf2`` is deprecated and will be removed in v4.0.0.
+  Use ``kdf_pbkdf2`` instead.
 
 ## 🛤 Migration Guide from v2.x to v3.0.0
 

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -138,9 +138,7 @@ from .protocols import (
     SPAKE2Server,
     create_shares,
     generate_aes_key,
-    generate_ec_keypair_and_save,
     generate_hotp,
-    generate_rsa_keypair_and_save,
     generate_totp,
     initialize_signal_session,
     key_exists,
@@ -291,8 +289,6 @@ __all__ = [
     "load_private_key_from_file",
     "load_public_key_from_file",
     "key_exists",
-    "generate_rsa_keypair_and_save",
-    "generate_ec_keypair_and_save",
     # Secret Sharing
     "create_shares",
     "reconstruct_secret",

--- a/cryptography_suite/protocols/__init__.py
+++ b/cryptography_suite/protocols/__init__.py
@@ -16,8 +16,6 @@ from .key_management import (
     load_private_key_from_file,
     load_public_key_from_file,
     key_exists,
-    generate_rsa_keypair_and_save,
-    generate_ec_keypair_and_save,
     KeyManager,
 )
 
@@ -40,7 +38,5 @@ __all__ = [
     "load_private_key_from_file",
     "load_public_key_from_file",
     "key_exists",
-    "generate_rsa_keypair_and_save",
-    "generate_ec_keypair_and_save",
     "KeyManager",
 ]

--- a/cryptography_suite/protocols/key_management.py
+++ b/cryptography_suite/protocols/key_management.py
@@ -87,8 +87,8 @@ def generate_rsa_keypair_and_save(
 ):
     """Legacy wrapper for :class:`KeyManager` RSA key generation.
 
-    .. deprecated:: 2.0.0
-       Use :class:`KeyManager.generate_rsa_keypair_and_save` instead.
+    Deprecated: will be removed in v4.0.0. Use
+    :class:`KeyManager.generate_rsa_keypair_and_save` instead.
     """
 
     km = KeyManager()
@@ -107,7 +107,11 @@ def generate_ec_keypair_and_save(
     password: str,
     curve: ec.EllipticCurve = ec.SECP256R1(),
 ):
-    """Legacy wrapper for :class:`KeyManager` EC key generation."""
+    """Legacy wrapper for :class:`KeyManager` EC key generation.
+
+    Deprecated: will be removed in v4.0.0. Use
+    :class:`KeyManager.generate_ec_keypair_and_save` instead.
+    """
 
     km = KeyManager()
     return km.generate_ec_keypair_and_save(

--- a/cryptography_suite/symmetric/__init__.py
+++ b/cryptography_suite/symmetric/__init__.py
@@ -21,8 +21,6 @@ from .chacha import (
     xchacha_decrypt,
 )
 from .stream import (
-    salsa20_encrypt as _salsa20_encrypt,
-    salsa20_decrypt as _salsa20_decrypt,
     chacha20_stream_encrypt,
     chacha20_stream_decrypt,
 )
@@ -34,15 +32,8 @@ from .kdf import (
     derive_key_argon2,
     derive_hkdf,
     kdf_pbkdf2,
-    derive_pbkdf2 as _derive_pbkdf2,
     generate_salt,
 )
-
-derive_pbkdf2 = _derive_pbkdf2
-
-# re-export deprecated ciphers
-salsa20_encrypt = _salsa20_encrypt
-salsa20_decrypt = _salsa20_decrypt
 
 __all__ = [
     "aes_encrypt",

--- a/cryptography_suite/symmetric/ascon.py
+++ b/cryptography_suite/symmetric/ascon.py
@@ -142,6 +142,10 @@ def encrypt(key: bytes, nonce: bytes, associated_data: bytes, plaintext: bytes) 
     """Encrypt and authenticate using Ascon-128a.
 
     .. warning:: This cipher is experimental and **not recommended for production**.
+
+    Deprecated: will be removed in v4.0.0. Use
+    :func:`cryptography_suite.aead.chacha20_encrypt_aead` or
+    :func:`cryptography_suite.symmetric.aes_encrypt` instead.
     """
     S = _initialize(key, nonce)
     _process_ad(S, associated_data)
@@ -155,6 +159,10 @@ def decrypt(key: bytes, nonce: bytes, associated_data: bytes, ciphertext: bytes)
     """Decrypt and verify using Ascon-128a.
 
     .. warning:: This cipher is experimental and **not recommended for production**.
+
+    Deprecated: will be removed in v4.0.0. Use
+    :func:`cryptography_suite.aead.chacha20_decrypt_aead` or
+    :func:`cryptography_suite.symmetric.aes_decrypt` instead.
     """
     if len(ciphertext) < 16:
         raise DecryptionError("Ciphertext too short.")

--- a/cryptography_suite/symmetric/kdf.py
+++ b/cryptography_suite/symmetric/kdf.py
@@ -163,7 +163,10 @@ def kdf_pbkdf2(password: str, salt: bytes, iterations: int, length: int) -> byte
 
 @deprecated("derive_pbkdf2 is deprecated; use kdf_pbkdf2")
 def derive_pbkdf2(password: str, salt: bytes, iterations: int, length: int) -> bytes:
-    """Deprecated alias for :func:`kdf_pbkdf2`."""
+    """Deprecated alias for :func:`kdf_pbkdf2`.
+
+    Deprecated: will be removed in v4.0.0. Use :func:`kdf_pbkdf2` instead.
+    """
 
     return kdf_pbkdf2(password, salt, iterations, length)
 

--- a/cryptography_suite/symmetric/stream.py
+++ b/cryptography_suite/symmetric/stream.py
@@ -26,6 +26,9 @@ def salsa20_encrypt(message: bytes, key: bytes, nonce: bytes) -> bytes:
 
     The ``key`` must be 32 bytes and ``nonce`` must be 8 bytes.
     Encryption is deterministic for a given key and nonce.
+
+    Deprecated: will be removed in v4.0.0. Use
+    :func:`chacha20_stream_encrypt` instead.
     """
     if not message:
         raise EncryptionError("Message cannot be empty.")
@@ -40,7 +43,11 @@ def salsa20_encrypt(message: bytes, key: bytes, nonce: bytes) -> bytes:
 
 @deprecated("Salsa20 is deprecated and not recommended for production.")
 def salsa20_decrypt(ciphertext: bytes, key: bytes, nonce: bytes) -> bytes:
-    """INSECURE: Decrypt data encrypted with :func:`salsa20_encrypt`."""
+    """INSECURE: Decrypt data encrypted with :func:`salsa20_encrypt`.
+
+    Deprecated: will be removed in v4.0.0. Use
+    :func:`chacha20_stream_decrypt` instead.
+    """
     if not ciphertext:
         raise DecryptionError("Ciphertext cannot be empty.")
     if not isinstance(key, (bytes, bytearray)) or len(key) != CHACHA20_KEY_SIZE:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,7 @@ formally verified, misuse-resistant workflows.
    mypy_plugin.md
    release_process.md
    migration_3.0.md
+   migration_4.0.md
    threat_model.md
    visualization.md
    security.rst

--- a/docs/migration_3.0.md
+++ b/docs/migration_3.0.md
@@ -14,7 +14,8 @@ accordingly.
   persistent key operations.
 
   Old helpers like ``generate_rsa_keypair_and_save`` and
-  ``generate_ec_keypair_and_save`` are deprecated. Convert code such as::
+  ``generate_ec_keypair_and_save`` are deprecated and will be removed in
+  v4.0.0. Convert code such as::
 
       generate_ec_keypair_and_save("priv.pem", "pub.pem", "pw")
 

--- a/docs/migration_4.0.md
+++ b/docs/migration_4.0.md
@@ -1,0 +1,15 @@
+# Migration Guide to Cryptography Suite 4.0.0
+
+The following functions are deprecated and scheduled for removal in v4.0.0. Update
+existing code to use the recommended replacements.
+
+| Deprecated Function | Replacement |
+| --- | --- |
+| `derive_pbkdf2` | `kdf_pbkdf2` |
+| `generate_rsa_keypair_and_save` | `KeyManager.generate_rsa_keypair_and_save` |
+| `generate_ec_keypair_and_save` | `KeyManager.generate_ec_keypair_and_save` |
+| `salsa20_encrypt` / `salsa20_decrypt` | `chacha20_stream_encrypt` / `chacha20_stream_decrypt` |
+| `ascon.encrypt` / `ascon.decrypt` | `aead.chacha20_encrypt_aead` / `aead.chacha20_decrypt_aead` or `symmetric.aes_encrypt` / `symmetric.aes_decrypt` |
+
+All deprecated helpers emit `DeprecationWarning` when used. Remove any remaining
+references before upgrading to v4.0.0.

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -4,8 +4,8 @@ Security Considerations
 .. warning::
    The following notes highlight important aspects for using ``cryptography-suite`` safely.
 
-- Insecure primitives like ``salsa20_encrypt`` and ``chacha20_stream_encrypt`` provide
-  no authentication and are for educational purposes only.
+- ``chacha20_stream_encrypt`` provides no authentication and is for educational
+  purposes only. The deprecated ``salsa20_encrypt`` will be removed in v4.0.0.
 - Enabling ``VERBOSE_MODE`` prints derived keys and nonces to stdout. Do **not** enable
   this in production environments.
 - When serializing private keys with :func:`cryptography_suite.serialize_private_key`

--- a/tests/test_stream_ciphers.py
+++ b/tests/test_stream_ciphers.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from cryptography_suite.symmetric import (
+from cryptography_suite.symmetric.stream import (
     salsa20_encrypt,
     salsa20_decrypt,
     chacha20_stream_encrypt,

--- a/tools/check_deprecated_exports.py
+++ b/tools/check_deprecated_exports.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Fail if deprecated functions are exported via __all__ or imported in public modules."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1] / "cryptography_suite"
+
+
+def module_of(path: Path, root: Path) -> str:
+    return path.relative_to(root).with_suffix("").as_posix().replace("/", ".")
+
+
+def find_deprecated(root: Path) -> set[tuple[str, str]]:
+    names: set[tuple[str, str]] = set()
+    for path in root.rglob("*.py"):
+        tree = ast.parse(path.read_text())
+        mod = module_of(path, root)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef):
+                for deco in node.decorator_list:
+                    func = getattr(deco, "func", deco)
+                    if isinstance(func, ast.Name) and func.id == "deprecated":
+                        names.add((mod, node.name))
+    return names
+
+
+def resolve_import_module(current_mod: str, node: ast.ImportFrom) -> str:
+    module = node.module or ""
+    if node.level:
+        parts = current_mod.split(".")
+        module_parts = parts[:-node.level]
+        if module:
+            module_parts.append(module)
+        module = ".".join(module_parts)
+    return module
+
+
+def check_exports(root: Path, deprecated: set[tuple[str, str]]) -> list[str]:
+    dep_names = {name for _, name in deprecated}
+    errors: list[str] = []
+    for path in root.rglob("*.py"):
+        tree = ast.parse(path.read_text())
+        current_mod = module_of(path, root)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "__all__":
+                        try:
+                            names = ast.literal_eval(node.value)
+                            for name in names:
+                                if name in dep_names:
+                                    errors.append(f"{path}: deprecated {name} found in __all__")
+                        except Exception:
+                            pass
+            elif isinstance(node, ast.ImportFrom):
+                mod = resolve_import_module(current_mod, node)
+                for alias in node.names:
+                    if (mod, alias.name) in deprecated:
+                        errors.append(
+                            f"{path}: deprecated {alias.name} imported from {mod}"
+                        )
+    return errors
+
+
+def main() -> int:
+    deprecated = find_deprecated(ROOT)
+    errors = check_exports(ROOT, deprecated)
+    if errors:
+        for err in errors:
+            print(err, file=sys.stderr)
+        return 1
+    print("No deprecated exports found.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- warn for legacy helpers and stream ciphers scheduled for v4 removal
- document deprecations and add migration guide
- add CI check to keep deprecated symbols out of public API

## Testing
- `python tools/check_deprecated_exports.py`
- `pytest`
