### PR TITLE
refactor: modularize public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## 🔑 Key Features
 
 - **Comprehensive Functionality**: Symmetric and asymmetric encryption, digital signatures, key management, secret sharing, password-authenticated key exchange (PAKE), and one-time passwords (OTP).
-- **Post-Quantum Primitives**: Kyber KEM, Dilithium signatures, and **experimental SPHINCS+** support (enable via `pip install "cryptography-suite[pqc]"` – demo-only, not production-grade).
+- **Post-Quantum Primitives**: Kyber KEM, Dilithium signatures, and **experimental SPHINCS+** support (enable via `pip install "cryptography-suite[pqc]"` – demo-only, not production-grade). These are available under ``cryptography_suite.experimental``.
 - **Signal Protocol Demo**: Minimal X3DH + Double Ratchet implementation for demonstration purposes (**experimental, not production-ready**).
 - **Developer-Friendly API**: Intuitive, well-documented interfaces that simplify integration and accelerate development.
 - **Cross-Platform Compatibility**: Fully compatible with macOS, Linux, and Windows environments.

--- a/cryptography_suite/__init__.py
+++ b/cryptography_suite/__init__.py
@@ -1,7 +1,5 @@
 """Cryptography Suite Package Initialization."""
 
-from typing import Any
-
 from .errors import (
     CryptographySuiteError,
     DecryptionError,
@@ -32,16 +30,9 @@ from .asymmetric import (
     serialize_private_key,
     serialize_public_key,
 )
-from .asymmetric.bls import (
-    bls_aggregate,
-    bls_aggregate_verify,
-    bls_sign,
-    bls_verify,
-    generate_bls_keypair,
-)
+
 from .asymmetric.signatures import (
     generate_ecdsa_keypair,
-    generate_ed448_keypair,
     generate_ed25519_keypair,
     load_ecdsa_private_key,
     load_ecdsa_public_key,
@@ -53,15 +44,13 @@ from .asymmetric.signatures import (
     serialize_ed25519_public_key,
     sign_message,
     sign_message_ecdsa,
-    sign_message_ed448,
     verify_signature,
     verify_signature_ecdsa,
-    verify_signature_ed448,
 )
 
-# Backend registry -----------------------------------------------------------------
-from .crypto_backends import pyca_backend  # noqa: F401  - registers default backend
-from .crypto_backends import available_backends, use_backend, select_backend  # noqa: E402
+# Backend registry -----------------------------------------------------------
+from .crypto_backends import pyca_backend  # noqa: F401 - registers default backend
+from .crypto_backends import available_backends, use_backend, select_backend
 from .hybrid import HybridEncryptor, hybrid_decrypt, hybrid_encrypt
 
 # Symmetric primitives -------------------------------------------------------
@@ -90,40 +79,19 @@ from .symmetric import (
     xchacha_encrypt,
 )
 
-# Post-quantum cryptography --------------------------------------------------
-try:  # pragma: no cover - optional dependency
-    from .pqc import (  # noqa: F401
-        PQCRYPTO_AVAILABLE,
-        SPHINCS_AVAILABLE,
-        dilithium_sign,
-        dilithium_verify,
-        generate_dilithium_keypair,
-        generate_kyber_keypair,
-        generate_sphincs_keypair,
-        kyber_decrypt,
-        kyber_encrypt,
-        sphincs_sign,
-        sphincs_verify,
-    )
-except Exception:  # pragma: no cover - fallback when pqcrypto is missing
-    PQCRYPTO_AVAILABLE = False
-
 from .audit import audit_log, set_audit_logger
 
-# Hashing and utilities ------------------------------------------------------
+# Hashing --------------------------------------------------------------------
 from .hashing import (
     blake2b_hash,
     blake3_hash,
-    blake3_hash_v2,
     sha3_256_hash,
     sha3_512_hash,
     sha256_hash,
     sha384_hash,
     sha512_hash,
 )
-from .pipeline import Pipeline, PipelineVisualizer
-from .rich_logging import get_rich_logger
-from .viz import HandshakeFlowWidget, KeyGraphWidget, SessionTimelineWidget
+
 from .protocols import (
     KeyManager,
     SignalReceiver,
@@ -159,40 +127,8 @@ from .utils import (
     secure_zero,
     to_pem,
 )
+
 from .x509 import generate_csr, load_certificate, self_sign_certificate
-
-# Optional homomorphic encryption -------------------------------------------
-try:  # pragma: no cover - optional dependency
-    from .homomorphic import add as fhe_add  # noqa: F401
-    from .homomorphic import decrypt as fhe_decrypt  # noqa: F401
-    from .homomorphic import encrypt as fhe_encrypt  # noqa: F401
-    from .homomorphic import keygen as fhe_keygen  # noqa: F401
-    from .homomorphic import multiply as fhe_multiply  # noqa: F401
-
-    FHE_AVAILABLE = True
-except Exception:  # pragma: no cover - handle missing Pyfhel
-    FHE_AVAILABLE = False
-
-# Zero-knowledge proofs ------------------------------------------------------
-bulletproof: Any
-try:  # pragma: no cover - optional dependency
-    from .zk import bulletproof as bulletproof_module
-
-    bulletproof = bulletproof_module
-    BULLETPROOF_AVAILABLE = True
-except Exception:  # pragma: no cover - handle missing dependency
-    bulletproof = None
-    BULLETPROOF_AVAILABLE = False
-
-zksnark: Any
-try:  # pragma: no cover - optional dependency
-    from .zk import zksnark as zksnark_module
-
-    zksnark = zksnark_module
-    ZKSNARK_AVAILABLE = getattr(zksnark_module, "ZKSNARK_AVAILABLE", False)
-except Exception:  # pragma: no cover - handle missing dependency
-    zksnark = None
-    ZKSNARK_AVAILABLE = False
 
 __all__ = [
     # Encryption
@@ -239,11 +175,8 @@ __all__ = [
     "HybridEncryptor",
     # Signatures
     "generate_ed25519_keypair",
-    "generate_ed448_keypair",
     "sign_message",
-    "sign_message_ed448",
     "verify_signature",
-    "verify_signature_ed448",
     "serialize_ed25519_private_key",
     "serialize_ed25519_public_key",
     "load_ed25519_private_key",
@@ -255,12 +188,6 @@ __all__ = [
     "serialize_ecdsa_public_key",
     "load_ecdsa_private_key",
     "load_ecdsa_public_key",
-    # BLS Signatures
-    "generate_bls_keypair",
-    "bls_sign",
-    "bls_verify",
-    "bls_aggregate",
-    "bls_aggregate_verify",
     # Hashing
     "sha384_hash",
     "sha256_hash",
@@ -269,7 +196,6 @@ __all__ = [
     "sha3_512_hash",
     "blake2b_hash",
     "blake3_hash",
-    "blake3_hash_v2",
     # Key Management
     "generate_aes_key",
     "rotate_aes_key",
@@ -301,15 +227,11 @@ __all__ = [
     "encode_encrypted_message",
     "decode_encrypted_message",
     "KeyManager",
+    # x509
     "generate_csr",
     "self_sign_certificate",
     "load_certificate",
-    "Pipeline",
-    "PipelineVisualizer",
-    "get_rich_logger",
-    "HandshakeFlowWidget",
-    "KeyGraphWidget",
-    "SessionTimelineWidget",
+    # Audit
     "audit_log",
     "set_audit_logger",
     # Signal Protocol
@@ -324,40 +246,9 @@ __all__ = [
     "SignatureVerificationError",
     "MissingDependencyError",
     "ProtocolError",
+    # Backends
     "available_backends",
     "use_backend",
     "select_backend",
 ]
 
-# Conditional exports -------------------------------------------------------
-if PQCRYPTO_AVAILABLE:
-    __all__.extend(
-        [
-            "generate_kyber_keypair",
-            "kyber_encrypt",
-            "kyber_decrypt",
-            "generate_dilithium_keypair",
-            "dilithium_sign",
-            "dilithium_verify",
-            "generate_sphincs_keypair",
-            "sphincs_sign",
-            "sphincs_verify",
-        ]
-    )
-
-if FHE_AVAILABLE:
-    __all__.extend(
-        [
-            "fhe_keygen",
-            "fhe_encrypt",
-            "fhe_decrypt",
-            "fhe_add",
-            "fhe_multiply",
-        ]
-    )
-
-# Zero-knowledge proofs modules
-if BULLETPROOF_AVAILABLE:
-    __all__.append("bulletproof")
-if ZKSNARK_AVAILABLE:
-    __all__.append("zksnark")

--- a/cryptography_suite/experimental/__init__.py
+++ b/cryptography_suite/experimental/__init__.py
@@ -1,0 +1,108 @@
+"""Experimental and optional features of :mod:`cryptography_suite`.
+
+These APIs are not part of the stable public interface and may change or be
+removed without notice. Import them explicitly, e.g.::
+
+    from cryptography_suite.experimental import kyber_encrypt
+"""
+
+from typing import Any
+
+# Post-quantum cryptography --------------------------------------------------
+try:  # pragma: no cover - optional dependency
+    from ..pqc import (
+        PQCRYPTO_AVAILABLE,
+        SPHINCS_AVAILABLE,
+        dilithium_sign,
+        dilithium_verify,
+        generate_dilithium_keypair,
+        generate_kyber_keypair,
+        generate_sphincs_keypair,
+        kyber_decrypt,
+        kyber_encrypt,
+        sphincs_sign,
+        sphincs_verify,
+    )
+except Exception:  # pragma: no cover - fallback when pqcrypto is missing
+    PQCRYPTO_AVAILABLE = False
+    SPHINCS_AVAILABLE = False
+    dilithium_sign = dilithium_verify = None  # type: ignore
+    generate_dilithium_keypair = None  # type: ignore
+    generate_kyber_keypair = None  # type: ignore
+    generate_sphincs_keypair = None  # type: ignore
+    kyber_decrypt = kyber_encrypt = None  # type: ignore
+    sphincs_sign = sphincs_verify = None  # type: ignore
+
+# Homomorphic encryption -----------------------------------------------------
+try:  # pragma: no cover - optional dependency
+    from ..homomorphic import (
+        add as fhe_add,
+        decrypt as fhe_decrypt,
+        encrypt as fhe_encrypt,
+        keygen as fhe_keygen,
+        multiply as fhe_multiply,
+    )
+
+    FHE_AVAILABLE = True
+except Exception:  # pragma: no cover - handle missing Pyfhel
+    fhe_add = fhe_decrypt = fhe_encrypt = fhe_keygen = fhe_multiply = None  # type: ignore
+    FHE_AVAILABLE = False
+
+# Zero-knowledge proofs ------------------------------------------------------
+bulletproof: Any
+try:  # pragma: no cover - optional dependency
+    from ..zk import bulletproof as bulletproof_module
+
+    bulletproof = bulletproof_module
+    BULLETPROOF_AVAILABLE = True
+except Exception:  # pragma: no cover - handle missing dependency
+    bulletproof = None
+    BULLETPROOF_AVAILABLE = False
+
+zksnark: Any
+try:  # pragma: no cover - optional dependency
+    from ..zk import zksnark as zksnark_module
+
+    zksnark = zksnark_module
+    ZKSNARK_AVAILABLE = getattr(zksnark_module, "ZKSNARK_AVAILABLE", False)
+except Exception:  # pragma: no cover - handle missing dependency
+    zksnark = None
+    ZKSNARK_AVAILABLE = False
+
+# Visualization widgets ------------------------------------------------------
+try:  # pragma: no cover - optional dependency
+    from ..viz import HandshakeFlowWidget, KeyGraphWidget, SessionTimelineWidget
+except Exception:  # pragma: no cover - widgets may be unavailable
+    HandshakeFlowWidget = KeyGraphWidget = SessionTimelineWidget = None  # type: ignore
+
+__all__ = [
+    # PQC
+    "PQCRYPTO_AVAILABLE",
+    "SPHINCS_AVAILABLE",
+    "dilithium_sign",
+    "dilithium_verify",
+    "generate_dilithium_keypair",
+    "generate_kyber_keypair",
+    "generate_sphincs_keypair",
+    "kyber_decrypt",
+    "kyber_encrypt",
+    "sphincs_sign",
+    "sphincs_verify",
+    # Homomorphic
+    "FHE_AVAILABLE",
+    "fhe_keygen",
+    "fhe_encrypt",
+    "fhe_decrypt",
+    "fhe_add",
+    "fhe_multiply",
+    # ZK proofs
+    "BULLETPROOF_AVAILABLE",
+    "bulletproof",
+    "ZKSNARK_AVAILABLE",
+    "zksnark",
+    # Visualization
+    "HandshakeFlowWidget",
+    "KeyGraphWidget",
+    "SessionTimelineWidget",
+]
+

--- a/cryptography_suite/legacy/__init__.py
+++ b/cryptography_suite/legacy/__init__.py
@@ -1,0 +1,35 @@
+"""Legacy APIs for :mod:`cryptography_suite`.
+
+These helpers are retained for backward compatibility but are not part of the
+recommended public interface. Prefer alternatives in the core API for new
+code.
+"""
+
+from ..asymmetric.bls import (
+    bls_aggregate,
+    bls_aggregate_verify,
+    bls_sign,
+    bls_verify,
+    generate_bls_keypair,
+)
+
+from ..asymmetric.signatures import (
+    generate_ed448_keypair,
+    sign_message_ed448,
+    verify_signature_ed448,
+)
+
+from ..hashing import blake3_hash_v2
+
+__all__ = [
+    "generate_bls_keypair",
+    "bls_sign",
+    "bls_verify",
+    "bls_aggregate",
+    "bls_aggregate_verify",
+    "generate_ed448_keypair",
+    "sign_message_ed448",
+    "verify_signature_ed448",
+    "blake3_hash_v2",
+]
+

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,7 +1,26 @@
 API Reference
 =============
 
+Core API
+--------
+
 .. automodule:: cryptography_suite
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Experimental API
+----------------
+
+.. automodule:: cryptography_suite.experimental
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Legacy API
+----------
+
+.. automodule:: cryptography_suite.legacy
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/api/public_api_table.rst
+++ b/docs/api/public_api_table.rst
@@ -1,0 +1,423 @@
+Public API Inventory
+====================
+
+.. list-table:: Public API Inventory
+   :header-rows: 1
+
+   * - API
+     - Summary
+     - Status
+   * - ``chacha20_encrypt``
+     - Encrypt using ChaCha20-Poly1305 with an Argon2-derived key.
+     - Core
+   * - ``chacha20_decrypt``
+     - Decrypt data encrypted with ChaCha20-Poly1305.
+     - Core
+   * - ``chacha20_encrypt_aead``
+     - Encrypt ``plaintext`` using ChaCha20-Poly1305.
+     - Core
+   * - ``chacha20_decrypt_aead``
+     - Decrypt data encrypted with :func:`chacha20_encrypt_aead`.
+     - Core
+   * - ``xchacha_encrypt``
+     - Encrypt ``message`` using XChaCha20-Poly1305.
+     - Core
+   * - ``xchacha_decrypt``
+     - Decrypt data encrypted with :func:`xchacha_encrypt`.
+     - Core
+   * - ``scrypt_encrypt``
+     - 
+     - Core
+   * - ``scrypt_decrypt``
+     - 
+     - Core
+   * - ``argon2_encrypt``
+     - 
+     - Core
+   * - ``argon2_decrypt``
+     - 
+     - Core
+   * - ``pbkdf2_encrypt``
+     - 
+     - Core
+   * - ``pbkdf2_decrypt``
+     - 
+     - Core
+   * - ``encrypt_file``
+     - Encrypt a file using AES-GCM with a password-derived key.
+     - Core
+   * - ``decrypt_file``
+     - Decrypt a file encrypted with AES-GCM using a password-derived key.
+     - Core
+   * - ``encrypt_file_async``
+     - Asynchronously encrypt a file using AES-GCM with a password-derived key.
+     - Core
+   * - ``decrypt_file_async``
+     - Asynchronously decrypt a file encrypted with AES-GCM using a password-derived key.
+     - Core
+   * - ``derive_key_scrypt``
+     - Derive a cryptographic key using Scrypt KDF.
+     - Core
+   * - ``derive_key_pbkdf2``
+     - Derive a key using PBKDF2 HMAC SHA-256.
+     - Core
+   * - ``derive_key_argon2``
+     - Derive a key using Argon2id.
+     - Core
+   * - ``derive_hkdf``
+     - Derive a key using HKDF-SHA256.
+     - Core
+   * - ``kdf_pbkdf2``
+     - Derive a key using PBKDF2-HMAC-SHA256 with configurable iterations.
+     - Core
+   * - ``verify_derived_key_scrypt``
+     - Verify a password against an expected key using Scrypt.
+     - Core
+   * - ``verify_derived_key_pbkdf2``
+     - Verify a password against a previously derived PBKDF2 key.
+     - Core
+   * - ``generate_salt``
+     - Generate a cryptographically secure random salt.
+     - Core
+   * - ``generate_rsa_keypair``
+     - Generates an RSA private and public key pair.
+     - Core
+   * - ``generate_rsa_keypair_async``
+     - Generate an RSA key pair in a background thread.
+     - Core
+   * - ``serialize_private_key``
+     - Serializes a private key to PEM format, encrypted with a password.
+     - Core
+   * - ``serialize_public_key``
+     - Serializes a public key to PEM format.
+     - Core
+   * - ``load_private_key``
+     - Loads a private key (RSA, X25519, X448, or EC) from PEM data.
+     - Core
+   * - ``load_public_key``
+     - Loads a public key (RSA, X25519, X448, or EC) from PEM data.
+     - Core
+   * - ``generate_x25519_keypair``
+     - Generates an X25519 private and public key pair.
+     - Core
+   * - ``derive_x25519_shared_key``
+     - Derives a shared key using X25519 key exchange.
+     - Core
+   * - ``generate_x448_keypair``
+     - Generates an X448 private and public key pair.
+     - Core
+   * - ``derive_x448_shared_key``
+     - Derives a shared key using X448 key exchange.
+     - Core
+   * - ``generate_ec_keypair``
+     - Generates an Elliptic Curve key pair.
+     - Core
+   * - ``ec_encrypt``
+     - Encrypt ``plaintext`` for ``public_key`` using ECIES.
+     - Core
+   * - ``ec_decrypt``
+     - Decrypt ECIES ``ciphertext`` using ``private_key``.
+     - Core
+   * - ``hybrid_encrypt``
+     - Encrypt ``message`` using hybrid RSA/ECIES + AES-GCM.
+     - Core
+   * - ``hybrid_decrypt``
+     - Decrypt data produced by :func:`hybrid_encrypt`.
+     - Core
+   * - ``HybridEncryptor``
+     - Object-oriented helper for hybrid encryption.
+     - Core
+   * - ``generate_ed25519_keypair``
+     - Generates an Ed25519 private and public key pair.
+     - Core
+   * - ``sign_message``
+     - Sign ``message`` using Ed25519 and return Base64 by default.
+     - Core
+   * - ``verify_signature``
+     - Verifies an Ed25519 signature.
+     - Core
+   * - ``serialize_ed25519_private_key``
+     - Serializes an Ed25519 private key to PEM format with encryption.
+     - Core
+   * - ``serialize_ed25519_public_key``
+     - Serializes an Ed25519 public key to PEM format.
+     - Core
+   * - ``load_ed25519_private_key``
+     - Loads an Ed25519 private key from PEM data.
+     - Core
+   * - ``load_ed25519_public_key``
+     - Loads an Ed25519 public key from PEM data.
+     - Core
+   * - ``generate_ecdsa_keypair``
+     - Generates an ECDSA private and public key pair.
+     - Core
+   * - ``sign_message_ecdsa``
+     - Sign a message using ECDSA and return Base64 by default.
+     - Core
+   * - ``verify_signature_ecdsa``
+     - Verifies an ECDSA signature.
+     - Core
+   * - ``serialize_ecdsa_private_key``
+     - Serializes an ECDSA private key to PEM format with encryption.
+     - Core
+   * - ``serialize_ecdsa_public_key``
+     - Serializes an ECDSA public key to PEM format.
+     - Core
+   * - ``load_ecdsa_private_key``
+     - Loads an ECDSA private key from PEM data.
+     - Core
+   * - ``load_ecdsa_public_key``
+     - Loads an ECDSA public key from PEM data.
+     - Core
+   * - ``sha384_hash``
+     - Generates a SHA-384 hash of the given data.
+     - Core
+   * - ``sha256_hash``
+     - Generates a SHA-256 hash of the given data.
+     - Core
+   * - ``sha512_hash``
+     - Generates a SHA-512 hash of the given data.
+     - Core
+   * - ``sha3_256_hash``
+     - Generates a SHA3-256 hash of the given data.
+     - Core
+   * - ``sha3_512_hash``
+     - Generates a SHA3-512 hash of the given data.
+     - Core
+   * - ``blake2b_hash``
+     - Generates a BLAKE2b hash of the given data.
+     - Core
+   * - ``blake3_hash``
+     - Generates a BLAKE3 hash of the given data.
+     - Core
+   * - ``generate_aes_key``
+     - Generates a secure random AES key.
+     - Core
+   * - ``rotate_aes_key``
+     - Generates a new AES key to replace the old one.
+     - Core
+   * - ``secure_save_key_to_file``
+     - Saves key data to a specified file path with secure permissions.
+     - Core
+   * - ``load_private_key_from_file``
+     - Loads a PEM-encoded private key from a file.
+     - Core
+   * - ``load_public_key_from_file``
+     - Loads a PEM-encoded public key from a file.
+     - Core
+   * - ``key_exists``
+     - Checks if a key file exists at the given filepath.
+     - Core
+   * - ``create_shares``
+     - Splits a secret into shares using Shamir's Secret Sharing.
+     - Core
+   * - ``reconstruct_secret``
+     - Reconstructs the secret from shares using Lagrange interpolation.
+     - Core
+   * - ``SPAKE2Client``
+     - Client-side implementation of the SPAKE2 protocol.
+     - Core
+   * - ``SPAKE2Server``
+     - Server-side implementation of the SPAKE2 protocol.
+     - Core
+   * - ``generate_totp``
+     - Generates a TOTP code based on a shared secret.
+     - Core
+   * - ``verify_totp``
+     - Verifies a TOTP code within the allowed time window.
+     - Core
+   * - ``generate_hotp``
+     - Generates an HOTP code based on a shared secret and counter.
+     - Core
+   * - ``verify_hotp``
+     - Verifies an HOTP code within the allowed counter window.
+     - Core
+   * - ``base62_encode``
+     - Encodes byte data into Base62 format.
+     - Core
+   * - ``base62_decode``
+     - Decodes a Base62-encoded string into bytes.
+     - Core
+   * - ``secure_zero``
+     - Overwrite ``data`` with zeros in-place using ``memset_s`` if available.
+     - Core
+   * - ``constant_time_compare``
+     - Return ``True`` if ``val1`` equals ``val2`` using a timing-safe check.
+     - Core
+   * - ``generate_secure_random_string``
+     - Generates a secure random string using Base62 encoding.
+     - Core
+   * - ``KeyVault``
+     - Context manager for sensitive key storage.
+     - Core
+   * - ``to_pem``
+     - Return a PEM-formatted string for a key.
+     - Core
+   * - ``from_pem``
+     - Load a key object from a PEM-formatted string.
+     - Core
+   * - ``pem_to_json``
+     - Serialize a key to a JSON object containing a PEM string.
+     - Core
+   * - ``encode_encrypted_message``
+     - Convert a hybrid or Signal encrypted message into a Base64 string.
+     - Core
+   * - ``decode_encrypted_message``
+     - Parse a Base64 string produced by :func:`encode_encrypted_message`.
+     - Core
+   * - ``KeyManager``
+     - Utility class for handling private key storage and rotation.
+     - Core
+   * - ``generate_csr``
+     - Generate a Certificate Signing Request (CSR).
+     - Core
+   * - ``self_sign_certificate``
+     - Generate a self-signed X.509 certificate.
+     - Core
+   * - ``load_certificate``
+     - Load a PEM encoded certificate.
+     - Core
+   * - ``audit_log``
+     - Decorator to log cryptographic operations.
+     - Core
+   * - ``set_audit_logger``
+     - Configure the audit logger.
+     - Core
+   * - ``SignalSender``
+     - Sender that initiates a Signal session.
+     - Core
+   * - ``SignalReceiver``
+     - Receiver that responds to a Signal session.
+     - Core
+   * - ``initialize_signal_session``
+     - Convenience function to create two parties with a shared session.
+     - Core
+   * - ``CryptographySuiteError``
+     - Base exception for the cryptography suite.
+     - Core
+   * - ``EncryptionError``
+     - Raised when encryption fails or invalid parameters are provided.
+     - Core
+   * - ``DecryptionError``
+     - Raised when decryption fails or invalid data is provided.
+     - Core
+   * - ``KeyDerivationError``
+     - Raised when a key derivation operation fails.
+     - Core
+   * - ``SignatureVerificationError``
+     - Raised when signature verification fails.
+     - Core
+   * - ``MissingDependencyError``
+     - Raised when an optional dependency is missing.
+     - Core
+   * - ``ProtocolError``
+     - Raised when a protocol implementation encounters an error.
+     - Core
+   * - ``available_backends``
+     - 
+     - Core
+   * - ``use_backend``
+     - Select the backend to use.
+     - Core
+   * - ``select_backend``
+     - Register and select a backend.
+     - Core
+   * - ``PQCRYPTO_AVAILABLE``
+     - bool(x) -> bool
+     - Experimental
+   * - ``SPHINCS_AVAILABLE``
+     - bool(x) -> bool
+     - Experimental
+   * - ``dilithium_sign``
+     - Sign a message using Dilithium level 2.
+     - Experimental
+   * - ``dilithium_verify``
+     - Verify a Dilithium signature using level 2.
+     - Experimental
+   * - ``generate_dilithium_keypair``
+     - Generate a Dilithium key pair using level 2 parameters.
+     - Experimental
+   * - ``generate_kyber_keypair``
+     - Generate a Kyber key pair for the given ``level``.
+     - Experimental
+   * - ``generate_sphincs_keypair``
+     - Generate a SPHINCS+ key pair using a 128-bit security level.
+     - Experimental
+   * - ``kyber_decrypt``
+     - Decrypt data encrypted by :func:`kyber_encrypt`.
+     - Experimental
+   * - ``kyber_encrypt``
+     - Encrypt ``plaintext`` using Kyber and AES-GCM.
+     - Experimental
+   * - ``sphincs_sign``
+     - Sign ``message`` with SPHINCS+ returning Base64 by default.
+     - Experimental
+   * - ``sphincs_verify``
+     - Verify a SPHINCS+ signature.
+     - Experimental
+   * - ``FHE_AVAILABLE``
+     - bool(x) -> bool
+     - Experimental
+   * - ``fhe_keygen``
+     - 
+     - Experimental
+   * - ``fhe_encrypt``
+     - 
+     - Experimental
+   * - ``fhe_decrypt``
+     - 
+     - Experimental
+   * - ``fhe_add``
+     - 
+     - Experimental
+   * - ``fhe_multiply``
+     - 
+     - Experimental
+   * - ``BULLETPROOF_AVAILABLE``
+     - bool(x) -> bool
+     - Experimental
+   * - ``bulletproof``
+     - Bulletproof range proof utilities using pybulletproofs.
+     - Experimental
+   * - ``ZKSNARK_AVAILABLE``
+     - bool(x) -> bool
+     - Experimental
+   * - ``zksnark``
+     - ZK-SNARK utilities using PySNARK.
+     - Experimental
+   * - ``HandshakeFlowWidget``
+     - Animated visualization of a handshake protocol.
+     - Experimental
+   * - ``KeyGraphWidget``
+     - Display key relationships as a graph.
+     - Experimental
+   * - ``SessionTimelineWidget``
+     - Visualize message and key events over time.
+     - Experimental
+   * - ``generate_bls_keypair``
+     - Generate a BLS12-381 key pair.
+     - Legacy
+   * - ``bls_sign``
+     - Sign a message using the BLS signature scheme.
+     - Legacy
+   * - ``bls_verify``
+     - Verify a BLS signature.
+     - Legacy
+   * - ``bls_aggregate``
+     - Aggregate multiple BLS signatures into one.
+     - Legacy
+   * - ``bls_aggregate_verify``
+     - Verify an aggregated BLS signature against multiple messages.
+     - Legacy
+   * - ``generate_ed448_keypair``
+     - Generates an Ed448 private and public key pair.
+     - Legacy
+   * - ``sign_message_ed448``
+     - Sign a message using Ed448 and return Base64 by default.
+     - Legacy
+   * - ``verify_signature_ed448``
+     - Verifies an Ed448 signature.
+     - Legacy
+   * - ``blake3_hash_v2``
+     - Another BLAKE3 hash helper used for testing.
+     - Legacy

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,4 +54,5 @@ formally verified, misuse-resistant workflows.
    security.rst
    api/modules
    api/pipeline
+   api/public_api_table
 

--- a/docs/migration_3.0.md
+++ b/docs/migration_3.0.md
@@ -37,8 +37,8 @@ accordingly.
 ## Example
 
 ```python
-from cryptography_suite import Pipeline, use_backend
-from cryptography_suite.pipeline import AESGCMEncrypt, AESGCMDecrypt
+from cryptography_suite import use_backend
+from cryptography_suite.pipeline import Pipeline, AESGCMEncrypt, AESGCMDecrypt
 
 with use_backend("pyca"):
     encrypt = AESGCMEncrypt(password="pass")

--- a/example_usage.py
+++ b/example_usage.py
@@ -241,7 +241,8 @@ def main():
     # Homomorphic Encryption Demo
     print("\n=== Homomorphic Encryption ===")
     try:
-        from cryptography_suite.homomorphic import (
+        from cryptography_suite.experimental import (
+            FHE_AVAILABLE,
             fhe_keygen,
             fhe_encrypt,
             fhe_decrypt,
@@ -249,12 +250,15 @@ def main():
             fhe_multiply,
         )
 
-        fhe = fhe_keygen("CKKS")
-        c1 = fhe_encrypt(fhe, 10.5)
-        c2 = fhe_encrypt(fhe, 5.25)
-        print("Decrypted Sum:", fhe_decrypt(fhe, fhe_add(fhe, c1, c2)))
-        print("Decrypted Product:", fhe_decrypt(fhe, fhe_multiply(fhe, c1, c2)))
-    except ImportError:
+        if FHE_AVAILABLE:
+            fhe = fhe_keygen("CKKS")
+            c1 = fhe_encrypt(fhe, 10.5)
+            c2 = fhe_encrypt(fhe, 5.25)
+            print("Decrypted Sum:", fhe_decrypt(fhe, fhe_add(fhe, c1, c2)))
+            print("Decrypted Product:", fhe_decrypt(fhe, fhe_multiply(fhe, c1, c2)))
+        else:
+            print("Pyfhel not installed; skipping homomorphic encryption demo.")
+    except Exception:
         print("Pyfhel not installed; skipping homomorphic encryption demo.")
 
 

--- a/tests/test_bulletproof.py
+++ b/tests/test_bulletproof.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cryptography_suite import bulletproof
+from cryptography_suite.experimental import bulletproof
 
 
 pytestmark = pytest.mark.skipif(

--- a/tests/test_package_init.py
+++ b/tests/test_package_init.py
@@ -1,23 +1,14 @@
-import builtins
 import importlib
-import sys
-import cryptography_suite
 
 
-def test_init_without_optional_modules(monkeypatch):
-    original_import = builtins.__import__
+def test_init_without_optional_modules() -> None:
+    import cryptography_suite
 
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if (name in {"cryptography_suite.zk", "zk"} and ("bulletproof" in fromlist or "zksnark" in fromlist)):
-            raise ImportError
-        return original_import(name, globals, locals, fromlist, level)
+    core_all = set(cryptography_suite.__all__)
+    assert "bulletproof" not in core_all
+    assert "zksnark" not in core_all
 
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-    for mod in ["cryptography_suite.zk", "cryptography_suite.zk.bulletproof", "cryptography_suite.zk.zksnark"]:
-        sys.modules.pop(mod, None)
-    mod = importlib.reload(cryptography_suite)
-    assert not mod.BULLETPROOF_AVAILABLE
-    assert not mod.ZKSNARK_AVAILABLE
-    assert "bulletproof" not in mod.__all__
-    assert "zksnark" not in mod.__all__
-    importlib.reload(mod)
+    experimental = importlib.import_module("cryptography_suite.experimental")
+    assert hasattr(experimental, "BULLETPROOF_AVAILABLE")
+    assert hasattr(experimental, "ZKSNARK_AVAILABLE")
+

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,11 @@
+from cryptography_suite import __all__ as core_all
+from cryptography_suite.experimental import __all__ as experimental_all
+from cryptography_suite.legacy import __all__ as legacy_all
+
+
+def test_no_experimental_or_legacy_in_core() -> None:
+    """Ensure the recommended namespace stays minimal."""
+
+    overlap = set(core_all) & (set(experimental_all) | set(legacy_all))
+    assert not overlap, f"Unexpected names leaked into core API: {sorted(overlap)}"
+

--- a/tests/test_zksnark.py
+++ b/tests/test_zksnark.py
@@ -1,6 +1,6 @@
 import unittest
 
-from cryptography_suite import zksnark
+from cryptography_suite.experimental import zksnark
 
 
 @unittest.skipUnless(

--- a/tools/generate_public_api_table.py
+++ b/tools/generate_public_api_table.py
@@ -1,0 +1,56 @@
+"""Generate a table of the public API for documentation.
+
+This script introspects the :mod:`cryptography_suite` package and writes an
+RST table listing each exported symbol along with a short docstring summary and
+its status (core, experimental, or legacy).
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from pathlib import Path
+
+
+SECTIONS = [
+    ("Core", "cryptography_suite"),
+    ("Experimental", "cryptography_suite.experimental"),
+    ("Legacy", "cryptography_suite.legacy"),
+]
+
+
+def _summary(obj: object) -> str:
+    doc = inspect.getdoc(obj) or ""
+    return doc.splitlines()[0] if doc else ""
+
+
+def generate_table() -> str:
+    rows = [
+        ".. list-table:: Public API Inventory",
+        "   :header-rows: 1",
+        "",
+        "   * - API",
+        "     - Summary",
+        "     - Status",
+    ]
+
+    for status, modname in SECTIONS:
+        mod = importlib.import_module(modname)
+        for name in getattr(mod, "__all__", []):
+            obj = getattr(mod, name, None)
+            rows.append(f"   * - ``{name}``")
+            rows.append(f"     - {_summary(obj)}")
+            rows.append(f"     - {status}")
+
+    return "\n".join(rows) + "\n"
+
+
+def main() -> None:
+    content = "Public API Inventory\n====================\n\n" + generate_table()
+    out_path = Path(__file__).resolve().parent.parent / "docs" / "api" / "public_api_table.rst"
+    out_path.write_text(content, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- streamline top-level exports to core production APIs
- move optional/legacy features into `experimental` and `legacy` submodules
- document public API and add coverage to prevent namespace leaks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c9e0b8740832ab0f553f12e97a74b