### PR TITLE
feat: deprecate one-shot helpers in favor of pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ cryptosuite-fuzz --runs 1000
 - **Hybrid Encryption**: Combine RSA/ECIES with AES-GCM for performance and security.
 - **Post-Quantum Cryptography**: Kyber key encapsulation and Dilithium signatures for quantum-safe workflows.
 - **XChaCha20-Poly1305**: Modern stream cipher support when ``cryptography`` exposes ``XChaCha20Poly1305``.
-- **Salsa20 and Ascon**: Deprecated and provided for reference only. **Not recommended for production**, removed from public imports, and scheduled for removal in v4.0.0. Use ``chacha20_stream_encrypt`` or authenticated ciphers like ``aes_encrypt`` instead.
+- **Salsa20 and Ascon**: Deprecated and provided for reference only. **Not recommended for production**, removed from public imports, and scheduled for removal in v4.0.0. Use ``chacha20_stream_encrypt`` or authenticated ciphers like ``AESGCMEncrypt`` instead.
 - **Audit Logging**: Decorators and helpers for encrypted audit trails.
 - **KeyVault Management**: Context manager to safely handle in-memory keys.
 - **Password-Authenticated Key Exchange (PAKE)**: SPAKE2 protocol implementation for secure password-based key exchange.

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -29,8 +29,6 @@ from .asymmetric import (
     generate_x25519_keypair,
     load_private_key,
     load_public_key,
-    rsa_decrypt,
-    rsa_encrypt,
     serialize_private_key,
     serialize_public_key,
 )
