### PR TITLE
Enforce safe verbose logging

### DIFF
--- a/cryptography_suite/debug.py
+++ b/cryptography_suite/debug.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 """Verbose debugging utilities for cryptography-suite.
@@ -5,13 +6,21 @@ import os
 WARNING: Never enable in production environments.
 """
 
-VERBOSE_MODE = os.getenv("VERBOSE_MODE", "").lower() not in {"", "0", "false"}
+# Explicit opt-in for verbose logging. This must be combined with a DEBUG
+# logging level; otherwise a runtime error is raised.
+VERBOSE = os.getenv("CRYPTOSUITE_VERBOSE_MODE") == "1"
+
+_logger = logging.getLogger("cryptography-suite")
 
 
 def verbose_print(message: str) -> None:
-    """Print *message* when :data:`VERBOSE_MODE` is enabled."""
-    if VERBOSE_MODE:
-        print(message)
+    """Log *message* when :data:`VERBOSE` is enabled."""
+
+    if not VERBOSE:
+        return
+    if _logger.level > logging.DEBUG:
+        raise RuntimeError("Verbose mode requires DEBUG level")
+    _logger.debug(message)
 
 
-__all__ = ["VERBOSE_MODE", "verbose_print"]
+__all__ = ["VERBOSE", "verbose_print"]

--- a/tests/test_verbose_logging.py
+++ b/tests/test_verbose_logging.py
@@ -1,0 +1,46 @@
+import importlib
+import logging
+import pytest
+import os
+
+
+def test_verbose_requires_debug(monkeypatch):
+    monkeypatch.setenv("CRYPTOSUITE_VERBOSE_MODE", "1")
+    import cryptography_suite.debug as debug
+    import cryptography_suite.symmetric.aes as aes
+    importlib.reload(debug)
+    importlib.reload(aes)
+
+    logger = logging.getLogger("cryptography_suite.symmetric.aes")
+    logger.setLevel(logging.INFO)
+
+    with pytest.raises(RuntimeError):
+        aes.aes_encrypt("secret", "pw", kdf="scrypt")
+
+    # reset modules
+    monkeypatch.setenv("CRYPTOSUITE_VERBOSE_MODE", "0")
+    importlib.reload(debug)
+    importlib.reload(aes)
+
+
+def test_ciphertext_logged_not_plain(monkeypatch, caplog):
+    monkeypatch.setenv("CRYPTOSUITE_VERBOSE_MODE", "1")
+    import cryptography_suite.debug as debug
+    import cryptography_suite.symmetric.aes as aes
+    importlib.reload(debug)
+    importlib.reload(aes)
+
+    logger = logging.getLogger("cryptography_suite.symmetric.aes")
+    logger.setLevel(logging.DEBUG)
+
+    plaintext = "sensitive data"
+    with caplog.at_level(logging.DEBUG, logger="cryptography_suite.symmetric.aes"):
+        aes.aes_encrypt(plaintext, "pw", kdf="scrypt")
+
+    assert "ciphertext=" in caplog.text
+    assert plaintext not in caplog.text
+
+    # reset modules
+    monkeypatch.setenv("CRYPTOSUITE_VERBOSE_MODE", "0")
+    importlib.reload(debug)
+    importlib.reload(aes)


### PR DESCRIPTION
## Summary
- gate verbose logging behind `CRYPTOSUITE_VERBOSE_MODE` and DEBUG level
- log truncated ciphertext in AES/ChaCha helpers instead of plaintext
- add tests covering verbose logging configuration and ciphertext-only output

## Testing
- `pytest`
