### PR TITLE
Add PKCS#11 keystore plugin with SoftHSM tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -112,6 +112,43 @@ jobs:
           flag-name: extras
           parallel: true
 
+  pkcs11-tests:
+    name: PKCS11 Tests
+    runs-on: ubuntu-latest
+    services:
+      softhsm:
+        image: mosipid/softhsm
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y softhsm2
+          python -m pip install --upgrade pip
+          pip install -e .[dev,hsm]
+      - name: Init token
+        run: |
+          softhsm2-util --init-token --slot 0 --label "TestToken" --pin 1234 --so-pin 0000
+      - name: Seed keys
+        run: |
+          python - <<'PY'
+import pkcs11
+lib = pkcs11.lib('/usr/lib/softhsm/libsofthsm2.so')
+token = lib.get_token(token_label='TestToken')
+with token.open(user_pin='1234') as session:
+    if not list(session.get_objects()):
+        session.generate_keypair(pkcs11.KeyType.RSA, 2048, label='rsa')
+PY
+      - name: Run pkcs11 tests
+        env:
+          PKCS11_LIBRARY: /usr/lib/softhsm/libsofthsm2.so
+          PKCS11_TOKEN_LABEL: TestToken
+          PKCS11_PIN: 1234
+        run: pytest tests/test_pkcs11_keystore.py
+
   coveralls:
     name: Finalize Coverage Merge
     needs: [tests, tests-extras]

--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -263,15 +263,31 @@ def keystore_cli(argv: list[str] | None = None) -> None:
         for name in list_keystores():
             cls = get_keystore(name)
             status = getattr(cls, "status", "unknown")
-            print(f"{name} ({status})")
+            extra = ""
+            try:
+                ks = cls()
+                label = getattr(ks, "token_label", None)
+                serial = getattr(ks, "token_serial", None)
+                if label and serial:
+                    extra = f" - {label} ({serial})"
+            except Exception:
+                pass
+            print(f"{name} ({status}){extra}")
     elif args.action == "test":
         for name in list_keystores():
             cls = get_keystore(name)
+            extra = ""
             try:
-                ok = cls().test_connection()
+                ks = cls()
+                ok = ks.test_connection()
+                if ok:
+                    label = getattr(ks, "token_label", None)
+                    serial = getattr(ks, "token_serial", None)
+                    if label and serial:
+                        extra = f" - {label} ({serial})"
             except Exception:
                 ok = False
-            print(f"{name}: {'ok' if ok else 'fail'}")
+            print(f"{name}: {'ok' if ok else 'fail'}{extra}")
     elif args.action == "migrate":
         import hashlib
 

--- a/cryptography_suite/keystores/pkcs11.py
+++ b/cryptography_suite/keystores/pkcs11.py
@@ -1,39 +1,166 @@
-"""Sample PKCS#11 keystore plugin skeleton.
-
-This module is not registered by default.  It serves as a template for
-implementing PKCS#11-backed key stores.  Developers should install a
-``python-pkcs11`` compatible library and fill in the methods below.
-"""
+"""PKCS#11 keystore plugin using python-pkcs11."""
 
 from __future__ import annotations
 
+import os
+import threading
+import pathlib
+import contextlib
+import hashlib
 from typing import List
 
-# from . import register_keystore  # Uncomment to register
-# from ..audit import audit_log
+try:
+    import tomllib  # Python 3.11+
+except Exception:  # pragma: no cover - fallback for older Python
+    tomllib = None  # type: ignore
+
+try:  # optional dependency
+    import pkcs11
+    from pkcs11 import Attribute, ObjectClass, KeyType, Mechanism
+except Exception:  # pragma: no cover - dependency missing
+    pkcs11 = None  # type: ignore
+
+from . import register_keystore
+from ..audit import audit_log
 
 
-# @register_keystore("pkcs11")
+@register_keystore("pkcs11")
 class PKCS11KeyStore:
-    """PKCS#11 KeyStore example (not functional)."""
+    """PKCS#11 backed keystore.
+
+    Configuration is loaded from environment variables or ``~/.cryptosuite.toml``:
+
+    - ``PKCS11_LIBRARY`` / ``library_path``
+    - ``PKCS11_TOKEN_LABEL`` / ``token_label``
+    - ``PKCS11_PIN`` / ``pin``
+    """
 
     name = "pkcs11"
-    status = "experimental"
+    status = "production"
 
