### PR TITLE
Add warnings for experimental Signal protocol demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,12 @@ policies on backend usage.
 - **Private Key Protection**: Always supply a password when saving private keys to PEM
   with `serialize_private_key` or `KeyManager.save_private_key`.
 
+### Signal Protocol: Experimental Demo Only
+
+This module is not a full Signal implementation. It lacks critical security
+properties and should never be used for production or high-assurance
+messaging.
+
 ---
 
 ## Migration to Pipeline API
@@ -572,8 +578,8 @@ print(ec_decrypt(cipher, priv))
 from cryptography_suite.experimental.signal import initialize_signal_session
 
 sender, receiver = initialize_signal_session()
-msg: bytes = sender.encrypt(b"hi")
-print(receiver.decrypt(msg))
+demo_msg: bytes = sender.encrypt(b"demo")  # demo-only data
+print(receiver.decrypt(demo_msg))
 ```
 
 ## Hashing

--- a/cryptography_suite/experimental/signal/__init__.py
+++ b/cryptography_suite/experimental/signal/__init__.py
@@ -1,11 +1,16 @@
-"""Simplified Signal protocol implementation.
+"""Simplified Signal protocol demonstration (X3DH + Double Ratchet).
 
-.. warning:: This module is experimental and not ready for production use.
+This implementation is a simplified demonstration of the Signal protocol
+(X3DH + Double Ratchet) and is NOT production-grade. It omits important
+features (multi-session, message headers, robust identity binding, etc.)
+and is suitable only for research, prototyping, or education. Do not use
+for real secure messaging.
 """
 
 from __future__ import annotations
 
 import os
+import warnings
 from dataclasses import dataclass
 from typing import Tuple
 
@@ -19,6 +24,13 @@ from .init_session import verify_signed_prekey
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
+
+WARNING_MSG = (
+    "Signal Protocol demo: This implementation is not production-grade and "
+    "omits critical features (multi-session, message headers, robust identity "
+    "binding, etc.). Use only for research, prototyping, or education. Do not "
+    "use for real secure messaging."
+)
 
 @dataclass
 class EncryptedMessage:
@@ -103,7 +115,12 @@ def x3dh_responder(
 
 
 class DoubleRatchet:
-    """Minimal Double Ratchet implementation."""
+    """Minimal Double Ratchet implementation.
+
+    This class backs the experimental Signal protocol demo and is **not**
+    production-grade. It omits features like skipped-message handling and
+    header encryption. Suitable only for research, prototyping, or education.
+    """
 
     def __init__(
         self,
@@ -183,7 +200,14 @@ class DoubleRatchet:
 
 
 class SignalSender:
-    """Sender that initiates a Signal session."""
+    """Sender that initiates a Signal session.
+
+    WARNING: This implementation is a simplified demonstration of the Signal
+    protocol (X3DH + Double Ratchet) and is NOT production-grade. It omits
+    important features (multi-session, message headers, robust identity
+    binding, etc.) and is suitable only for research, prototyping, or
+    education. Do not use for real secure messaging.
+    """
 
     def __init__(
         self,
@@ -193,6 +217,7 @@ class SignalSender:
         *,
         use_one_time_prekey: bool = False,
     ) -> None:
+        warnings.warn(WARNING_MSG, UserWarning, stacklevel=2)
         self.identity_priv = identity_priv
         self.identity_pub = identity_priv.public_key()
         self.ephemeral_priv = x25519.X25519PrivateKey.generate()
@@ -274,9 +299,17 @@ class SignalSender:
 
 
 class SignalReceiver:
-    """Receiver that responds to a Signal session."""
+    """Receiver that responds to a Signal session.
+
+    WARNING: This implementation is a simplified demonstration of the Signal
+    protocol (X3DH + Double Ratchet) and is NOT production-grade. It omits
+    important features (multi-session, message headers, robust identity
+    binding, etc.) and is suitable only for research, prototyping, or
+    education. Do not use for real secure messaging.
+    """
 
     def __init__(self, identity_priv: x25519.X25519PrivateKey) -> None:
+        warnings.warn(WARNING_MSG, UserWarning, stacklevel=2)
         self.identity_priv = identity_priv
         self.identity_pub = identity_priv.public_key()
         self.prekey_priv = x25519.X25519PrivateKey.generate()
@@ -346,10 +379,18 @@ class SignalReceiver:
 
 
 def initialize_signal_session(*, use_one_time_prekey: bool = False) -> Tuple[SignalSender, SignalReceiver]:
-    """Convenience function to create two parties with a shared session."""
+    """Convenience function to create two parties with a shared session.
+
+    WARNING: This implementation is a simplified demonstration of the Signal
+    protocol (X3DH + Double Ratchet) and is NOT production-grade. It omits
+    important features (multi-session, message headers, robust identity
+    binding, etc.) and is suitable only for research, prototyping, or
+    education. Do not use for real secure messaging.
+    """
 
     sender_id_priv = x25519.X25519PrivateKey.generate()
     receiver_id_priv = x25519.X25519PrivateKey.generate()
+    warnings.warn(WARNING_MSG, UserWarning, stacklevel=2)
     receiver = SignalReceiver(receiver_id_priv)
     sender = SignalSender(
         sender_id_priv,

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -10,3 +10,10 @@ Security Considerations
 - When serializing private keys with :func:`cryptography_suite.serialize_private_key`
   or using :class:`cryptography_suite.protocols.key_management.KeyManager`, always
   supply a password so the key material is encrypted.
+
+Signal Protocol: Experimental Demo Only
+---------------------------------------
+
+The ``cryptography_suite.experimental.signal`` module is not a full Signal
+implementation. It lacks critical security properties and should never be
+used for production or high-assurance messaging.

--- a/tests/test_interfaces_full.py
+++ b/tests/test_interfaces_full.py
@@ -18,6 +18,8 @@ from cryptography_suite.protocols import (
     SPAKE2Client,
     SPAKE2Server,
 )
+import warnings
+
 from cryptography_suite.experimental.signal import (
     initialize_signal_session,
     SignalReceiver,
@@ -60,7 +62,10 @@ def test_spake2_invalid_peer_message():
 
 
 def test_signal_protocol_valid_flow():
-    sender, receiver = initialize_signal_session()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        sender, receiver = initialize_signal_session()
+    assert any("Signal Protocol" in str(wi.message) for wi in w)
     msg = b"hi"
     enc = sender.encrypt(msg)
     dec = receiver.decrypt(enc)
@@ -71,7 +76,10 @@ def test_signal_protocol_valid_flow():
 
 
 def test_signal_protocol_tampered_ciphertext():
-    sender, receiver = initialize_signal_session()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        sender, receiver = initialize_signal_session()
+    assert any("Signal Protocol" in str(wi.message) for wi in w)
     enc = sender.encrypt(b"hi")
     tampered = types.SimpleNamespace(
         dh_public=enc.dh_public,
@@ -83,8 +91,11 @@ def test_signal_protocol_tampered_ciphertext():
 
 
 def test_signal_protocol_wrong_receiver():
-    sender, receiver = initialize_signal_session()
-    other = SignalReceiver(x25519.X25519PrivateKey.generate())
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        sender, receiver = initialize_signal_session()
+        other = SignalReceiver(x25519.X25519PrivateKey.generate())
+    assert any("Signal Protocol" in str(wi.message) for wi in w)
     other.initialize_session(*sender.handshake_public)
     enc = sender.encrypt(b"hi")
     # other has different keys; decryption should fail

--- a/tests/test_signal_protocol.py
+++ b/tests/test_signal_protocol.py
@@ -1,11 +1,15 @@
 import unittest
+import warnings
 
 from cryptography_suite.experimental.signal import initialize_signal_session
 
 
 class TestSignalProtocol(unittest.TestCase):
     def test_message_exchange_and_ratchet(self):
-        sender, receiver = initialize_signal_session()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            sender, receiver = initialize_signal_session()
+        self.assertTrue(any("Signal Protocol" in str(wi.message) for wi in w))
         first_root = sender.ratchet.root_key
 
         msg1 = b"Hello Bob"

--- a/tests/test_x3dh.py
+++ b/tests/test_x3dh.py
@@ -4,13 +4,17 @@ from cryptography_suite.experimental.signal import (
     x3dh_initiator,
     x3dh_responder,
 )
+import warnings
 from cryptography_suite.asymmetric import generate_x25519_keypair
 from cryptography_suite.errors import SignatureVerificationError
 
 
 class TestX3DH(unittest.TestCase):
     def test_invalid_signed_prekey(self):
-        sender, receiver = initialize_signal_session()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            sender, receiver = initialize_signal_session()
+        self.assertTrue(any("Signal Protocol" in str(wi.message) for wi in w))
         bundle = list(sender.handshake_bundle)
         bundle[3] = b"bad"  # corrupt signature
         with self.assertRaises(SignatureVerificationError):


### PR DESCRIPTION
## Summary
- Warn that the Signal protocol helpers are an educational demo only
- Emit runtime warnings when demo Signal sessions are created
- Document experimental status of Signal in README and security notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d27afcb6c832aa4bf9b79fc9806dd