### PR TITLE
Add KEM negotiation with handshake support

### DIFF
--- a/protocol/handshake.proto
+++ b/protocol/handshake.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+package crypto_suite;
+
+message HandshakeHello {
+  // Ordered by preference (strongest first).
+  repeated string supported_kem = 1;
+}
+
+enum Alert {
+  NoCommonKEM = 0;
+}

--- a/src/crypto_suite/__init__.py
+++ b/src/crypto_suite/__init__.py
@@ -1,0 +1,1 @@
+"""Minimal crypto_suite package for handshake tests."""

--- a/src/crypto_suite/handshake.py
+++ b/src/crypto_suite/handshake.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import hashlib
+import hmac
+from typing import List
+
+
+class Alert(Enum):
+    """Alerts that may be raised during the handshake."""
+
+    NoCommonKEM = "NoCommonKEM"
+
+
+class HandshakeError(Exception):
+    """Exception raised when a handshake alert occurs."""
+
+    def __init__(self, alert: Alert):
+        super().__init__(alert.value)
+        self.alert = alert
+
+
+@dataclass
+class HandshakeHello:
+    """Client or server hello message containing supported KEMs."""
+
+    supported_kem: List[str]
+
+    def serialize(self) -> bytes:
+        return ",".join(self.supported_kem).encode()
+
+
+class HandshakeContext:
+    """Maintains a transcript hash for downgrade protection."""
+
+    def __init__(self) -> None:
+        self._hash = hashlib.sha256()
+
+    def add_hello(self, hello: HandshakeHello) -> None:
+        self._hash.update(hello.serialize())
+
+    def finished_mac(self, secret: bytes, chosen_kem: str) -> bytes:
+        self._hash.update(chosen_kem.encode())
+        return hmac.new(secret, self._hash.digest(), hashlib.sha256).digest()
+
+
+def negotiate_kem(client: HandshakeHello, server: HandshakeHello) -> str:
+    """Return the first common KEM in server preference order.
+
+    Raises:
+        HandshakeError: if no common KEM exists.
+    """
+
+    for kem in server.supported_kem:
+        if kem in client.supported_kem:
+            return kem
+    raise HandshakeError(Alert.NoCommonKEM)

--- a/tests/test_kem_negotiation.py
+++ b/tests/test_kem_negotiation.py
@@ -1,0 +1,29 @@
+import pytest
+
+from crypto_suite.handshake import (
+    HandshakeHello,
+    HandshakeContext,
+    HandshakeError,
+    Alert,
+    negotiate_kem,
+)
+
+
+def test_mismatched_lists_abort():
+    client = HandshakeHello(["Kyber512"])
+    server = HandshakeHello(["Dilithium3"])
+    with pytest.raises(HandshakeError) as exc:
+        negotiate_kem(client, server)
+    assert exc.value.alert is Alert.NoCommonKEM
+
+
+def test_intersection_picks_strongest():
+    client = HandshakeHello(["X25519", "Kyber512", "Dilithium3"])
+    server = HandshakeHello(["Dilithium3", "Kyber512", "X25519"])
+    chosen = negotiate_kem(client, server)
+    assert chosen == "Dilithium3"
+    ctx = HandshakeContext()
+    ctx.add_hello(client)
+    ctx.add_hello(server)
+    mac = ctx.finished_mac(b"secret", chosen)
+    assert isinstance(mac, bytes)


### PR DESCRIPTION
## Summary
- extend handshake proto to advertise ordered `supported_kem`
- implement KEM negotiation and transcript-bound Finished MAC
- test KEM mismatch and strongest common selection

## Testing
- `PYTHONPATH=src pytest tests/test_kem_negotiation.py -q`