-    def __init__(self, library_path: str, token_label: str, pin: str) -> None:
-        raise NotImplementedError("PKCS#11 support is a skeleton example")
+    def __init__(self,
+                 library_path: str | None = None,
+                 token_label: str | None = None,
+                 pin: str | None = None) -> None:
+        if pkcs11 is None:  # pragma: no cover - dependency missing
+            raise ImportError("python-pkcs11>=0.9 is required for PKCS11KeyStore")
 
+        library_path, token_label, pin = self._load_config(
+            library_path, token_label, pin
+        )
+
+        self.library_path = library_path
+        self.token_label = token_label
+        self.pin = pin
+
+        self.lib = pkcs11.lib(self.library_path)
+        self.token = self.lib.get_token(token_label=self.token_label)
+        self.token_serial = self.token.serial
+
+        self._session_cache = None
+        self._lock = threading.RLock()
+
+    # ------------------------------------------------------------------
+    # configuration helpers
+    def _load_config(
+        self,
+        library_path: str | None,
+        token_label: str | None,
+        pin: str | None,
+    ) -> tuple[str, str, str]:
+        env = os.environ
+        library_path = library_path or env.get("PKCS11_LIBRARY")
+        token_label = token_label or env.get("PKCS11_TOKEN_LABEL")
+        pin = pin or env.get("PKCS11_PIN")
+
+        if library_path and token_label and pin:
+            return library_path, token_label, pin
+
+        cfg_path = pathlib.Path.home() / ".cryptosuite.toml"
+        if cfg_path.exists() and tomllib is not None:
+            try:
+                cfg = tomllib.loads(cfg_path.read_text())
+                section = cfg.get("pkcs11", {})
+                library_path = library_path or section.get("library_path")
+                token_label = token_label or section.get("token_label")
+                pin = pin or section.get("pin")
+            except Exception:  # pragma: no cover - config errors
+                pass
+
+        if not (library_path and token_label and pin):
+            raise ValueError("Missing PKCS#11 configuration")
+        return library_path, token_label, pin
+
+    # ------------------------------------------------------------------
+    @contextlib.contextmanager
+    def _session(self):
+        """Return a cached session with locking and automatic login."""
+        with self._lock:
+            if self._session_cache is None:
+                self._session_cache = self.token.open(user_pin=self.pin)
+            yield self._session_cache
+
+    def _get_key(self, session, label: str):
+        objs = session.get_objects(
+            {Attribute.CLASS: ObjectClass.PRIVATE_KEY, Attribute.LABEL: label}
+        )
+        for obj in objs:
+            return obj
+        raise FileNotFoundError(label)
+
+    # ------------------------------------------------------------------
     def list_keys(self) -> List[str]:
-        raise NotImplementedError
+        with self._session() as session:
+            keys = []
+            for obj in session.get_objects({Attribute.CLASS: ObjectClass.PRIVATE_KEY}):
+                label = obj.get(Attribute.LABEL)
+                if isinstance(label, bytes):
+                    label = label.decode()
+                keys.append(label)
+            return keys
 
     def test_connection(self) -> bool:
-        raise NotImplementedError
+        try:
+            with self._session():
+                pass
+            return True
+        except Exception:
+            return False
 
+    @audit_log
     def sign(self, key_id: str, data: bytes) -> bytes:
-        raise NotImplementedError
+        with self._session() as session:
+            key = self._get_key(session, key_id)
+            ktype = key.key_type
+            if ktype == KeyType.RSA:
+                mech = Mechanism.SHA256_RSA_PKCS
+                return key.sign(data, mechanism=mech)
+            elif ktype == KeyType.EC:
+                mech = getattr(Mechanism, "ECDSA_SHA256", Mechanism.ECDSA)
+                if mech == Mechanism.ECDSA:
+                    digest = hashlib.sha256(data).digest()
+                    return key.sign(digest, mechanism=Mechanism.ECDSA)
+                return key.sign(data, mechanism=mech)
+            elif getattr(KeyType, "EC_EDWARDS", None) and ktype == KeyType.EC_EDWARDS:
+                mech = getattr(Mechanism, "EDDSA")
+                return key.sign(data, mechanism=mech)
+            raise ValueError("Unsupported key type")
 
+    @audit_log
     def decrypt(self, key_id: str, data: bytes) -> bytes:
