### PR TITLE
Add Kyber, ECIES, and hybrid pipeline modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,15 @@
 | AESGCMDecrypt | cryptography_suite.pipeline | Yes | No | No | stable |  |
 | AESGCMEncrypt | cryptography_suite.pipeline | Yes | No | No | stable |  |
 | BULLETPROOF_AVAILABLE |  | No | Yes | No | experimental |  |
+| ECIESX25519Decrypt | cryptography_suite.pipeline | Yes | No | No | stable |  |
+| ECIESX25519Encrypt | cryptography_suite.pipeline | Yes | No | No | stable |  |
 | FHE_AVAILABLE |  | No | No | No | experimental |  |
 | HandshakeFlowWidget | cryptography_suite.viz.widgets | No | No | No | experimental |  |
+| HybridDecrypt | cryptography_suite.pipeline | Yes | No | No | stable |  |
+| HybridEncrypt | cryptography_suite.pipeline | Yes | No | No | stable |  |
 | KeyGraphWidget | cryptography_suite.viz.widgets | No | No | No | experimental |  |
+| KyberDecrypt | cryptography_suite.pipeline | Yes | No | No | experimental |  |
+| KyberEncrypt | cryptography_suite.pipeline | Yes | No | No | experimental |  |
 | PQCRYPTO_AVAILABLE |  | No | Yes | No | experimental |  |
 | RSADecrypt | cryptography_suite.pipeline | Yes | No | No | stable |  |
 | RSAEncrypt | cryptography_suite.pipeline | Yes | No | No | stable |  |
@@ -313,6 +319,8 @@ from cryptography_suite.pipeline import Pipeline, AESGCMEncrypt, AESGCMDecrypt
 p = Pipeline() >> AESGCMEncrypt(password="pw") >> AESGCMDecrypt(password="pw")
 assert p.run("secret") == "secret"
 ```
+
+For a catalog of built-in modules see [docs/pipeline_catalog.md](docs/pipeline_catalog.md).
 
 ---
 

--- a/docs/pipeline_catalog.md
+++ b/docs/pipeline_catalog.md
@@ -1,0 +1,16 @@
+# Pipeline Module Catalog
+
+Quick reference of built-in modules for the `Pipeline` DSL.
+
+| Module | Description |
+| --- | --- |
+| AESGCMEncrypt | Encrypt data using AES-GCM. |
+| AESGCMDecrypt | Decrypt AES-GCM data. |
+| RSAEncrypt | Encrypt data using RSA-OAEP. |
+| RSADecrypt | Decrypt RSA-OAEP ciphertext. |
+| ECIESX25519Encrypt | Encrypt data using ECIES with X25519. |
+| ECIESX25519Decrypt | Decrypt ECIES X25519 ciphertext. |
+| HybridEncrypt | Encrypt using hybrid RSA/ECIES + AES-GCM. |
+| HybridDecrypt | Decrypt data produced by HybridEncrypt. |
+| KyberEncrypt | Encrypt data using Kyber and AES-GCM. |
+| KyberDecrypt | Decrypt data produced by KyberEncrypt. |

--- a/docs/pipeline_coverage.md
+++ b/docs/pipeline_coverage.md
@@ -4,6 +4,12 @@
 | ------------- | --------------- |
 | `aes_encrypt` | `AESGCMEncrypt` |
 | `aes_decrypt` | `AESGCMDecrypt` |
+| `ec_encrypt` | `ECIESX25519Encrypt` |
+| `ec_decrypt` | `ECIESX25519Decrypt` |
+| `hybrid_encrypt` | `HybridEncrypt` |
+| `hybrid_decrypt` | `HybridDecrypt` |
+| `kyber_encrypt` | `KyberEncrypt` |
+| `kyber_decrypt` | `KyberDecrypt` |
 | `rsa_encrypt` | `RSAEncrypt`    |
 | `rsa_decrypt` | `RSADecrypt`    |
 

--- a/tests/test_pipeline_roundtrip_property.py
+++ b/tests/test_pipeline_roundtrip_property.py
@@ -1,0 +1,49 @@
+import pytest
+from hypothesis import given, strategies as st
+
+from cryptography_suite.pipeline import (
+    Pipeline,
+    ECIESX25519Encrypt,
+    ECIESX25519Decrypt,
+    HybridEncrypt,
+    HybridDecrypt,
+    KyberEncrypt,
+    KyberDecrypt,
+)
+from cryptography_suite.asymmetric import generate_x25519_keypair, generate_rsa_keypair
+from cryptography_suite.pqc import generate_kyber_keypair, PQCRYPTO_AVAILABLE
+
+PRIVATE_X25519, PUBLIC_X25519 = generate_x25519_keypair()
+RSA_PRIV, RSA_PUB = generate_rsa_keypair(key_size=2048)
+
+if PQCRYPTO_AVAILABLE:
+    KYBER_PUB, KYBER_PRIV = generate_kyber_keypair()
+else:  # pragma: no cover - environment without pqcrypto
+    KYBER_PUB = KYBER_PRIV = b""
+
+
+@given(message=st.binary(min_size=1, max_size=256))
+def test_ecies_pipeline_roundtrip(message: bytes) -> None:
+    pipe = (
+        Pipeline()
+        >> ECIESX25519Encrypt(public_key=PUBLIC_X25519)
+        >> ECIESX25519Decrypt(private_key=PRIVATE_X25519)
+    )
+    assert pipe.run(message) == message
+
+
+@given(message=st.binary(min_size=1, max_size=256))
+def test_hybrid_pipeline_roundtrip(message: bytes) -> None:
+    pipe = (
+        Pipeline() >> HybridEncrypt(public_key=RSA_PUB) >> HybridDecrypt(private_key=RSA_PRIV)
+    )
+    assert pipe.run(message) == message
+
+
+@pytest.mark.skipif(not PQCRYPTO_AVAILABLE, reason="pqcrypto not installed")
+@given(message=st.binary(min_size=1, max_size=256))
+def test_kyber_pipeline_roundtrip(message: bytes) -> None:
+    pipe = (
+        Pipeline() >> KyberEncrypt(public_key=KYBER_PUB) >> KyberDecrypt(private_key=KYBER_PRIV)
+    )
+    assert pipe.run(message) == message


### PR DESCRIPTION
## Summary
- add KyberEncrypt/KyberDecrypt, ECIESX25519Encrypt/Decrypt and HybridEncrypt/Decrypt modules to the pipeline DSL
- document new modules in pipeline catalog, coverage, and README support matrix
- test round-trip encryption/decryption through Pipeline for the new modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dcec02470832a922a5d94dc76a669