@@ -68,8 +66,6 @@ from .hybrid import HybridEncryptor, hybrid_decrypt, hybrid_encrypt
 
 # Symmetric primitives -------------------------------------------------------
 from .symmetric import (
-    aes_decrypt,
-    aes_encrypt,
     argon2_decrypt,
     argon2_encrypt,
     chacha20_decrypt,
@@ -202,8 +198,6 @@ except Exception:  # pragma: no cover - handle missing dependency
 
 __all__ = [
     # Encryption
-    "aes_encrypt",
-    "aes_decrypt",
     "chacha20_encrypt",
     "chacha20_decrypt",
     "chacha20_encrypt_aead",
@@ -233,8 +227,6 @@ __all__ = [
     # Asymmetric
     "generate_rsa_keypair",
     "generate_rsa_keypair_async",
-    "rsa_encrypt",
-    "rsa_decrypt",
     "serialize_private_key",
     "serialize_public_key",
     "load_private_key",

--- a/cryptography_suite/asymmetric/__init__.py
+++ b/cryptography_suite/asymmetric/__init__.py
@@ -1,6 +1,7 @@
 from typing import Tuple, Callable, Optional
 from concurrent.futures import Future, ThreadPoolExecutor
 from ..errors import EncryptionError, DecryptionError
+from ..utils import deprecated
 import base64
 
 from cryptography.hazmat.primitives import serialization, hashes, constant_time
@@ -68,6 +69,7 @@ def generate_rsa_keypair_async(
     return fut
 
 
+@deprecated("rsa_encrypt is deprecated; use the RSAEncrypt pipeline module")
 def rsa_encrypt(
     plaintext: bytes,
     public_key: rsa.RSAPublicKey,
@@ -75,6 +77,9 @@ def rsa_encrypt(
     raw_output: bool = False,
 ) -> str | bytes:
     """Encrypt ``plaintext`` for ``public_key`` using RSA-OAEP with SHA-256.
+
+    This one-shot helper will be removed in a future release. Prefer
+    ``RSAEncrypt`` from :mod:`cryptography_suite.pipeline`.
 
     By default the ciphertext is returned as a Base64-encoded string for ease of
     storage and transmission. Set ``raw_output=True`` to receive the raw byte
@@ -98,9 +103,12 @@ def rsa_encrypt(
     return base64.b64encode(ciphertext).decode()
 
 
+@deprecated("rsa_decrypt is deprecated; use the RSADecrypt pipeline module")
 def rsa_decrypt(ciphertext: bytes | str, private_key: rsa.RSAPrivateKey) -> bytes:
-    """
-    Decrypts ciphertext using RSA-OAEP with SHA-256.
+    """Decrypt ``ciphertext`` using RSA-OAEP with SHA-256.
+
+    This one-shot helper will be removed in a future release. Prefer
+    ``RSADecrypt`` from :mod:`cryptography_suite.pipeline`.
     """
     if not isinstance(private_key, rsa.RSAPrivateKey):
         raise TypeError("Invalid RSA private key provided.")

--- a/cryptography_suite/hybrid.py
+++ b/cryptography_suite/hybrid.py
@@ -70,7 +70,13 @@ def hybrid_encrypt(
     aes_key = urandom(32)
 
     if isinstance(public_key, rsa.RSAPublicKey):
-        encrypted_key = cast(bytes, rsa_encrypt(aes_key, public_key, raw_output=True))
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            encrypted_key = cast(
+                bytes, rsa_encrypt(aes_key, public_key, raw_output=True)
+            )
     elif isinstance(public_key, x25519.X25519PublicKey):
         encrypted_key = cast(bytes, ec_encrypt(aes_key, public_key, raw_output=True))
     else:
@@ -135,7 +141,11 @@ def hybrid_decrypt(
         raise DecryptionError("Invalid encrypted payload.")
 
     if isinstance(private_key, rsa.RSAPrivateKey):
-        aes_key = rsa_decrypt(enc_key, private_key)
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            aes_key = rsa_decrypt(enc_key, private_key)
     elif isinstance(private_key, x25519.X25519PrivateKey):
         aes_key = ec_decrypt(enc_key, private_key)
     else:

--- a/cryptography_suite/pipeline.py
+++ b/cryptography_suite/pipeline.py
@@ -201,13 +201,15 @@ class AESGCMEncrypt(CryptoModule[str, str]):
     kdf: str = "argon2"
 
     def run(self, data: str) -> str:
-        from .symmetric import aes_encrypt
+        from .symmetric import aes as _aes_mod
         import warnings
 
         # aes_encrypt returns ``str`` when ``raw_output`` is ``False`` (default)
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
-            return cast(str, aes_encrypt(data, self.password, kdf=self.kdf))
+            return cast(
+                str, _aes_mod.aes_encrypt(data, self.password, kdf=self.kdf)
+            )
 
     def to_proverif(self) -> str:  # pragma: no cover - simple serialization
         return f"aesgcm_encrypt({self.kdf})"
@@ -244,12 +246,12 @@ class AESGCMDecrypt(CryptoModule[str, str]):
     kdf: str = "argon2"
 
     def run(self, data: str) -> str:
-        from .symmetric import aes_decrypt
+        from .symmetric import aes as _aes_mod
         import warnings
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
-            return aes_decrypt(data, self.password, kdf=self.kdf)
+            return _aes_mod.aes_decrypt(data, self.password, kdf=self.kdf)
 
     def to_proverif(self) -> str:  # pragma: no cover - simple serialization
         return f"aesgcm_decrypt({self.kdf})"

--- a/cryptography_suite/pipeline.py
+++ b/cryptography_suite/pipeline.py
@@ -202,9 +202,12 @@ class AESGCMEncrypt(CryptoModule[str, str]):
 
     def run(self, data: str) -> str:
         from .symmetric import aes_encrypt
+        import warnings
 
         # aes_encrypt returns ``str`` when ``raw_output`` is ``False`` (default)
-        return cast(str, aes_encrypt(data, self.password, kdf=self.kdf))
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            return cast(str, aes_encrypt(data, self.password, kdf=self.kdf))
 
     def to_proverif(self) -> str:  # pragma: no cover - simple serialization
         return f"aesgcm_encrypt({self.kdf})"
@@ -242,14 +245,78 @@ class AESGCMDecrypt(CryptoModule[str, str]):
 
     def run(self, data: str) -> str:
         from .symmetric import aes_decrypt
+        import warnings
 
-        return aes_decrypt(data, self.password, kdf=self.kdf)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            return aes_decrypt(data, self.password, kdf=self.kdf)
 
     def to_proverif(self) -> str:  # pragma: no cover - simple serialization
         return f"aesgcm_decrypt({self.kdf})"
 
     def to_tamarin(self) -> str:  # pragma: no cover - simple serialization
         return f"aesgcm_decrypt({self.kdf})"
+
+
+@register_module
+@dataclass
+class RSAEncrypt(CryptoModule[bytes, str | bytes]):
+    """Encrypt data using RSA-OAEP.
+
+    Parameters
+    ----------
+    public_key:
+        The :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey`
+        used for encryption.
+    raw_output:
+        When ``True`` return raw bytes instead of Base64 encoded text.
+    """
+
+    public_key: Any
+    raw_output: bool = False
+
+    def run(self, data: bytes) -> str | bytes:
+        from .asymmetric import rsa_encrypt
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            return rsa_encrypt(data, self.public_key, raw_output=self.raw_output)
+
+    def to_proverif(self) -> str:  # pragma: no cover - simple serialization
+        return "rsa_encrypt"
+
+    def to_tamarin(self) -> str:  # pragma: no cover - simple serialization
+        return "rsa_encrypt"
+
+
+@register_module
+@dataclass
+class RSADecrypt(CryptoModule[str | bytes, bytes]):
+    """Decrypt RSA-OAEP ciphertext.
+
+    Parameters
+    ----------
+    private_key:
+        The :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey`
+        used for decryption.
+    """
+
+    private_key: Any
+
+    def run(self, data: str | bytes) -> bytes:
+        from .asymmetric import rsa_decrypt
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            return rsa_decrypt(data, self.private_key)
+
+    def to_proverif(self) -> str:  # pragma: no cover - simple serialization
+        return "rsa_decrypt"
+
+    def to_tamarin(self) -> str:  # pragma: no cover - simple serialization
+        return "rsa_decrypt"
 
 
 __all__ = [
@@ -260,4 +327,6 @@ __all__ = [
     "list_modules",
     "AESGCMEncrypt",
     "AESGCMDecrypt",
+    "RSAEncrypt",
+    "RSADecrypt",
 ]

--- a/cryptography_suite/symmetric/__init__.py
+++ b/cryptography_suite/symmetric/__init__.py
@@ -1,8 +1,6 @@
 """Symmetric cryptography primitives."""
 
 from .aes import (
-    aes_encrypt,
-    aes_decrypt,
     encrypt_file,
     decrypt_file,
     encrypt_file_async,
@@ -36,8 +34,6 @@ from .kdf import (
 )
 
 __all__ = [
-    "aes_encrypt",
-    "aes_decrypt",
     "encrypt_file",
     "decrypt_file",
     "encrypt_file_async",

--- a/cryptography_suite/symmetric/aes.py
+++ b/cryptography_suite/symmetric/aes.py
@@ -344,8 +344,6 @@ def argon2_decrypt(encrypted_data: str, password: str) -> str:
 
 
 __all__ = [
-    "aes_encrypt",
-    "aes_decrypt",
     "encrypt_file",
     "decrypt_file",
     "encrypt_file_async",

--- a/cryptography_suite/symmetric/aes.py
+++ b/cryptography_suite/symmetric/aes.py
@@ -12,6 +12,7 @@ from ..errors import (
     MissingDependencyError,
     KeyDerivationError,
 )
+from ..utils import deprecated
 from ..debug import verbose_print
 
 from ..constants import NONCE_SIZE, SALT_SIZE
@@ -22,6 +23,7 @@ CHUNK_SIZE = 4096
 TAG_SIZE = 16  # AES-GCM authentication tag size
 
 
+@deprecated("aes_encrypt is deprecated; use the AESGCMEncrypt pipeline module")
 def aes_encrypt(
     plaintext: str,
     password: str,
@@ -29,7 +31,10 @@ def aes_encrypt(
     *,
     raw_output: bool = False,
 ) -> str | bytes:
-    """Encrypt plaintext using AES-GCM with a password-derived key.
+    """Encrypt ``plaintext`` using AES-GCM with a password-derived key.
+
+    This one-shot helper will be removed in a future release. Prefer
+    ``AESGCMEncrypt`` from :mod:`cryptography_suite.pipeline`.
 
     Argon2id is used by default. Pass ``kdf='scrypt'`` or ``kdf='pbkdf2'`` for
     compatibility with older data.
@@ -58,12 +63,16 @@ def aes_encrypt(
     return base64.b64encode(data).decode()
 
 
+@deprecated("aes_decrypt is deprecated; use the AESGCMDecrypt pipeline module")
 def aes_decrypt(
     encrypted_data: bytes | str,
     password: str,
     kdf: str = "argon2",
 ) -> str:
     """Decrypt AES-GCM encrypted data using a password-derived key.
+
+    This one-shot helper will be removed in a future release. Prefer
+    ``AESGCMDecrypt`` from :mod:`cryptography_suite.pipeline`.
 
     Argon2id is used by default. Pass ``kdf='scrypt'`` or ``kdf='pbkdf2'`` for
     compatibility with data encrypted using those KDFs.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ formally verified, misuse-resistant workflows.
    architecture.md
    protocols.md
    pipeline.md
+   pipeline_coverage.md
    cli.md
    formal.md
    fuzzing.md
@@ -45,6 +46,7 @@ formally verified, misuse-resistant workflows.
    release_process.md
    migration_3.0.md
    migration_4.0.md
+   migration_pipeline_api.md
    threat_model.md
    visualization.md
    security.rst

--- a/docs/migration_pipeline_api.md
+++ b/docs/migration_pipeline_api.md
@@ -1,0 +1,27 @@
+# Migration to Pipeline API
+
+Legacy one-shot helpers such as `aes_encrypt` and `rsa_encrypt` are deprecated in
+favor of the composable Pipeline DSL.
+
+## Replacing AES helpers
+
+```python
+from cryptography_suite.pipeline import AESGCMEncrypt, AESGCMDecrypt
+
+ciphertext = AESGCMEncrypt(password="pw").run("secret")
+plaintext = AESGCMDecrypt(password="pw").run(ciphertext)
+```
+
+## Replacing RSA helpers
+
+```python
+from cryptography_suite.asymmetric import generate_rsa_keypair
+from cryptography_suite.pipeline import RSAEncrypt, RSADecrypt
+
+priv, pub = generate_rsa_keypair()
+ct = RSAEncrypt(public_key=pub).run(b"data")
+pt = RSADecrypt(private_key=priv).run(ct)
+```
+
+After one major version, these legacy helpers will be removed. Always prefer
+adding new functionality as Pipeline modules.

--- a/docs/pipeline_coverage.md
+++ b/docs/pipeline_coverage.md
@@ -1,0 +1,10 @@
+# Pipeline API Coverage
+
+| Legacy Helper | Pipeline Module |
+| ------------- | --------------- |
+| `aes_encrypt` | `AESGCMEncrypt` |
+| `aes_decrypt` | `AESGCMDecrypt` |
+| `rsa_encrypt` | `RSAEncrypt`    |
+| `rsa_decrypt` | `RSADecrypt`    |
+
+Additional helpers will be migrated to Pipeline modules in future releases.

--- a/example_usage.py
+++ b/example_usage.py
@@ -12,16 +12,12 @@ from time import sleep
 
 from cryptography_suite import (
     # Symmetric Encryption
-    aes_encrypt,
-    aes_decrypt,
     chacha20_encrypt,
     chacha20_decrypt,
     encrypt_file,
     decrypt_file,
     # Asymmetric Encryption
     generate_rsa_keypair,
-    rsa_encrypt,
-    rsa_decrypt,
     serialize_private_key,
     serialize_public_key,
     load_private_key,
@@ -61,6 +57,12 @@ from cryptography_suite import (
     base62_decode,
     generate_secure_random_string,
 )
+from cryptography_suite.pipeline import (
+    AESGCMEncrypt,
+    AESGCMDecrypt,
+    RSAEncrypt,
+    RSADecrypt,
+)
 
 
 def main():
@@ -70,8 +72,12 @@ def main():
     symmetric_password = "strong_password"
 
     # AES Encryption with Scrypt KDF
-    encrypted_aes = aes_encrypt(plaintext, symmetric_password, kdf="scrypt")
-    decrypted_aes = aes_decrypt(encrypted_aes, symmetric_password, kdf="scrypt")
+    encrypted_aes = AESGCMEncrypt(password=symmetric_password, kdf="scrypt").run(
+        plaintext
+    )
+    decrypted_aes = AESGCMDecrypt(password=symmetric_password, kdf="scrypt").run(
+        encrypted_aes
+    )
     print(f"AES Encrypted: {encrypted_aes}")
     print(f"AES Decrypted: {decrypted_aes}")
 
@@ -103,8 +109,8 @@ def main():
     rsa_private_key, rsa_public_key = generate_rsa_keypair()
     message = b"Hello, Asymmetric Encryption!"
 
-    rsa_ciphertext = rsa_encrypt(message, rsa_public_key)
-    rsa_plaintext = rsa_decrypt(rsa_ciphertext, rsa_private_key)
+    rsa_ciphertext = RSAEncrypt(public_key=rsa_public_key).run(message)
+    rsa_plaintext = RSADecrypt(private_key=rsa_private_key).run(rsa_ciphertext)
     print(f"RSA Decrypted Message: {rsa_plaintext.decode()}")
 
     # Key Serialization and Loading

--- a/tests/test_aes_property.py
+++ b/tests/test_aes_property.py
@@ -1,6 +1,14 @@
 import unittest
 from hypothesis import given, strategies as st
-from cryptography_suite.symmetric import aes_encrypt, aes_decrypt
+from cryptography_suite.pipeline import AESGCMEncrypt, AESGCMDecrypt
+
+
+def aes_encrypt(message, password, kdf="scrypt"):
+    return AESGCMEncrypt(password=password, kdf=kdf).run(message)
+
+
+def aes_decrypt(ciphertext, password, kdf="scrypt"):
+    return AESGCMDecrypt(password=password, kdf=kdf).run(ciphertext)
 
 class TestAesProperty(unittest.TestCase):
     @given(message=st.text(min_size=1), password=st.text(min_size=1))

--- a/tests/test_asymmetric.py
+++ b/tests/test_asymmetric.py
@@ -3,8 +3,6 @@ import base64
 from cryptography_suite.asymmetric import (
     generate_rsa_keypair,
     generate_rsa_keypair_async,
-    rsa_encrypt,
-    rsa_decrypt,
     serialize_private_key,
     serialize_public_key,
     load_private_key,
@@ -17,6 +15,15 @@ from cryptography_suite.asymmetric import (
     ec_encrypt,
     ec_decrypt,
 )
+from cryptography_suite.pipeline import RSAEncrypt, RSADecrypt
+
+
+def rsa_encrypt(data, public_key, *, raw_output=False):
+    return RSAEncrypt(public_key=public_key, raw_output=raw_output).run(data)
+
+
+def rsa_decrypt(data, private_key):
+    return RSADecrypt(private_key=private_key).run(data)
 from cryptography.hazmat.primitives.asymmetric import rsa, x25519, x448, ec
 from cryptography_suite.errors import CryptographySuiteError
 

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -3,9 +3,8 @@ import os
 import unittest
 from unittest.mock import patch
 
+from cryptography_suite.pipeline import AESGCMEncrypt, AESGCMDecrypt
 from cryptography_suite.symmetric import (
-    aes_encrypt,
-    aes_decrypt,
     chacha20_encrypt,
     chacha20_decrypt,
     derive_key_argon2,
@@ -18,6 +17,14 @@ from cryptography_suite.errors import (
     DecryptionError,
     KeyDerivationError,
 )
+
+
+def aes_encrypt(plaintext, password, kdf="argon2", *, raw_output=False):
+    return AESGCMEncrypt(password=password, kdf=kdf).run(plaintext)
+
+
+def aes_decrypt(encrypted_data, password, kdf="argon2"):
+    return AESGCMDecrypt(password=password, kdf=kdf).run(encrypted_data)
 
 
 class TestEncryption(unittest.TestCase):

--- a/tests/test_no_new_oneshot.py
+++ b/tests/test_no_new_oneshot.py
@@ -3,8 +3,6 @@ import cryptography_suite as cs
 # Baseline of allowed legacy helpers. New crypto features should be exposed
 # via the Pipeline DSL instead of introducing additional one-shot functions.
 EXPECTED_ONE_SHOTS = {
-    "aes_decrypt",
-    "aes_encrypt",
     "argon2_decrypt",
     "argon2_encrypt",
     "chacha20_decrypt",
@@ -19,8 +17,6 @@ EXPECTED_ONE_SHOTS = {
     "kyber_encrypt",
     "pbkdf2_decrypt",
     "pbkdf2_encrypt",
-    "rsa_decrypt",
-    "rsa_encrypt",
     "scrypt_decrypt",
     "scrypt_encrypt",
     "xchacha_decrypt",

--- a/tests/test_no_new_oneshot.py
+++ b/tests/test_no_new_oneshot.py
@@ -1,0 +1,32 @@
+import cryptography_suite as cs
+
+# Baseline of allowed legacy helpers. New crypto features should be exposed
+# via the Pipeline DSL instead of introducing additional one-shot functions.
+EXPECTED_ONE_SHOTS = {
+    "aes_decrypt",
+    "aes_encrypt",
+    "argon2_decrypt",
+    "argon2_encrypt",
+    "chacha20_decrypt",
+    "chacha20_encrypt",
+    "chacha20_stream_decrypt",
+    "chacha20_stream_encrypt",
+    "ec_decrypt",
+    "ec_encrypt",
+    "hybrid_decrypt",
+    "hybrid_encrypt",
+    "kyber_decrypt",
+    "kyber_encrypt",
+    "pbkdf2_decrypt",
+    "pbkdf2_encrypt",
+    "rsa_decrypt",
+    "rsa_encrypt",
+    "scrypt_decrypt",
+    "scrypt_encrypt",
+    "xchacha_decrypt",
+    "xchacha_encrypt",
+}
+
+def test_no_new_oneshot_helpers():
+    current = {n for n in cs.__all__ if n.endswith("_encrypt") or n.endswith("_decrypt")}
+    assert current <= EXPECTED_ONE_SHOTS

--- a/tests/test_readme_snippet.py
+++ b/tests/test_readme_snippet.py
@@ -2,12 +2,11 @@
 
 Example from the documentation::
 
-    >>> from cryptography_suite.asymmetric import (
-    ...     generate_rsa_keypair, rsa_encrypt, rsa_decrypt
-    ... )
+    >>> from cryptography_suite.asymmetric import generate_rsa_keypair
+    >>> from cryptography_suite.pipeline import RSAEncrypt, RSADecrypt
     >>> priv, pub = generate_rsa_keypair()
-    >>> ct = rsa_encrypt(b"data", pub)
-    >>> rsa_decrypt(ct, priv)
+    >>> ct = RSAEncrypt(public_key=pub).run(b"data")
+    >>> RSADecrypt(private_key=priv).run(ct)
     b'data'
 """
 

--- a/tests/test_root_exports.py
+++ b/tests/test_root_exports.py
@@ -4,8 +4,10 @@ import cryptography_suite as cs
 
 
 def test_root_exports_available():
-    assert callable(cs.aes_encrypt)
-    assert callable(cs.rsa_encrypt)
+    from cryptography_suite.pipeline import AESGCMEncrypt, RSAEncrypt
+
+    assert callable(AESGCMEncrypt)
+    assert callable(RSAEncrypt)
     assert callable(cs.KeyVault)
     assert callable(cs.to_pem)
     assert callable(cs.from_pem)

--- a/tests/test_verbose.py
+++ b/tests/test_verbose.py
@@ -8,16 +8,17 @@ import cryptography_suite.debug as debug
 def reload_modules():
     importlib.reload(debug)
     importlib.reload(importlib.import_module('cryptography_suite.symmetric.aes'))
+    importlib.reload(importlib.import_module('cryptography_suite.pipeline'))
 
 
 def test_verbose_mode_env_variable(tmp_path):
     _ = tmp_path  # unused fixture to satisfy vulture
     os.environ['VERBOSE_MODE'] = '1'
     reload_modules()
-    from cryptography_suite.symmetric import aes_encrypt
+    from cryptography_suite.pipeline import AESGCMEncrypt
 
     with patch('builtins.print') as mock_print:
-        aes_encrypt('msg', 'pass')
+        AESGCMEncrypt(password='pass').run('msg')
 
     assert any('Derived key' in call.args[0] for call in mock_print.call_args_list)
     os.environ.pop('VERBOSE_MODE')


### PR DESCRIPTION
## Summary
- deprecate aes_encrypt/rsa_encrypt one-shot helpers and add pipeline modules
- document migration to Pipeline API and map legacy helpers to modules
- add test guarding against new one-shot encryption helpers

## Testing
- `pytest -q`
