### PR TITLE
Use coverage run for tests and clarify config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,16 +1,10 @@
 [run]
 branch = True
+source = cryptography_suite
 omit =
-    src/crypto_suite/aead.py
-    src/crypto_suite/experimental/*
+    cryptography_suite/experimental/*
+    cryptography_suite/tests/*
+    src/cryptography_suite/*
 
 [report]
-omit =
-    tests/*
-    */tests/*
-
-[paths]
-source =
-    cryptography_suite
-    source/cryptography_suite
-    */site-packages/cryptography_suite
+fail_under = 96

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,15 +19,16 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[dev]
       - name: Run tests
-        run: |
-          pytest --cov=crypto_suite --cov-report=xml
-      - name: Fail if coverage < 95 %
+        run: coverage run -m pytest cryptography_suite tests
+      - name: Generate coverage XML
+        run: coverage xml
+      - name: Fail if coverage < 96 %
         run: |
           python - <<'PY'
           import xml.etree.ElementTree as ET, sys
           cov = float(ET.parse('coverage.xml').getroot().attrib['line-rate']) * 100
           print(f"Total coverage: {cov:.2f}%")
-          if cov < 95:
+          if cov < 96:
             print('Coverage threshold not met')
             sys.exit(1)
           PY

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skip_missing_interpreters = true
 
 [testenv]
 extras = dev
-commands = pytest
+commands = coverage run -m pytest cryptography_suite tests
 
 [testenv:legacy]
 extras = dev,legacy


### PR DESCRIPTION
## Summary
- Replace `.coveragerc` with explicit run/report sections targeting the flat `cryptography_suite` layout
- Run tests through `coverage run -m pytest` in CI and tox, generating an XML report and enforcing a 96% threshold

## Testing
- `pytest -q`
- `coverage run -m pytest cryptography_suite tests`
- `coverage report | tail -n 1`
- `coverage xml`
