### PR TITLE
feat: make legacy ciphers optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ For optional functionality install extras:
 pip install "cryptography-suite[pqc,fhe,zk]"
 ```
 
+To include deprecated stream ciphers:
+
+> pip install cryptography-suite[legacy]
+
 The **SPHINCS+** signature helpers are included in the `pqc` extra and are experimental/demo-only.
 
 > **Note**: Requires Python 3.10 or higher. Homomorphic encryption features need `Pyfhel` installed separately if the `fhe` extra is not used.

--- a/cryptography_suite/experimental/ascon.py
+++ b/cryptography_suite/experimental/ascon.py
@@ -6,17 +6,20 @@ This pure-Python implementation is experimental and **not recommended for
 production use**.
 """
 
+import warnings
 from typing import List
 import hmac
+
+from cryptography.utils import CryptographyDeprecationWarning
 
 from ..errors import EncryptionError, DecryptionError
 from ..utils import deprecated
 
-DEPRECATED_MSG = (
-    "This function is deprecated and will be removed in v4.0.0. For reference/education only. DO NOT USE IN PRODUCTION."
+warnings.warn(
+    "Legacy cipher loaded; consider modern alternative",
+    CryptographyDeprecationWarning,
+    stacklevel=2,
 )
-
-raise RuntimeError(DEPRECATED_MSG)
 
 # Original Ascon-128a implementation retained for educational purposes only.
 

--- a/cryptography_suite/experimental/salsa20.py
+++ b/cryptography_suite/experimental/salsa20.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import warnings
+from cryptography.utils import CryptographyDeprecationWarning
+
 from ..errors import EncryptionError, DecryptionError
 from ..constants import CHACHA20_KEY_SIZE
 
-DEPRECATED_MSG = (
-    "This function is deprecated and will be removed in v4.0.0. For reference/education only. DO NOT USE IN PRODUCTION."
+warnings.warn(
+    "Legacy cipher loaded; consider modern alternative",
+    CryptographyDeprecationWarning,
+    stacklevel=2,
 )
-
-raise RuntimeError(DEPRECATED_MSG)
 
 # Reference implementation retained for educational purposes only.
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -4,7 +4,9 @@ Security Considerations
 .. warning::
    The following notes highlight important aspects for using ``cryptography-suite`` safely.
 
-- Experimental/insecure primitives (e.g., ``salsa20_encrypt``, ``ascon_encrypt``) are for research/education only and will be removed in v4.0.0. They are NOT supported for production use. If you depend on them, migrate now.
+ - Experimental/insecure primitives (e.g., ``salsa20_encrypt``, ``ascon_encrypt``) are for research/education only and will be removed in v4.0.0. They are NOT supported for production use. If you depend on them, migrate now.
+
+   > pip install cryptography-suite[legacy]
 - Enabling ``VERBOSE_MODE`` prints derived keys and nonces to stdout. Do **not** enable
   this in production environments.
 - Private keys should always be stored encrypted, either with a strong password or in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ dependencies = [
 pqc = ["pqcrypto"]
 fhe = ["Pyfhel"]
 zk = ["pybulletproofs", "PySNARK"]
-salsa20 = ["pycryptodome"]
 dev = [
     "pytest",
     "pytest-cov",
@@ -69,6 +68,7 @@ docs = ["sphinx", "furo", "myst-parser", "sphinxcontrib-mermaid"]
 viz = ["rich", "ipywidgets", "networkx"]
 aws = ["boto3"]
 hsm = ["python-pkcs11>=0.8.1"]
+legacy = ["salsa20>=0.9", "ascon>=1.2"]
 
 [project.scripts]
 cryptography-suite = "cryptography_suite.cli:main"

--- a/tests/test_ascon.py
+++ b/tests/test_ascon.py
@@ -1,14 +1,20 @@
-import os
+import importlib
 import sys
 import pytest
+from cryptography.utils import CryptographyDeprecationWarning
 
 
-def test_ascon_import_raises():
-    if os.getenv("CRYPTOSUITE_ALLOW_EXPERIMENTAL"):
-        with pytest.raises(RuntimeError):
-            __import__("cryptography_suite.experimental.ascon")
-    else:
-        for mod in ["cryptography_suite.experimental", "cryptography_suite.experimental.ascon"]:
-            sys.modules.pop(mod, None)
-        with pytest.raises(ImportError):
-            __import__("cryptography_suite.experimental.ascon")
+def test_ascon_import_warns(monkeypatch):
+    monkeypatch.setenv("CRYPTOSUITE_ALLOW_EXPERIMENTAL", "1")
+    for mod in ["cryptography_suite.experimental", "cryptography_suite.experimental.ascon"]:
+        sys.modules.pop(mod, None)
+    with pytest.warns(CryptographyDeprecationWarning):
+        importlib.import_module("cryptography_suite.experimental.ascon")
+
+
+def test_ascon_import_requires_flag(monkeypatch):
+    monkeypatch.delenv("CRYPTOSUITE_ALLOW_EXPERIMENTAL", raising=False)
+    for mod in ["cryptography_suite.experimental", "cryptography_suite.experimental.ascon"]:
+        sys.modules.pop(mod, None)
+    with pytest.raises(ImportError):
+        importlib.import_module("cryptography_suite.experimental.ascon")

--- a/tests/test_stream_ciphers.py
+++ b/tests/test_stream_ciphers.py
@@ -1,14 +1,20 @@
-import os
+import importlib
 import sys
 import pytest
+from cryptography.utils import CryptographyDeprecationWarning
 
 
-def test_salsa20_import_raises():
-    if os.getenv("CRYPTOSUITE_ALLOW_EXPERIMENTAL"):
-        with pytest.raises(RuntimeError):
-            __import__("cryptography_suite.experimental.salsa20")
-    else:
-        for mod in ["cryptography_suite.experimental", "cryptography_suite.experimental.salsa20"]:
-            sys.modules.pop(mod, None)
-        with pytest.raises(ImportError):
-            __import__("cryptography_suite.experimental.salsa20")
+def test_salsa20_import_warns(monkeypatch):
+    monkeypatch.setenv("CRYPTOSUITE_ALLOW_EXPERIMENTAL", "1")
+    for mod in ["cryptography_suite.experimental", "cryptography_suite.experimental.salsa20"]:
+        sys.modules.pop(mod, None)
+    with pytest.warns(CryptographyDeprecationWarning):
+        importlib.import_module("cryptography_suite.experimental.salsa20")
+
+
+def test_salsa20_import_requires_flag(monkeypatch):
+    monkeypatch.delenv("CRYPTOSUITE_ALLOW_EXPERIMENTAL", raising=False)
+    for mod in ["cryptography_suite.experimental", "cryptography_suite.experimental.salsa20"]:
+        sys.modules.pop(mod, None)
+    with pytest.raises(ImportError):
+        importlib.import_module("cryptography_suite.experimental.salsa20")

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py311, legacy
+minversion = 4.0
+isolated_build = true
+skip_missing_interpreters = true
+
+[testenv]
+extras = dev
+commands = pytest
+
+[testenv:legacy]
+extras = dev,legacy


### PR DESCRIPTION
## Summary
- expose SALSA20 and ASCON via a new `legacy` optional extra
- warn when SALSA20 or ASCON modules are imported
- document optional legacy extra and provide tox config to test it

## Testing
- `pytest`
- `tox run -e legacy` *(fails: Could not find a version that satisfies the requirement ascon>=1.2)*


------
https://chatgpt.com/codex/tasks/task_e_689052fe9030832aa5020ff6675827ea