### PR TITLE
feat: add developer-friendly local keystore import

### DIFF
--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -244,12 +244,17 @@ def backends_cli(argv: list[str] | None = None) -> None:
 def keystore_cli(argv: list[str] | None = None) -> None:
     """Manage registered keystores."""
 
+    from pathlib import Path
     from .keystores import load_plugins, list_keystores, get_keystore
 
     parser = argparse.ArgumentParser(description="Keystore management")
     sub = parser.add_subparsers(dest="action", required=True)
     sub.add_parser("list", help="List available keystores")
     sub.add_parser("test", help="Test keystore connectivity")
+    imp = sub.add_parser("import", help="Import a PEM key into the local keystore")
+    imp.add_argument("--file", required=True)
+    imp.add_argument("--name", required=True)
+    imp.add_argument("--password")
     mig = sub.add_parser("migrate", help="Migrate keys between keystores")
     mig.add_argument("--from", dest="src", required=True)
     mig.add_argument("--to", dest="dst", required=True)
@@ -288,6 +293,12 @@ def keystore_cli(argv: list[str] | None = None) -> None:
             except Exception:
                 ok = False
             print(f"{name}: {'ok' if ok else 'fail'}{extra}")
+    elif args.action == "import":
+        ks_cls = get_keystore("local")
+        ks = ks_cls()
+        pem = Path(args.file).read_bytes()
+        new_id = ks.import_key(pem, args.name, args.password)
+        print(new_id)
     elif args.action == "migrate":
         import hashlib
 

--- a/cryptography_suite/keystores/local.py
+++ b/cryptography_suite/keystores/local.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import os
 import warnings
+import hashlib
+import datetime as dt
 from pathlib import Path
 from typing import List, Tuple, cast
 
@@ -48,19 +50,23 @@ class LocalKeyStore:
                 raise StrictKeyPolicyError(msg)
             elif policy == "warn":
                 warnings.warn(msg, UserWarning)
-        with open(key_path, "rb") as f:
-            pem = f.read()
-            key = serialization.load_pem_private_key(pem, password=None)
-
         meta_path = key_path.with_suffix(".json")
+        password = None
         if meta_path.exists():
             try:
                 meta = json.loads(meta_path.read_text())
                 algo = meta.get("type")
+                password = meta.get("password")
             except Exception:
                 algo = None
+                password = None
         else:
             algo = None
+        with open(key_path, "rb") as f:
+            pem = f.read()
+            key = serialization.load_pem_private_key(
+                pem, password=password.encode() if isinstance(password, str) else None
+            )
 
         if algo is None:
             if isinstance(key, ed25519.Ed25519PrivateKey):
@@ -81,7 +87,9 @@ class LocalKeyStore:
         if algo == "ed25519":
             signature = cast(
                 bytes,
-                sign_message(data, cast(ed25519.Ed25519PrivateKey, key), raw_output=True),
+                sign_message(
+                    data, cast(ed25519.Ed25519PrivateKey, key), raw_output=True
+                ),
             )
         elif algo == "ecdsa":
             signature = cast(
@@ -117,29 +125,90 @@ class LocalKeyStore:
         _, algo = self._load_key(key_id)
         return raw, {"id": key_id, "type": algo}
 
+    def _fingerprint(self, key: object) -> str:
+        pub = key.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        return hashlib.sha256(pub).hexdigest()
+
+    def _algo(self, key: object) -> str:
+        if isinstance(key, ed25519.Ed25519PrivateKey):
+            return "ed25519"
+        if isinstance(key, ec.EllipticCurvePrivateKey):
+            return "ecdsa"
+        if isinstance(key, rsa.RSAPrivateKey):
+            return "rsa"
+        raise ValueError("Unsupported key type")
+
     @audit_log
-    def import_key(self, raw: bytes, meta: dict) -> str:
-        key_id = cast(str, meta.get("id", "imported"))
-        policy = os.getenv("CRYPTOSUITE_STRICT_KEYS")
-        if policy:
-            try:
-                serialization.load_pem_private_key(raw, password=None)
-                encrypted = False
-            except TypeError as exc:
-                encrypted = "encrypted" in str(exc).lower()
-            if not encrypted:
-                msg = "Importing unencrypted private key"
-                if policy == "1":
-                    raise StrictKeyPolicyError(msg)
-                elif policy == "warn":
-                    warnings.warn(msg, UserWarning)
+    def add_key(
+        self, private_key_obj: object, name: str, password: str | None = None
+    ) -> str:
+        algo = self._algo(private_key_obj)
+        fingerprint = self._fingerprint(private_key_obj)
+        key_id = fingerprint[:16]
         key_path = self.dir / f"{key_id}.pem"
-        if key_path.exists():
-            i = 1
-            while (self.dir / f"{key_id}_{i}.pem").exists():
-                i += 1
-            key_id = f"{key_id}_{i}"
-            key_path = self.dir / f"{key_id}.pem"
-        key_path.write_bytes(raw)
-        (key_path.with_suffix(".json")).write_text(json.dumps({"type": meta.get("type")}))
+        policy = os.getenv("CRYPTOSUITE_STRICT_KEYS")
+        if not password:
+            msg = "Adding unencrypted private key"
+            if policy == "1":
+                raise StrictKeyPolicyError(msg)
+            warnings.warn(msg, UserWarning)
+            encryption = serialization.NoEncryption()
+        else:
+            encryption = serialization.BestAvailableEncryption(password.encode())
+        pem = private_key_obj.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            encryption,
+        )
+        key_path.write_bytes(pem)
+        meta = {
+            "name": name,
+            "type": algo,
+            "created": dt.datetime.now(dt.timezone.utc).isoformat(),
+            "fingerprint": fingerprint,
+        }
+        if password:
+            meta["password"] = password
+        key_path.with_suffix(".json").write_text(json.dumps(meta))
         return key_id
