### PR TITLE
docs: document pipeline dsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,22 @@ Example pipeline configuration:
 
 ```python
 from cryptography_suite import use_backend
-from cryptography_suite.pipeline import Pipeline, AESGCMEncrypt, AESGCMDecrypt
+from cryptography_suite.pipeline import (
+    Pipeline,
+    AESGCMEncrypt,
+    AESGCMDecrypt,
+    list_modules,
+)
 
 use_backend("pyca")
 
 p = Pipeline() >> AESGCMEncrypt(password="pass") >> AESGCMDecrypt(password="pass")
-assert p.run(b"data") == b"data"
+assert p.run("data") == "data"
+print(list_modules())  # ['AESGCMDecrypt', 'AESGCMEncrypt']
 ```
+
+*Contributors*: new pipeline modules can be exposed with the
+`@register_module` decorator in ``cryptography_suite.pipeline``.
 
 Visualize and export the pipeline:
 

--- a/cryptography_suite/pipeline.py
+++ b/cryptography_suite/pipeline.py
@@ -8,7 +8,7 @@ pipeline steps.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Generic, Iterable, Protocol, TypeVar
+from typing import Any, Callable, Generic, Iterable, Protocol, TypeVar, cast
 import json
 import logging
 
@@ -203,7 +203,8 @@ class AESGCMEncrypt(CryptoModule[str, str]):
     def run(self, data: str) -> str:
         from .symmetric import aes_encrypt
 
-        return aes_encrypt(data, self.password, kdf=self.kdf)
+        # aes_encrypt returns ``str`` when ``raw_output`` is ``False`` (default)
+        return cast(str, aes_encrypt(data, self.password, kdf=self.kdf))
 
     def to_proverif(self) -> str:  # pragma: no cover - simple serialization
         return f"aesgcm_encrypt({self.kdf})"

--- a/docs/api/pipeline.rst
+++ b/docs/api/pipeline.rst
@@ -1,0 +1,7 @@
+Pipeline DSL
+============
+
+.. automodule:: cryptography_suite.pipeline
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,4 +49,5 @@ formally verified, misuse-resistant workflows.
    visualization.md
    security.rst
    api/modules
+   api/pipeline
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -4,15 +4,44 @@ The `Pipeline` class allows sequential composition of cryptographic modules. Eac
 module implements a simple `run` method. Pipelines can be built using the `>>`
 operator and inspected as JSON.
 
-Example:
+## Pipeline DSL
+
+The package ships with a small DSL for common cryptographic operations such as
+AES-GCM encryption. Modules are importable from
+`cryptography_suite.pipeline` and can be composed declaratively:
 
 ```python
-from cryptography_suite.pipeline import Pipeline
+from cryptography_suite.pipeline import (
+    Pipeline,
+    AESGCMEncrypt,
+    AESGCMDecrypt,
+    list_modules,
+)
 
-class UpperCase:
-    def run(self, data: bytes) -> bytes:
-        return data.upper()
-
-p = Pipeline() >> UpperCase()
-print(p.run(b"abc"))  # b'ABC'
+p = Pipeline() >> AESGCMEncrypt(password="pw") >> AESGCMDecrypt(password="pw")
+print(p.run("hi"))        # 'hi'
+print(list_modules())      # ['AESGCMDecrypt', 'AESGCMEncrypt']
 ```
+
+## Extending the Pipeline DSL
+
+Backends or applications can expose custom modules using the
+`@register_module` decorator. Registered classes automatically appear in
+`list_modules` and are importable from the pipeline namespace:
+
+```python
+from dataclasses import dataclass
+from cryptography_suite.pipeline import CryptoModule, register_module
+
+@register_module
+@dataclass
+class ROT13(CryptoModule[str, str]):
+    def run(self, data: str) -> str:
+        import codecs
+        return codecs.encode(data, "rot13")
+
+Pipeline() >> ROT13()
+```
+
+Use :func:`cryptography_suite.crypto_backends.use_backend` to switch the
+backend providing primitive implementations.


### PR DESCRIPTION
## Summary
- add registry and AES-GCM pipeline DSL modules
- document and expose pipeline DSL with usage and extension examples
- include pipeline DSL in API docs and README

## Testing
- `PYTHONPATH=. pytest tests/test_pipeline.py tests/test_pipeline_export.py tests/test_readme_snippet.py -q`
- `sphinx-build -b dummy docs docs/_build`
