### PR TITLE
Document experimental Signal and SPHINCS+ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@
 
 ---
 
-## 🚀 Why Choose Cryptography Suite?
+## 🔑 Key Features
 
-- **Comprehensive Functionality**: Access a wide array of cryptographic algorithms and protocols, including symmetric and asymmetric encryption, digital signatures, key management, secret sharing, password-authenticated key exchange (PAKE), and one-time passwords (OTP).
-- **High Security Standards**: Implements industry-leading algorithms with best practices, ensuring your data is safeguarded with the highest level of security.
-- **Developer-Friendly API**: Offers intuitive and well-documented APIs that simplify integration and accelerate development.
+- **Comprehensive Functionality**: Symmetric and asymmetric encryption, digital signatures, key management, secret sharing, password-authenticated key exchange (PAKE), and one-time passwords (OTP).
+- **Post-Quantum Primitives**: Kyber KEM, Dilithium signatures, and **experimental SPHINCS+** support (enable via `pip install "cryptography-suite[pqc]"` – demo-only, not production-grade).
+- **Signal Protocol Demo**: Minimal X3DH + Double Ratchet implementation for demonstration purposes (**experimental, not production-ready**).
+- **Developer-Friendly API**: Intuitive, well-documented interfaces that simplify integration and accelerate development.
 - **Cross-Platform Compatibility**: Fully compatible with macOS, Linux, and Windows environments.
-- **Rigorous Testing**: Achieves **99% code coverage** with a comprehensive test suite, guaranteeing reliability and robustness.
+- **Rigorous Testing**: ~**99%** test coverage as of v3.0.0, ensuring reliability and robustness.
 
 ---
 
@@ -112,6 +113,8 @@ For optional functionality install extras:
 ```bash
 pip install "cryptography-suite[pqc,fhe,zk]"
 ```
+
+The **SPHINCS+** signature helpers are included in the `pqc` extra and are experimental/demo-only.
 
 > **Note**: Requires Python 3.10 or higher. Homomorphic encryption features need `Pyfhel` installed separately if the `fhe` extra is not used.
 
@@ -512,6 +515,8 @@ print(ec_decrypt(cipher, priv))
 ```
 
 ### Signal Protocol Messaging
+
+> **Note**: The Signal Protocol helpers are experimental and intended for demonstrations only.
 
 ```python
 from cryptography_suite.protocols import initialize_signal_session

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,8 @@ formally verified, misuse-resistant workflows.
 - HSM, YubiKey, PKCS#11, Cloud KMS Plugin Architecture
 - Fuzzing Harness & Property-Based Testing
 - Supply-Chain Attestation, SLSA, and Reproducible Builds
+- Signal Protocol components (X3DH + Double Ratchet) for demo use (*experimental, not production-ready*)
+- Post-Quantum primitives: Kyber KEM, Dilithium signatures, and *experimental* SPHINCS+ (requires `pip install "cryptography-suite[pqc]"`)
 
 
 .. toctree::

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -1,7 +1,8 @@
 # Protocol Notes
 
 The suite provides a light-weight X3DH implementation used for Signal-like
-sessions. During session setup the receiver verifies that the sender's
+sessions. **This Signal Protocol support is experimental and intended for
+demonstrations only; it is not production-ready.** During session setup the receiver verifies that the sender's
 ``signed_prekey`` is signed with the sender's identity key using the helper
 ``verify_signed_prekey``. A failed verification raises
 ``SignatureVerificationError``.

--- a/tools/sync_check.py
+++ b/tools/sync_check.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Synchronisation checker for README vs codebase."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import cryptography_suite
+
+
+def get_exports() -> list[str]:
+    return list(getattr(cryptography_suite, "__all__", []))
+
+
+def get_cli_subcommands() -> list[str]:
+    cli_src = Path("cryptography_suite/cli.py").read_text()
+    # Rough pattern for sub.add_parser("name")
+    pattern = re.compile(r"sub\.add_parser\(\n?\s*\"([^\"]+)\"")
+    return sorted(set(pattern.findall(cli_src)))
+
+
+def get_documented_features() -> list[str]:
+    lines = Path("README.md").read_text().splitlines()
+    features: list[str] = []
+    start = None
+    for i, line in enumerate(lines):
+        if line.lower().startswith("## ") and "key features" in line.lower():
+            start = i + 1
+            break
+    if start is None:
+        return features
+    for line in lines[start:]:
+        if line.startswith("## "):
+            break
+        if line.strip().startswith("- "):
+            features.append(line.strip()[2:])
+    return features
+
+
+def check_mismatches(exports: list[str], subcommands: list[str], features: list[str]) -> list[str]:
+    lower_exports = [e.lower() for e in exports]
+    lower_cmds = [c.lower() for c in subcommands]
+    mismatches: list[str] = []
+    for feat in features:
+        feat_l = feat.lower()
+        if not any(name in feat_l for name in lower_exports + lower_cmds):
+            mismatches.append(feat)
+    return mismatches
+
+
+def main() -> None:
+    exports = get_exports()
+    subcommands = get_cli_subcommands()
+    features = get_documented_features()
+    mismatches = check_mismatches(exports, subcommands, features)
+
+    print("Exports (__all__):")
+    for e in exports:
+        print(f" - {e}")
+    print("\nCLI subcommands:")
+    for c in subcommands:
+        print(f" - {c}")
+    print("\nDocumented features:")
+    for f in features:
+        print(f" - {f}")
+    if mismatches:
+        print("\nFeatures without matching export or subcommand:")
+        for m in mismatches:
+            print(f" - {m}")
+    else:
+        print("\nAll documented features map to exports or subcommands.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- clarify README feature list and note experimental Signal Protocol and SPHINCS+
- document SPHINCS+ and Signal demo status in docs
- add sync checker listing exports, CLI commands, and docs features

## Testing
- `pytest -q`
- `python tools/sync_check.py`
