### PR TITLE
Add generated support matrix and docs check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: docs-support-matrix
+
+docs-support-matrix:
+	python tools/generate_support_matrix.py
+	git diff --exit-code README.md

--- a/README.md
+++ b/README.md
@@ -33,6 +33,58 @@
 - **Cross-Platform Compatibility**: Fully compatible with macOS, Linux, and Windows environments.
 - **Rigorous Testing**: ~**99%** test coverage as of v3.0.0, ensuring reliability and robustness.
 
+## 🔍 Support Matrix
+
+<!-- SUPPORT-MATRIX-START -->
+| Feature | Module | Pipeline? | CLI? | Keystore? | Status | Extra |
+| --- | --- | --- | --- | --- | --- | --- |
+| AESGCMDecrypt | cryptography_suite.pipeline | Yes | No | No | stable |  |
+| AESGCMEncrypt | cryptography_suite.pipeline | Yes | No | No | stable |  |
+| BULLETPROOF_AVAILABLE |  | No | Yes | No | experimental |  |
+| FHE_AVAILABLE |  | No | No | No | experimental |  |
+| HandshakeFlowWidget | cryptography_suite.viz.widgets | No | No | No | experimental |  |
+| KeyGraphWidget | cryptography_suite.viz.widgets | No | No | No | experimental |  |
+| PQCRYPTO_AVAILABLE |  | No | Yes | No | experimental |  |
+| RSADecrypt | cryptography_suite.pipeline | Yes | No | No | stable |  |
+| RSAEncrypt | cryptography_suite.pipeline | Yes | No | No | stable |  |
+| SIGNAL_AVAILABLE |  | No | No | No | experimental |  |
+| SPHINCS_AVAILABLE |  | No | Yes | No | experimental |  |
+| SessionTimelineWidget | cryptography_suite.viz.widgets | No | No | No | experimental |  |
+| SignalReceiver | cryptography_suite.experimental.signal | No | No | No | experimental |  |
+| SignalSender | cryptography_suite.experimental.signal | No | No | No | experimental |  |
+| ZKSNARK_AVAILABLE |  | No | Yes | No | experimental |  |
+| blake3_hash_v2 | cryptography_suite.hashing | No | No | No | deprecated |  |
+| bls_aggregate | cryptography_suite.asymmetric.bls | No | No | No | deprecated |  |
+| bls_aggregate_verify | cryptography_suite.asymmetric.bls | No | No | No | deprecated |  |
+| bls_sign | cryptography_suite.asymmetric.bls | No | No | No | deprecated |  |
+| bls_verify | cryptography_suite.asymmetric.bls | No | No | No | deprecated |  |
+| bulletproof |  | No | Yes | No | experimental |  |
+| dilithium_sign |  | No | No | No | experimental |  |
+| dilithium_verify |  | No | No | No | experimental |  |
+| fhe_add | cryptography_suite.homomorphic | No | No | No | experimental |  |
+| fhe_decrypt | cryptography_suite.homomorphic | No | No | No | experimental |  |
+| fhe_encrypt | cryptography_suite.homomorphic | No | No | No | experimental |  |
+| fhe_keygen | cryptography_suite.homomorphic | No | No | No | experimental |  |
+| fhe_load_context | cryptography_suite.homomorphic | No | No | No | experimental |  |
+| fhe_multiply | cryptography_suite.homomorphic | No | No | No | experimental |  |
+| fhe_serialize_context | cryptography_suite.homomorphic | No | No | No | experimental |  |
+| generate_bls_keypair | cryptography_suite.asymmetric.bls | No | No | No | deprecated |  |
+| generate_dilithium_keypair |  | No | Yes | No | experimental |  |
+| generate_ed448_keypair | cryptography_suite.asymmetric.signatures | No | No | No | deprecated |  |
+| generate_kyber_keypair |  | No | Yes | No | experimental |  |
+| generate_sphincs_keypair |  | No | Yes | No | experimental |  |
+| initialize_signal_session | cryptography_suite.experimental.signal | No | No | No | experimental |  |
+| kyber_decrypt |  | No | No | No | experimental |  |
+| kyber_encrypt |  | No | No | No | experimental |  |
+| sign_message_ed448 | cryptography_suite.asymmetric.signatures | No | No | No | deprecated |  |
+| sphincs_sign |  | No | No | No | experimental |  |
+| sphincs_verify |  | No | No | No | experimental |  |
+| verify_signature_ed448 | cryptography_suite.asymmetric.signatures | No | No | No | deprecated |  |
+| x3dh_initiator | cryptography_suite.experimental.signal | No | No | No | experimental |  |
+| x3dh_responder | cryptography_suite.experimental.signal | No | No | No | experimental |  |
+| zksnark |  | No | Yes | No | experimental |  |
+<!-- SUPPORT-MATRIX-END -->
+
 ---
 
 ## ✨ Version 3.0.0 Highlights