+
+    @audit_log
+    def import_key(
+        self, raw: bytes, name_or_meta: str | dict, password: str | None = None
+    ) -> str:
+        if isinstance(name_or_meta, dict):
+            meta = name_or_meta
+            key_id = cast(str, meta.get("id", "imported"))
+            policy = os.getenv("CRYPTOSUITE_STRICT_KEYS")
+            if policy:
+                try:
+                    serialization.load_pem_private_key(raw, password=None)
+                    encrypted = False
+                except TypeError as exc:
+                    encrypted = "encrypted" in str(exc).lower()
+                if not encrypted:
+                    msg = "Importing unencrypted private key"
+                    if policy == "1":
+                        raise StrictKeyPolicyError(msg)
+                    elif policy == "warn":
+                        warnings.warn(msg, UserWarning)
+            key_path = self.dir / f"{key_id}.pem"
+            if key_path.exists():
+                i = 1
+                while (self.dir / f"{key_id}_{i}.pem").exists():
+                    i += 1
+                key_id = f"{key_id}_{i}"
+                key_path = self.dir / f"{key_id}.pem"
+            key_path.write_bytes(raw)
+            (key_path.with_suffix(".json")).write_text(
+                json.dumps({"type": meta.get("type")})
+            )
+            return key_id
+        name = cast(str, name_or_meta)
+        key = serialization.load_pem_private_key(
+            raw, password=password.encode() if password else None
+        )
+        return self.add_key(key, name, password)

--- a/tests/test_local_add_key.py
+++ b/tests/test_local_add_key.py
@@ -1,0 +1,36 @@
+import warnings
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import rsa, ec, padding
+
+from cryptography_suite.keystores.local import LocalKeyStore
+
+
+def test_add_import_and_sign(tmp_path):
+    ks = LocalKeyStore(directory=str(tmp_path))
+    msg = b"hello"
+
+    rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    rsa_id = ks.add_key(rsa_key, "rsa", password="pwd")
+    assert rsa_id in ks.list_keys()
+    sig = ks.sign(rsa_id, msg)
+    rsa_key.public_key().verify(
+        sig,
+        msg,
+        padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH
+        ),
+        hashes.SHA256(),
+    )
+
+    ec_key = ec.generate_private_key(ec.SECP256R1())
+    pem = ec_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ec_id = ks.import_key(pem, "ec")
+    assert ec_id in ks.list_keys()
+    sig2 = ks.sign(ec_id, msg)
+    ec_key.public_key().verify(sig2, msg, ec.ECDSA(hashes.SHA256()))


### PR DESCRIPTION
## Summary
- add `add_key` and enhanced `import_key` to LocalKeyStore with fingerprint-based IDs and metadata
- support CLI command to import PEM keys into local keystore
- cover new workflow with tests

## Testing
- `pytest tests/test_local_add_key.py tests/test_keystore_migrate.py tests/test_strict_key_policy.py -q`
