### PR TITLE
Handle failing keystore plugins

### DIFF
--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -245,7 +245,12 @@ def keystore_cli(argv: list[str] | None = None) -> None:
     """Manage registered keystores."""
 
     from pathlib import Path
-    from .keystores import load_plugins, list_keystores, get_keystore
+    from .keystores import (
+        load_plugins,
+        list_keystores,
+        get_keystore,
+        failed_plugins,
+    )
 
     parser = argparse.ArgumentParser(description="Keystore management")
     sub = parser.add_subparsers(dest="action", required=True)
@@ -263,6 +268,7 @@ def keystore_cli(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     load_plugins()
+    failed = failed_plugins()
 
     if args.action == "list":
         for name in list_keystores():
@@ -278,6 +284,10 @@ def keystore_cli(argv: list[str] | None = None) -> None:
             except Exception:
                 pass
             print(f"{name} ({status}){extra}")
+        for name in failed:
+            print(f"{name} (broken)")
+        if failed:
+            sys.exit(1)
     elif args.action == "test":
         for name in list_keystores():
             cls = get_keystore(name)
@@ -293,6 +303,10 @@ def keystore_cli(argv: list[str] | None = None) -> None:
             except Exception:
                 ok = False
             print(f"{name}: {'ok' if ok else 'fail'}{extra}")
+        for name in failed:
+            print(f"{name}: broken")
+        if failed:
+            sys.exit(1)
     elif args.action == "import":
         ks_cls = get_keystore("local")
         ks = ks_cls()

--- a/docs/keystore_plugins.md
+++ b/docs/keystore_plugins.md
@@ -86,3 +86,11 @@ class PKCS11KeyStore:
 
 Refer to :mod:`cryptography_suite.keystores.pkcs11` for a copy of this
 skeleton in the source tree.
+
+## Third-party plugin troubleshooting
+
+If your plugin fails to load it will be listed as ``broken`` when running
+``cryptography-suite keystore list``. The command exits with a non-zero status
+to highlight the problem but still displays the table of other available
+keystores. Inspect the logged error message and verify that all dependencies
+for the plugin are installed correctly.


### PR DESCRIPTION
## Summary
- make keystore plugin loader resilient to exceptions
- report failed plugins as "broken" in CLI list/test commands
- document third-party keystore troubleshooting and add regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688dc7770384832aa28e369d48455d2f