+        with self._session() as session:
+            key = self._get_key(session, key_id)
+            if key.key_type != KeyType.RSA:
+                raise ValueError("Key type not suitable for decryption")
+            return key.decrypt(data, mechanism=Mechanism.RSA_PKCS)
+
+    @audit_log
+    def unwrap(self, key_id: str, wrapped_key: bytes) -> bytes:
+        return self.decrypt(key_id, wrapped_key)
+
+    # export/import are intentionally not implemented for HSM-backed keys
+    def export_key(self, key_id: str):  # pragma: no cover - not supported
         raise NotImplementedError
 
-    def unwrap(self, key_id: str, wrapped_key: bytes) -> bytes:
+    def import_key(self, raw: bytes, meta: dict):  # pragma: no cover - not supported
         raise NotImplementedError

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ formally verified, misuse-resistant workflows.
    cli.md
    keystore.md
    keystore_plugins.md
+   pkcs11.md
    formal.md
    fuzzing.md
    mypy_plugin.md

--- a/docs/pkcs11.md
+++ b/docs/pkcs11.md
@@ -1,0 +1,33 @@
+# Using Hardware HSM (PKCS#11)
+
+The suite can interface with hardware security modules via the PKCS#11
+standard.  Install the optional dependency with:
+
+```bash
+pip install cryptography-suite[hsm]
+```
+
+Configuration can be provided through environment variables or a
+`~/.cryptosuite.toml` file under the `[pkcs11]` section:
+
+```toml
+[pkcs11]
+library_path = "/usr/lib/softhsm/libsofthsm2.so"
+token_label = "TestToken"
+pin = "1234"
+```
+
+## SoftHSM Quickstart
+
+SoftHSMv2 offers a software implementation of an HSM for development:
+
+```bash
+softhsm2-util --init-token --slot 0 --label "TestToken" --pin 1234 --so-pin 0000
+cryptography-suite keystore list
+```
+
+## Security Caveats
+
+SoftHSM is **not** a secure HSM.  It stores key material on disk and lacks
+physical protections.  Use a real hardware module in production and ensure
+proper access controls around the PKCS#11 library and PIN management.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ async = ["aiofiles"]
 docs = ["sphinx", "furo", "myst-parser", "sphinxcontrib-mermaid"]
 viz = ["rich", "ipywidgets", "networkx"]
 aws = ["boto3"]
+hsm = ["python-pkcs11>=0.9"]
 
 [project.scripts]
 cryptography-suite = "cryptography_suite.cli:main"

--- a/tests/test_pkcs11_keystore.py
+++ b/tests/test_pkcs11_keystore.py
@@ -1,0 +1,42 @@
+import os
+import pytest
+
+from cryptography_suite.keystores import load_plugins, get_keystore
+
+pkcs11 = pytest.importorskip("pkcs11")
+
+LIB = os.getenv("PKCS11_LIBRARY")
+LABEL = os.getenv("PKCS11_TOKEN_LABEL")
+PIN = os.getenv("PKCS11_PIN", "1234")
+
+if not LIB or not LABEL:
+    pytest.skip("PKCS#11 library not configured", allow_module_level=True)
+
+load_plugins()
+PKCS11KS = get_keystore("pkcs11")
+
+
+@pytest.fixture(scope="session")
+def ks():
+    ks = PKCS11KS(LIB, LABEL, PIN)
+    # seed an RSA key if none exist
+    with ks._session() as session:  # type: ignore[attr-defined]
+        if not ks.list_keys():
+            session.generate_keypair(pkcs11.KeyType.RSA, 2048, label="rsa")
+    return ks
+
+
+def test_list_keys(ks):
+    keys = ks.list_keys()
+    assert keys
+    assert all(isinstance(k, str) for k in keys)
+
+
+def test_sign_decrypt_roundtrip(ks):
+    data = b"hello"
+    with ks._session() as session:  # type: ignore[attr-defined]
+        key = ks._get_key(session, "rsa")  # type: ignore[attr-defined]
+        ciphertext = key.public_key.encrypt(data, mechanism=pkcs11.Mechanism.RSA_PKCS)
+    assert ks.decrypt("rsa", ciphertext) == data
+    sig = ks.sign("rsa", data)
+    assert isinstance(sig, bytes) and sig


### PR DESCRIPTION
## Summary
- add production PKCS#11 keystore with session caching and RSA/ECDSA/Ed25519 support
- expose token label & serial in keystore CLI
- document hardware HSM usage and add SoftHSM based CI tests

## Testing
- `pytest`
