### PR TITLE
Expand fuzzing and property tests for core primitives

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -2,6 +2,8 @@
 
 This project includes fuzzing harnesses powered by [Google Atheris](https://github.com/google/atheris) and property-based tests built with [Hypothesis](https://hypothesis.readthedocs.io/).
 
+Atheris primarily helps surface memory corruption and input-parsing issues by exercising functions with large volumes of malformed data. Hypothesis targets semantic properties and invariants such as round-trip encryption and correct error handling. Neither technique can prove cryptographic soundness; they only increase confidence by exploring a wide range of behaviours.
+
 ## Local Usage
 
 ```bash
@@ -19,4 +21,20 @@ Coverage from fuzzing is merged with the standard coverage report when possible.
 
 ## Limitations
 
-Argon2-based functionality is skipped when the underlying cryptography backend does not provide Argon2.
+- Atheris focuses on finding crashes and unexpected exceptions. It does not reason about protocol correctness or key strength.
+- Hypothesis checks logical properties but cannot exhaust the entire input space.
+- No fuzzing strategy can guarantee cryptographic security.
+- Argon2-based functionality is skipped when the underlying cryptography backend does not provide Argon2.
+
+## Test Coverage Matrix
+
+| Primitive        | Unit Tests                     | Fuzz Harness           | Property Tests                |
+|------------------|--------------------------------|------------------------|-------------------------------|
+| AES-GCM          | `tests/test_encryption.py`     | `fuzz/fuzz_aes.py`     | `tests/test_aes_property.py`  |
+| RSA              | `tests/test_asymmetric.py`     | `fuzz/fuzz_rsa.py`     | `tests/test_rsa_property.py`  |
+| ECIES            | `tests/test_asymmetric.py`     | `fuzz/fuzz_ecies.py`   | `tests/test_ecies_property.py`|
+| Pipeline modules | `tests/test_pipeline.py`       | `fuzz/fuzz_pipeline.py`| `tests/test_pipeline_property.py` |
+
+## Contribution Requirements
+
+New cryptographic primitives or backend implementations must include unit tests, an Atheris fuzzing harness, and Hypothesis property tests before they can be merged.

--- a/fuzz/fuzz_ecies.py
+++ b/fuzz/fuzz_ecies.py
@@ -1,0 +1,19 @@
+import atheris
+import sys
+from cryptography_suite.asymmetric import generate_x25519_keypair, ec_encrypt, ec_decrypt
+
+PRIVATE_KEY, PUBLIC_KEY = generate_x25519_keypair()
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    msg = fdp.ConsumeBytes(128)
+    try:
+        ciphertext = ec_encrypt(msg, PUBLIC_KEY, raw_output=True)
+        plaintext = ec_decrypt(ciphertext, PRIVATE_KEY)
+        if plaintext != msg:
+            raise RuntimeError("Roundtrip mismatch")
+    except Exception:
+        pass
+
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()

--- a/fuzz/fuzz_rsa.py
+++ b/fuzz/fuzz_rsa.py
@@ -1,0 +1,20 @@
+import atheris
+import sys
+from cryptography_suite.asymmetric import generate_rsa_keypair
+from cryptography_suite.pipeline import RSAEncrypt, RSADecrypt
+
+PRIVATE_KEY, PUBLIC_KEY = generate_rsa_keypair(key_size=2048)
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    msg = fdp.ConsumeBytes(128)
+    try:
+        ciphertext = RSAEncrypt(public_key=PUBLIC_KEY, raw_output=True).run(msg)
+        plaintext = RSADecrypt(private_key=PRIVATE_KEY).run(ciphertext)
+        if plaintext != msg:
+            raise RuntimeError("Roundtrip mismatch")
+    except Exception:
+        pass
+
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+# Tests
+
+This directory hosts unit tests, fuzz harnesses, and property-based tests for the cryptographic primitives.
+
+## Fuzzing vs Property Testing
+
+- **Fuzzing (Atheris)** explores malformed inputs to trigger crashes and parsing errors.
+- **Property-based tests (Hypothesis)** check semantic properties such as `decrypt(encrypt(x)) == x` and that tampered data or invalid keys raise errors.
+- **Limitations:** These techniques do not prove cryptographic security; they merely increase confidence by exercising many paths.
+
+New algorithms or backend integrations must include unit tests, an Atheris fuzz harness, and Hypothesis property tests before being merged.

--- a/tests/test_ecies_property.py
+++ b/tests/test_ecies_property.py
@@ -1,0 +1,29 @@
+import base64
+import pytest
+from hypothesis import given, strategies as st
+from cryptography_suite.asymmetric import generate_x25519_keypair, ec_encrypt, ec_decrypt
+from cryptography_suite.errors import CryptographySuiteError
+
+PRIVATE_KEY, PUBLIC_KEY = generate_x25519_keypair()
+
+@given(message=st.binary(min_size=1, max_size=256))
+def test_ecies_roundtrip(message: bytes) -> None:
+    ciphertext = ec_encrypt(message, PUBLIC_KEY)
+    plaintext = ec_decrypt(ciphertext, PRIVATE_KEY)
+    assert plaintext == message
+
+@given(message=st.binary(min_size=1, max_size=256))
+def test_ecies_tamper_raises(message: bytes) -> None:
+    ciphertext = ec_encrypt(message, PUBLIC_KEY)
+    data = bytearray(base64.b64decode(ciphertext))
+    if data:
+        data[0] ^= 0xFF
+    tampered = base64.b64encode(bytes(data)).decode()
+    with pytest.raises(CryptographySuiteError):
+        ec_decrypt(tampered, PRIVATE_KEY)
+
+def test_ecies_invalid_keys() -> None:
+    with pytest.raises(TypeError):
+        ec_encrypt(b"data", object())
+    with pytest.raises(TypeError):
+        ec_decrypt(b"data", object())

--- a/tests/test_pipeline_property.py
+++ b/tests/test_pipeline_property.py
@@ -1,0 +1,18 @@
+from hypothesis import given, strategies as st
+from cryptography_suite.pipeline import Pipeline
+
+
+class Upper:
+    def run(self, data: bytes) -> bytes:
+        return data.upper()
+
+
+class Reverse:
+    def run(self, data: bytes) -> bytes:
+        return data[::-1]
+
+
+@given(st.binary())
+def test_pipeline_semantics(data: bytes) -> None:
+    pipe = Pipeline() >> Upper() >> Reverse()
+    assert pipe.run(data) == data.upper()[::-1]

--- a/tests/test_rsa_property.py
+++ b/tests/test_rsa_property.py
@@ -1,0 +1,30 @@
+import base64
+import pytest
+from hypothesis import given, strategies as st
+from cryptography_suite.asymmetric import generate_rsa_keypair
+from cryptography_suite.pipeline import RSAEncrypt, RSADecrypt
+from cryptography_suite.errors import CryptographySuiteError
+
+PRIVATE_KEY, PUBLIC_KEY = generate_rsa_keypair(key_size=2048)
+
+@given(message=st.binary(min_size=1, max_size=256))
+def test_rsa_roundtrip(message: bytes) -> None:
+    ciphertext = RSAEncrypt(public_key=PUBLIC_KEY).run(message)
+    plaintext = RSADecrypt(private_key=PRIVATE_KEY).run(ciphertext)
+    assert plaintext == message
+
+@given(message=st.binary(min_size=1, max_size=256))
+def test_rsa_tamper_raises(message: bytes) -> None:
+    ciphertext = RSAEncrypt(public_key=PUBLIC_KEY).run(message)
+    data = bytearray(base64.b64decode(ciphertext))
+    if data:
+        data[0] ^= 0xFF
+    tampered = base64.b64encode(bytes(data)).decode()
+    with pytest.raises(CryptographySuiteError):
+        RSADecrypt(private_key=PRIVATE_KEY).run(tampered)
+
+def test_rsa_invalid_keys() -> None:
+    with pytest.raises(TypeError):
+        RSAEncrypt(public_key=object()).run(b"data")
+    with pytest.raises(TypeError):
+        RSADecrypt(private_key=object()).run(b"cipher")


### PR DESCRIPTION
## Summary
- add Hypothesis property tests for RSA, ECIES and pipeline modules
- add Atheris fuzz harnesses for RSA and ECIES
- document fuzzing limitations and add test coverage matrix

## Testing
- `pytest tests/test_aes_property.py tests/test_rsa_property.py tests/test_ecies_property.py tests/test_pipeline_property.py`
- `pip install atheris` *(failed: missing clang/libFuzzer)*

------
https://chatgpt.com/codex/tasks/task_e_688d9b7cbd78832a8d074ea02fefc1b9