### PR TITLE
Add nonce manager and AES-GCM key rotation

### DIFF
--- a/src/crypto_suite/aead.py
+++ b/src/crypto_suite/aead.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from .nonce import KeyRotationRequired, NonceManager
+
+BYTE_LIMIT = 2**54  # 2**24 GiB
+NONCE_SIZE = 12
+
+
+class AesGcm:
+    """AES-GCM wrapper with nonce management and usage limits."""
+
+    def __init__(self, key: bytes, *, byte_limit: int = BYTE_LIMIT) -> None:
+        if len(key) not in {16, 24, 32}:
+            raise ValueError("key must be 128, 192 or 256 bits")
+        self._aesgcm = AESGCM(key)
+        self._byte_limit = byte_limit
+        self._bytes_processed = 0
+        self._lock = threading.Lock()
+
+    def encrypt(
+        self,
+        plaintext: bytes,
+        *,
+        associated_data: Optional[bytes] = None,
+        nonce: Optional[bytes] = None,
+        nonce_manager: Optional[NonceManager] = None,
+    ) -> tuple[bytes, bytes]:
+        """Encrypt ``plaintext`` and return ``(nonce, ciphertext)``."""
+        if nonce_manager is not None:
+            nonce = nonce_manager.next()
+        if nonce is None:
+            raise ValueError("nonce or nonce_manager required")
+        with self._lock:
+            if self._bytes_processed + len(plaintext) > self._byte_limit:
+                raise KeyRotationRequired("byte limit reached")
+            self._bytes_processed += len(plaintext)
+        ciphertext = self._aesgcm.encrypt(nonce, plaintext, associated_data)
+        return nonce, ciphertext
+
+    def decrypt(
+        self,
+        ciphertext: bytes,
+        *,
+        nonce: bytes,
+        associated_data: Optional[bytes] = None,
+        nonce_manager: Optional[NonceManager] = None,
+    ) -> bytes:
+        """Decrypt ``ciphertext`` using ``nonce``."""
+        if nonce_manager is not None:
+            nonce_manager.remember(nonce)
+        with self._lock:
+            if self._bytes_processed + len(ciphertext) > self._byte_limit:
+                raise KeyRotationRequired("byte limit reached")
+            self._bytes_processed += len(ciphertext)
+        return self._aesgcm.decrypt(nonce, ciphertext, associated_data)

--- a/src/crypto_suite/nonce.py
+++ b/src/crypto_suite/nonce.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import threading
+from hmac import compare_digest
+from typing import Iterable, Protocol, Optional
+
+
+class KeyRotationRequired(RuntimeError):
+    """Signal that cryptographic keys should be rotated."""
+
+
+class NonceReuseError(RuntimeError):
+    """Raised when a nonce is reused."""
+
+
+class StateStore(Protocol):
+    """Minimal protocol for storing seen nonces."""
+
+    def __iter__(self) -> Iterable[bytes]:
+        ...
+
+    def add(self, item: bytes) -> None:
+        ...
+
+
+class NonceManager:
+    """Manage monotonically increasing 96-bit nonces."""
+
+    _counter: int
+    _limit: int
+    _storage: StateStore
+    _lock: threading.Lock
+
+    def __init__(
+        self,
+        *,
+        start: int = 0,
+        limit: int = 2**32,
+        storage: Optional[StateStore] = None,
+    ) -> None:
+        if start < 0:
+            raise ValueError("start must be non-negative")
+        if limit <= start:
+            raise ValueError("limit must be greater than start")
+        self._counter = start
+        self._limit = limit
+        self._storage = storage if storage is not None else set()
+        self._lock = threading.Lock()
+
+    def next(self) -> bytes:
+        """Return the next unique 96-bit nonce."""
+        with self._lock:
+            if self._counter >= self._limit:
+                raise KeyRotationRequired("nonce limit reached")
+            value = self._counter
+            self._counter += 1
+            nonce = value.to_bytes(12, "big")
+            self._remember_locked(nonce)
+            return nonce
+
+    def remember(self, nonce: bytes) -> None:
+        """Record an externally provided nonce."""
+        if len(nonce) != 12:
+            raise ValueError("nonce must be 12 bytes")
+        with self._lock:
+            self._remember_locked(nonce)
+
+    def _remember_locked(self, nonce: bytes) -> None:
+        for existing in self._storage:
+            if compare_digest(existing, nonce):
+                raise NonceReuseError("nonce reuse detected")
+        self._storage.add(nonce)

--- a/tests/test_nonce_manager.py
+++ b/tests/test_nonce_manager.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import given, strategies as st
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+# Ensure src directory is importable
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from crypto_suite.nonce import KeyRotationRequired, NonceManager, NonceReuseError
+from crypto_suite.aead import AesGcm
+
+
+@given(st.integers(min_value=1, max_value=100))
+def test_nonce_monotonic(count: int) -> None:
+    manager = NonceManager()
+    nonces = [int.from_bytes(manager.next(), "big") for _ in range(count)]
+    assert nonces == sorted(nonces)
+
+
+@given(st.binary(min_size=12, max_size=12))
+def test_nonce_reuse_detection(nonce: bytes) -> None:
+    manager = NonceManager()
+    manager.remember(nonce)
+    with pytest.raises(NonceReuseError):
+        manager.remember(nonce)
+
+
+@given(st.integers(min_value=1, max_value=10))
+def test_nonce_limit_triggers_rotation(limit: int) -> None:
+    manager = NonceManager(limit=limit)
+    for _ in range(limit):
+        manager.next()
+    with pytest.raises(KeyRotationRequired):
+        manager.next()
+
+
+def test_aead_byte_limit_rotation() -> None:
+    key = AESGCM.generate_key(bit_length=128)
+    aes = AesGcm(key, byte_limit=16)
+    manager = NonceManager()
+    aes.encrypt(b"a" * 8, nonce_manager=manager)
+    with pytest.raises(KeyRotationRequired):
+        aes.encrypt(b"b" * 9, nonce_manager=manager)


### PR DESCRIPTION
## Summary
- add thread-safe NonceManager with reuse protection and rotation signaling
- extend AES-GCM wrapper to use NonceManager and enforce byte limits
- property-based tests for nonce monotonicity, reuse, and rotation limits

## Testing
- `python -m pytest tests/test_nonce_manager.py -q`
- `python -m pytest -q`
