### PR TITLE
Add missing dependencies for tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -115,9 +115,8 @@ jobs:
   pkcs11-tests:
     name: PKCS11 Tests
     runs-on: ubuntu-latest
-    services:
-      softhsm:
-        image: mosipid/softhsm
+    env:
+      SOFTHSM2_CONF: ${{ runner.temp }}/softhsm2.conf
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -127,6 +126,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y softhsm2
+          mkdir -p "$RUNNER_TEMP/tokens"
+          cat > "$SOFTHSM2_CONF" <<EOF
+          directories.tokendir = $RUNNER_TEMP/tokens
+          objectstore.backend = file
+          slots.removable = true
+          EOF
           python -m pip install --upgrade pip
           pip install -e .[dev,hsm]
       - name: Init token
@@ -135,13 +140,13 @@ jobs:
       - name: Seed keys
         run: |
           python - <<'PY'
-import pkcs11
-lib = pkcs11.lib('/usr/lib/softhsm/libsofthsm2.so')
-token = lib.get_token(token_label='TestToken')
-with token.open(user_pin='1234') as session:
-    if not list(session.get_objects()):
-        session.generate_keypair(pkcs11.KeyType.RSA, 2048, label='rsa')
-PY
+          import pkcs11
+          lib = pkcs11.lib('/usr/lib/softhsm/libsofthsm2.so')
+          token = lib.get_token(token_label='TestToken')
+          with token.open(user_pin='1234') as session:
+              if not list(session.get_objects()):
+                  session.generate_keypair(pkcs11.KeyType.RSA, 2048, label='rsa')
+          PY
       - name: Run pkcs11 tests
         env:
           PKCS11_LIBRARY: /usr/lib/softhsm/libsofthsm2.so

--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from .errors import MissingDependencyError, DecryptionError
 from .protocols import generate_totp
+from typing import cast
 from .hashing import (
     sha3_256_hash,
     sha3_512_hash,
@@ -308,7 +309,9 @@ def keystore_cli(argv: list[str] | None = None) -> None:
         if failed:
             sys.exit(1)
     elif args.action == "import":
-        ks_cls = get_keystore("local")
+        from .keystores.local import LocalKeyStore
+
+        ks_cls = cast(type[LocalKeyStore], get_keystore("local"))
         ks = ks_cls()
         pem = Path(args.file).read_bytes()
         new_id = ks.import_key(pem, args.name, args.password)
@@ -609,8 +612,9 @@ def main(argv: list[str] | None = None) -> None:
         spec = util.spec_from_file_location(
             "cryptography_suite.cli.migrate_keys", mod_path
         )
+        if spec is None or spec.loader is None:
+            raise RuntimeError("Unable to load migrate_keys module")
         module = util.module_from_spec(spec)
-        assert spec.loader is not None
         spec.loader.exec_module(module)
         argv2 = ["--from", args.src, "--to", args.dst]
         if getattr(args, "batch", False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     , "rich"
     , "ipywidgets"
     , "networkx"
+    , "requests"
 ]
 
 [project.optional-dependencies]
@@ -67,7 +68,7 @@ async = ["aiofiles"]
 docs = ["sphinx", "furo", "myst-parser", "sphinxcontrib-mermaid"]
 viz = ["rich", "ipywidgets", "networkx"]
 aws = ["boto3"]
-hsm = ["python-pkcs11>=0.9"]
+hsm = ["python-pkcs11>=0.8.1"]
 
 [project.scripts]
 cryptography-suite = "cryptography_suite.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ rich
 ipywidgets
 networkx
 jinja2
+requests
+hypothesis


### PR DESCRIPTION
## Summary
- ensure requests is installed with the package
- include hypothesis in requirements for property tests
- fix PKCS11 workflow indentation
- relax python-pkcs11 requirement to match available versions
- resolve mypy type-checking failures in keystore and CLI modules
- clean up unused Path import and reorder keystore imports so flake8 passes
- generate a temporary SoftHSM config and token directory in the pkcs11 workflow so tokens can be initialized
- attach public key to PKCS11 private keys and read labels directly via obj.label

## Testing
- `pip install -e '.[dev,hsm]'`
- `flake8`
- `mypy cryptography_suite`
- `pytest tests/test_pkcs11_keystore.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f2414d218832aa64023cc84436254