### PR TITLE
Document SHA-1 default in OTP and warn users

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ policies on backend usage.
   enable it in production.
 - **Private Key Protection**: Always supply a password when saving private keys to PEM
   with `serialize_private_key` or `KeyManager.save_private_key`.
+- **TOTP/HOTP Hash Choice**: TOTP and HOTP use SHA-1 by default for RFC compatibility,
+  but stronger hash functions are supported. These algorithms are suitable for
+  second-factor authentication, NOT as general-purpose hash functions.
 
 ### Signal Protocol: Experimental Demo Only
 

--- a/docs/api/public_api_table.rst
+++ b/docs/api/public_api_table.rst
@@ -221,16 +221,24 @@ Public API Inventory
      - Server-side implementation of the SPAKE2 protocol.
      - Core
    * - ``generate_totp``
-     - Generates a TOTP code based on a shared secret.
+     - Generates a TOTP code based on a shared secret. Uses SHA-1 by default
+       for RFC compatibility; SHA-256 and SHA-512 are supported via
+       parameters. Prefer SHA-256 or higher if supported.
      - Core
    * - ``verify_totp``
-     - Verifies a TOTP code within the allowed time window.
+     - Verifies a TOTP code within the allowed time window. Uses SHA-1 by
+       default; SHA-256 and SHA-512 are supported via parameters. Prefer
+       stronger digests when possible.
      - Core
    * - ``generate_hotp``
-     - Generates an HOTP code based on a shared secret and counter.
+     - Generates an HOTP code based on a shared secret and counter. Uses
+       SHA-1 by default for RFC compatibility; SHA-256 and SHA-512 are
+       supported via parameters. Prefer SHA-256 or higher if supported.
      - Core
    * - ``verify_hotp``
-     - Verifies an HOTP code within the allowed counter window.
+     - Verifies an HOTP code within the allowed counter window. Uses SHA-1
+       by default; SHA-256 and SHA-512 are supported via parameters. Prefer
+       stronger digests when possible.
      - Core
    * - ``base62_encode``
      - Encodes byte data into Base62 format.

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -1,5 +1,6 @@
 import base64
 import unittest
+import warnings
 
 from cryptography_suite.errors import CryptographySuiteError
 
@@ -20,7 +21,9 @@ class TestOTP(unittest.TestCase):
 
     def test_generate_and_verify_totp(self):
         """Test TOTP generation and verification."""
-        totp_code = generate_totp(self.secret, interval=self.interval, digits=self.digits)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            totp_code = generate_totp(self.secret, interval=self.interval, digits=self.digits)
         is_valid = verify_totp(totp_code, self.secret, interval=self.interval, digits=self.digits)
         self.assertTrue(is_valid)
 
@@ -32,7 +35,9 @@ class TestOTP(unittest.TestCase):
 
     def test_generate_and_verify_hotp(self):
         """Test HOTP generation and verification."""
-        hotp_code = generate_hotp(self.secret, self.counter, digits=self.digits)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            hotp_code = generate_hotp(self.secret, self.counter, digits=self.digits)
         is_valid = verify_hotp(hotp_code, self.secret, self.counter, digits=self.digits)
         self.assertTrue(is_valid)
 
@@ -42,30 +47,39 @@ class TestOTP(unittest.TestCase):
         is_valid = verify_hotp(invalid_code, self.secret, self.counter)
         self.assertFalse(is_valid)
 
-    def test_totp_with_different_hash_algorithms(self):
-        """Test TOTP with different hash algorithms."""
-        for algorithm in ['sha1', 'sha256', 'sha512']:
+    def test_totp_with_stronger_hash_algorithms(self):
+        """Test TOTP with SHA-256 and SHA-512."""
+        for algorithm in ['sha256', 'sha512']:
             totp_code = generate_totp(self.secret, algorithm=algorithm)
             is_valid = verify_totp(totp_code, self.secret, algorithm=algorithm)
             self.assertTrue(is_valid)
 
-    def test_hotp_with_different_hash_algorithms(self):
-        """Test HOTP with different hash algorithms."""
-        for algorithm in ['sha1', 'sha256', 'sha512']:
+    def test_hotp_with_stronger_hash_algorithms(self):
+        """Test HOTP with SHA-256 and SHA-512."""
+        for algorithm in ['sha256', 'sha512']:
             hotp_code = generate_hotp(self.secret, self.counter, algorithm=algorithm)
             is_valid = verify_hotp(hotp_code, self.secret, self.counter, algorithm=algorithm)
             self.assertTrue(is_valid)
 
+    def test_default_sha1_warning(self):
+        """Ensure using the default SHA-1 algorithm emits a warning."""
+        with self.assertWarns(UserWarning):
+            generate_totp(self.secret)
+
     def test_generate_totp_with_invalid_secret(self):
         """Test TOTP generation with invalid secret."""
         with self.assertRaises(CryptographySuiteError):
-            generate_totp("invalid_secret")
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                generate_totp("invalid_secret")
 
     def test_generate_hotp_with_invalid_secret(self):
         """Test generating HOTP with invalid secret."""
         invalid_secret = "invalid_base32_secret"
         with self.assertRaises(CryptographySuiteError) as context:
-            generate_hotp(invalid_secret, self.counter)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                generate_hotp(invalid_secret, self.counter)
         self.assertIn("Invalid secret", str(context.exception))
 
 
@@ -77,19 +91,27 @@ class TestOTP(unittest.TestCase):
 
     def test_verify_totp_with_timestamp(self):
         ts = 1000000000
-        code = generate_totp(self.secret, timestamp=ts)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            code = generate_totp(self.secret, timestamp=ts)
         self.assertTrue(verify_totp(code, self.secret, timestamp=ts))
 
     def test_totp_with_missing_padding(self):
         secret = base64.b32encode(b'123456789').decode('utf-8').rstrip('=')
-        code = generate_totp(secret)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            code = generate_totp(secret)
         self.assertTrue(verify_totp(code, secret))
 
     def test_totp_with_lowercase_secret(self):
         secret = self.secret.lower()
-        code = generate_totp(secret)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            code = generate_totp(secret)
         self.assertTrue(verify_totp(code, secret))
 
     def test_totp_invalid_secret_should_raise(self):
         with self.assertRaises(CryptographySuiteError):
-            generate_totp('%%%%')
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                generate_totp('%%%%')


### PR DESCRIPTION
## Summary
- clarify HOTP/TOTP docs to note SHA-1 is the default and recommend SHA-256 or SHA-512
- warn when OTP generators rely on SHA-1 implicitly
- document OTP hash choice in API table and README
- test SHA-256/SHA-512 OTP generation and warn on default

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d7686f81c832a81f61688ce7654c4