### PR TITLE
feat: add context-aware backend selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,18 @@ from cryptography_suite.pipeline import (
     list_modules,
 )
 
-use_backend("pyca")
-
-p = Pipeline() >> AESGCMEncrypt(password="pass") >> AESGCMDecrypt(password="pass")
-assert p.run("data") == "data"
-print(list_modules())  # ['AESGCMDecrypt', 'AESGCMEncrypt']
+with use_backend("pyca"):
+    p = (
+        Pipeline()
+        >> AESGCMEncrypt(password="pass")
+        >> AESGCMDecrypt(password="pass")
+    )
+    assert p.run("data") == "data"
+    print(list_modules())  # ['AESGCMDecrypt', 'AESGCMEncrypt']
 ```
+
+Backend selection is context-local: each thread or async task maintains its
+own active backend when using :func:`use_backend` as a context manager.
 
 *Contributors*: new pipeline modules can be exposed with the
 `@register_module` decorator in ``cryptography_suite.pipeline``.
@@ -728,7 +734,8 @@ cryptography-suite/
 
 Version 3.0.0 introduces several breaking changes. To upgrade from 2.x:
 
-- **Backend Selection Required** via ``use_backend``.
+- **Backend Selection Required** via ``use_backend``; the library emits a
+  runtime warning if no backend is explicitly selected.
 - **Pipeline API** replaces chained helper calls.
 - **KeyManager Interfaces Updated** for persistent key handling.
 - **Deprecated Helpers Removed** in favor of pipeline stages.

--- a/cryptography_suite/crypto_backends/__init__.py
+++ b/cryptography_suite/crypto_backends/__init__.py
@@ -1,13 +1,24 @@
-"""Backend abstraction layer for cryptography-suite."""
+"""Backend abstraction layer for cryptography-suite.
+
+Backend selection is context-local and can be temporarily overridden using
+``use_backend`` as a context manager.
+"""
 
 from __future__ import annotations
 
 from typing import Callable, Dict, Type, Optional, Any
 import warnings
+import contextlib
+from contextvars import ContextVar
 
 
 _backend_registry: Dict[str, Type[Any]] = {}
-_current_backend: Optional[Any] = None
+_current_backend: ContextVar[Optional[Any]] = ContextVar(
+    "cryptography_suite_current_backend", default=None
+)
+_default_warning_emitted = ContextVar(
+    "cryptography_suite_backend_warned", default=False
+)
 
 
 def register_backend(name: str) -> Callable[[Type[Any]], Type[Any]]:
@@ -24,45 +35,92 @@ def available_backends() -> list[str]:
     return list(_backend_registry.keys())
 
 
-def use_backend(name: str) -> None:
-    """Select the backend to use at runtime.
+class _BackendContext(contextlib.AbstractContextManager[Any]):
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._prev: Optional[Any] = None
+        self._entered = False
 
-    Example
-    -------
+        # Set immediately for compatibility with previous behaviour
+        self.__enter__()
 
-    >>> from cryptography_suite.crypto_backends import use_backend
-    >>> use_backend("pyca")
-    >>> use_backend("sodium")  # doctest: +SKIP
-    >>> use_backend("rust")    # doctest: +SKIP
+    def __enter__(self) -> Any:  # pragma: no cover - simple state switch
+        if not self._entered:
+            self._prev = _current_backend.get()
+            try:
+                backend_cls = _backend_registry[self.name]
+            except KeyError as exc:
+                raise ValueError(f"Unknown backend: {self.name}") from exc
+            backend = backend_cls()
+            _current_backend.set(backend)
+            self._entered = True
+        return _current_backend.get()
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - simple
+        if self._entered:
+            _current_backend.set(self._prev)
+            self._entered = False
+
+
+def use_backend(name: str) -> _BackendContext:
+    """Select the backend to use.
+
+    Backend selection is stored in a :class:`contextvars.ContextVar`, making it
+    safe for threads and asynchronous tasks. The function returns a context
+    manager so it can be used in ``with`` blocks::
+
+        with use_backend("pyca"):
+            ...
+
+    Calling it without ``with`` permanently switches the backend for the
+    current thread or task.
     """
-    global _current_backend
-    try:
-        backend_cls = _backend_registry[name]
-    except KeyError as exc:  # pragma: no cover - defensive
-        raise ValueError(f"Unknown backend: {name}") from exc
-    _current_backend = backend_cls()
+
+    return _BackendContext(name)
 
 
-def select_backend(name: str) -> None:
-    """Deprecated alias for :func:`use_backend`."""
-    warnings.warn(
-        "select_backend is deprecated; use use_backend instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    use_backend(name)
+def select_backend(obj: Any) -> None:
+    """Register and select a backend.
+
+    Parameters
+    ----------
+    obj:
+        Either the name of a registered backend or a backend instance. When an
+        instance is provided it will be registered under ``obj.name`` if the
+        attribute exists, otherwise the lower-cased class name.
+    """
+
+    if isinstance(obj, str):
+        use_backend(obj)
+    else:
+        name = getattr(obj, "name", obj.__class__.__name__.lower())
+        _backend_registry[name] = obj.__class__
+        _current_backend.set(obj)
 
 
 def get_backend() -> Any:
-    """Return the currently selected backend instance."""
-    if _current_backend is None:
-        # default to first registered backend
+    """Return the currently selected backend instance.
+
+    Emits a :class:`RuntimeWarning` if no backend was explicitly selected.
+    """
+
+    backend = _current_backend.get()
+    if backend is None:
         if not _backend_registry:
             raise RuntimeError("No backends registered")
         name = next(iter(_backend_registry))
-        use_backend(name)
-    assert _current_backend is not None
-    return _current_backend
+        backend_cls = _backend_registry[name]
+        backend = backend_cls()
+        _current_backend.set(backend)
+        if not _default_warning_emitted.get():
+            warnings.warn(
+                "No backend explicitly selected; defaulting to '%s'. "
+                "Call use_backend() to select one explicitly." % name,
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            _default_warning_emitted.set(True)
+    return backend
 
 
 # register built-in backends

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -12,6 +12,9 @@ Selecting a backend
 .. doctest::
 
     >>> from cryptography_suite.crypto_backends import use_backend
-    >>> use_backend("pyca")
-    >>> use_backend("sodium")  # doctest: +SKIP
-    >>> use_backend("rust")    # doctest: +SKIP
+    >>> with use_backend("pyca"):
+    ...     pass
+    >>> with use_backend("sodium"):  # doctest: +SKIP
+    ...     pass
+    >>> with use_backend("rust"):  # doctest: +SKIP
+    ...     pass

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,6 +3,11 @@
 The ``cryptography-suite`` executable exposes several subcommands. Run
 ``cryptography-suite --help`` to see the list.
 
+.. note::
+   The CLI uses the default registered backend. When writing scripts or
+   libraries, call :func:`cryptography_suite.crypto_backends.use_backend`
+   explicitly.
+
 ```bash
 cryptography-suite --help
 ```

--- a/docs/migration_3.0.md
+++ b/docs/migration_3.0.md
@@ -6,8 +6,9 @@ accordingly.
 
 ## Breaking Changes
 
-- **Backend Selection** is now mandatory via `use_backend`. The default
-  `cryptography` backend can be enabled with `use_backend("pyca")`.
+- **Backend Selection** is now mandatory via `use_backend` (typically as a
+  context manager). The default `cryptography` backend can be enabled with
+  `use_backend("pyca")`.
 - **Pipeline API** replaces ad-hoc helper chains. Compose operations using the
   `Pipeline` class.
 - **Key Management Interfaces** have changed. Use `KeyManager` for all
@@ -39,13 +40,12 @@ accordingly.
 from cryptography_suite import Pipeline, use_backend
 from cryptography_suite.pipeline import AESGCMEncrypt, AESGCMDecrypt
 
-use_backend("pyca")
+with use_backend("pyca"):
+    encrypt = AESGCMEncrypt(password="pass")
+    decrypt = AESGCMDecrypt(password="pass")
 
-encrypt = AESGCMEncrypt(password="pass")
-decrypt = AESGCMDecrypt(password="pass")
-
-p = Pipeline() >> encrypt >> decrypt
-assert p.run(b"msg") == b"msg"
+    p = Pipeline() >> encrypt >> decrypt
+    assert p.run(b"msg") == b"msg"
 ```
 
 See the [full documentation](index.html) for details on the new architecture and

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -44,4 +44,7 @@ Pipeline() >> ROT13()
 ```
 
 Use :func:`cryptography_suite.crypto_backends.use_backend` to switch the
-backend providing primitive implementations.
+backend providing primitive implementations::
+
+    with use_backend("pyca"):
+        ...

--- a/example_usage.py
+++ b/example_usage.py
@@ -56,6 +56,7 @@ from cryptography_suite import (
     base62_encode,
     base62_decode,
     generate_secure_random_string,
+    use_backend,
 )
 from cryptography_suite.pipeline import (
     AESGCMEncrypt,
@@ -66,58 +67,59 @@ from cryptography_suite.pipeline import (
 
 
 def main():
-    # Symmetric Encryption Example
-    print("=== Symmetric Encryption ===")
-    plaintext = "Hello, Symmetric Encryption!"
-    symmetric_password = "strong_password"
+    with use_backend("pyca"):
+        # Symmetric Encryption Example
+        print("=== Symmetric Encryption ===")
+        plaintext = "Hello, Symmetric Encryption!"
+        symmetric_password = "strong_password"
 
-    # AES Encryption with Scrypt KDF
-    encrypted_aes = AESGCMEncrypt(password=symmetric_password, kdf="scrypt").run(
-        plaintext
-    )
-    decrypted_aes = AESGCMDecrypt(password=symmetric_password, kdf="scrypt").run(
-        encrypted_aes
-    )
-    print(f"AES Encrypted: {encrypted_aes}")
-    print(f"AES Decrypted: {decrypted_aes}")
+        # AES Encryption with Scrypt KDF
+        encrypted_aes = AESGCMEncrypt(password=symmetric_password, kdf="scrypt").run(
+            plaintext
+        )
+        decrypted_aes = AESGCMDecrypt(password=symmetric_password, kdf="scrypt").run(
+            encrypted_aes
+        )
+        print(f"AES Encrypted: {encrypted_aes}")
+        print(f"AES Decrypted: {decrypted_aes}")
 
-    # ChaCha20 Encryption
-    encrypted_chacha = chacha20_encrypt(plaintext, symmetric_password)
-    decrypted_chacha = chacha20_decrypt(encrypted_chacha, symmetric_password)
-    print(f"ChaCha20 Encrypted: {encrypted_chacha}")
-    print(f"ChaCha20 Decrypted: {decrypted_chacha}")
+        # ChaCha20 Encryption
+        encrypted_chacha = chacha20_encrypt(plaintext, symmetric_password)
+        decrypted_chacha = chacha20_decrypt(encrypted_chacha, symmetric_password)
+        print(f"ChaCha20 Encrypted: {encrypted_chacha}")
+        print(f"ChaCha20 Decrypted: {decrypted_chacha}")
 
-    # Symmetric File Encryption
-    print("\n=== File Encryption ===")
-    try:
-        with open("test.txt", "w") as f:
-            f.write("This is a test file for encryption.")
+        # Symmetric File Encryption
+        print("\n=== File Encryption ===")
+        try:
+            with open("test.txt", "w") as f:
+                f.write("This is a test file for encryption.")
 
-        encrypt_file("test.txt", "encrypted_test.enc", symmetric_password)
-        decrypt_file("encrypted_test.enc", "decrypted_test.txt", symmetric_password)
-        with open("decrypted_test.txt", "r") as f:
-            decrypted_content = f.read()
-        print(f"Decrypted File Content: {decrypted_content}")
-    finally:
-        # Clean up
-        os.remove("test.txt")
-        os.remove("encrypted_test.enc")
-        os.remove("decrypted_test.txt")
+            encrypt_file("test.txt", "encrypted_test.enc", symmetric_password)
+            decrypt_file("encrypted_test.enc", "decrypted_test.txt", symmetric_password)
+            with open("decrypted_test.txt", "r") as f:
+                decrypted_content = f.read()
+            print(f"Decrypted File Content: {decrypted_content}")
+        finally:
+            # Clean up
+            os.remove("test.txt")
+            os.remove("encrypted_test.enc")
+            os.remove("decrypted_test.txt")
 
-    # Asymmetric Encryption Example
-    print("\n=== Asymmetric Encryption ===")
-    rsa_private_key, rsa_public_key = generate_rsa_keypair()
-    message = b"Hello, Asymmetric Encryption!"
+        # Asymmetric Encryption Example
+        print("\n=== Asymmetric Encryption ===")
+        rsa_private_key, rsa_public_key = generate_rsa_keypair()
+        message = b"Hello, Asymmetric Encryption!"
 
-    rsa_ciphertext = RSAEncrypt(public_key=rsa_public_key).run(message)
-    rsa_plaintext = RSADecrypt(private_key=rsa_private_key).run(rsa_ciphertext)
-    print(f"RSA Decrypted Message: {rsa_plaintext.decode()}")
+        rsa_ciphertext = RSAEncrypt(public_key=rsa_public_key).run(message)
+        rsa_plaintext = RSADecrypt(private_key=rsa_private_key).run(rsa_ciphertext)
+        print(f"RSA Decrypted Message: {rsa_plaintext.decode()}")
 
-    # Key Serialization and Loading
-    key_password = "encryption_password"
-    private_pem = serialize_private_key(rsa_private_key, key_password)
-    public_pem = serialize_public_key(rsa_public_key)
-    loaded_private_key = load_private_key(private_pem, key_password)
+        # Key Serialization and Loading
+        key_password = "encryption_password"
+        private_pem = serialize_private_key(rsa_private_key, key_password)
+        public_pem = serialize_public_key(rsa_public_key)
+        loaded_private_key = load_private_key(private_pem, key_password)
     loaded_public_key = load_public_key(public_pem)
     print("RSA keys serialized and loaded successfully.")
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -9,25 +9,48 @@ def test_available_backends_contains_pyca():
     assert "pyca" in backends.available_backends()
 
 
-def test_use_backend_runtime_switch():
+def test_get_backend_warns_when_default_used():
+    importlib.reload(backends)
+    importlib.reload(pyca_backend)
+    with pytest.warns(RuntimeWarning):
+        b = backends.get_backend()
+    assert isinstance(b, pyca_backend.PyCABackend)
+    backends.use_backend("pyca")
+
+
+def test_use_backend_context_manager():
     class Dummy:
         def __init__(self) -> None:
             self.value = 1
 
     backends.register_backend("dummy")(Dummy)
-    backends.use_backend("dummy")
-    b = backends.get_backend()
-    assert isinstance(b, Dummy)
-    assert b.value == 1
+    backends.use_backend("pyca")
+    with backends.use_backend("dummy"):
+        b = backends.get_backend()
+        assert isinstance(b, Dummy)
+        assert b.value == 1
+    assert isinstance(backends.get_backend(), pyca_backend.PyCABackend)
+
+
+def test_select_backend_with_instance():
+    class Dummy2:
+        name = "dummy2"
+
+    inst = Dummy2()
+    backends.select_backend(inst)
+    assert isinstance(backends.get_backend(), Dummy2)
+    assert "dummy2" in backends.available_backends()
     backends.use_backend("pyca")
 
 
-def test_select_backend_alias():
-    class Dummy2:
+def test_pipeline_backend_override():
+    class Dummy:
         pass
 
-    backends.register_backend("dummy2")(Dummy2)
-    with pytest.deprecated_call():
-        backends.select_backend("dummy2")
-    assert isinstance(backends.get_backend(), Dummy2)
+    backends.register_backend("dummy")(Dummy)
     backends.use_backend("pyca")
+    from cryptography_suite.pipeline import AESGCMEncrypt
+
+    AESGCMEncrypt(password="pw", backend="dummy").run("hi")
+    # original backend restored
+    assert isinstance(backends.get_backend(), pyca_backend.PyCABackend)


### PR DESCRIPTION
## Summary
- add context-aware backend selection API with `use_backend` context manager and `select_backend`
- allow per-operation backend overrides in AESGCM pipeline modules
- document explicit backend selection and thread-safe behavior across docs and examples

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography_suite')*
- `pip install -q -r requirements.txt hypothesis`
- `pip install -q -e .`
- `pytest tests/test_backends.py -q`