--- a/tools/generate_support_matrix.py
+++ b/tools/generate_support_matrix.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Generate support matrix for cryptography-suite features."""
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _load_cli_text() -> str:
+    return Path("cryptography_suite/cli.py").read_text(encoding="utf-8").lower()
+
+
+def _load_keystore_text() -> str:
+    folder = Path("cryptography_suite/keystores")
+    parts = [p.read_text(encoding="utf-8").lower() for p in folder.glob("*.py")]
+    return "\n".join(parts)
+
+
+def _get_module(obj: object | None) -> str:
+    return getattr(obj, "__module__", "")
+
+
+def collect_features() -> dict[str, dict[str, str]]:
+    features: dict[str, dict[str, str]] = {}
+
+    pipeline = importlib.import_module("cryptography_suite.pipeline")
+    for name, cls in pipeline.MODULE_REGISTRY.items():
+        features[name] = {
+            "module": _get_module(cls),
+            "pipeline": "Yes",
+            "status": "stable",
+        }
+
+    experimental = importlib.import_module("cryptography_suite.experimental")
+    for name in getattr(experimental, "__all__", []):
+        obj = getattr(experimental, name, None)
+        data = features.setdefault(
+            name,
+            {
+                "module": _get_module(obj),
+                "pipeline": "Yes" if name in features else "No",
+            },
+        )
+        data["module"] = _get_module(obj)
+        data["status"] = "experimental"
+        data.setdefault("pipeline", "No")
+
+    legacy = importlib.import_module("cryptography_suite.legacy")
+    for name in getattr(legacy, "__all__", []):
+        obj = getattr(legacy, name, None)
+        data = features.setdefault(
+            name,
+            {
+                "module": _get_module(obj),
+                "pipeline": "Yes" if name in features else "No",
+            },
+        )
+        data["module"] = _get_module(obj)
+        data["status"] = "deprecated"
+        data.setdefault("pipeline", "No")
+
+    return features
+
+
+def enrich_features(features: dict[str, dict[str, str]]) -> dict[str, dict[str, str]]:
+    cli_text = _load_cli_text()
+    keystore_text = _load_keystore_text()
+    for name, data in features.items():
+        lname = name.lower()
+        data["cli"] = "Yes" if re.search(rf"\b{re.escape(lname)}\b", cli_text) else "No"
+        data["keystore"] = (
+            "Yes" if re.search(rf"\b{re.escape(lname)}\b", keystore_text) else "No"
+        )
+        data.setdefault("extra", "")
+    return features
+
+
+def generate_table(features: dict[str, dict[str, str]]) -> str:
+    header = (
+        "| Feature | Module | Pipeline? | CLI? | Keystore? | Status | Extra |\n"
+        "| --- | --- | --- | --- | --- | --- | --- |\n"
+    )
+    rows: list[str] = []
+    for name in sorted(features):
+        data = features[name]
+        rows.append(
+            f"| {name} | {data.get('module', '')} | {data.get('pipeline', 'No')} | "
+            f"{data.get('cli', 'No')} | {data.get('keystore', 'No')} | {data.get('status', '')} | "
+            f"{data.get('extra', '')} |"
+        )
+    return header + "\n".join(rows) + "\n"
+
+
+def update_readme(table: str) -> None:
+    readme = Path(__file__).resolve().parent.parent / "README.md"
+    text = readme.read_text(encoding="utf-8")
+    start = "<!-- SUPPORT-MATRIX-START -->"
+    end = "<!-- SUPPORT-MATRIX-END -->"
+    pattern = re.compile(start + r".*?" + end, re.DOTALL)
+    new_text = pattern.sub(f"{start}\n{table}{end}", text)
+    readme.write_text(new_text, encoding="utf-8")
+
+
+def main() -> None:
+    features = collect_features()
+    features = enrich_features(features)
+    table = generate_table(features)
+    update_readme(table)
+    print(table)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tools/generate_support_matrix.py` to introspect experimental, legacy and pipeline modules and update the README support matrix
- provide `docs-support-matrix` make target for regeneration and sync checking
- document autogenerated support matrix in README

## Testing
- `make docs-support-matrix`
- `pytest -q`
