### PR TITLE
Add nonce manager and AES-GCM byte limits

### DIFF
--- a/cryptography_suite/aead.py
+++ b/cryptography_suite/aead.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
-from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+import threading
+from typing import Optional
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM, ChaCha20Poly1305
 
 from .constants import CHACHA20_KEY_SIZE, NONCE_SIZE
+from .exceptions import KeyRotationRequired
+from .nonce import NonceManager
 
-__all__ = ["chacha20_encrypt_aead", "chacha20_decrypt_aead"]
+__all__ = ["chacha20_encrypt_aead", "chacha20_decrypt_aead", "AESGCMContext"]
 
 
 def chacha20_encrypt_aead(
@@ -44,3 +49,61 @@ def chacha20_decrypt_aead(
     cipher = ChaCha20Poly1305(key)
     ad = associated_data or b""
     return cipher.decrypt(nonce, ciphertext, ad)
+
+
+BYTE_LIMIT = 2**54  # 2**24 GiB
+
+
+class AESGCMContext:
+    """AES-GCM wrapper with nonce management and usage limits."""
+
+    def __init__(self, key: bytes, *, byte_limit: int = BYTE_LIMIT) -> None:
+        if len(key) not in {16, 24, 32}:
+            raise ValueError("key must be 128, 192 or 256 bits")
+        self._aesgcm = AESGCM(key)
+        self._byte_limit = byte_limit
+        self._bytes_processed = 0
+        self._lock = threading.Lock()
+
+    @property
+    def bytes_processed(self) -> int:
+        return self._bytes_processed
+
+    def encrypt(
+        self,
+        plaintext: bytes,
+        *,
+        nonce: Optional[bytes] = None,
+        associated_data: Optional[bytes] = None,
+        nm: Optional[NonceManager] = None,
+    ) -> tuple[bytes, bytes]:
+        """Encrypt ``plaintext`` and return ``(nonce, ciphertext)``."""
+        if nm is not None:
+            if nonce is None:
+                nonce = nm.next()
+            nm.remember(nonce)
+        elif nonce is None:
+            raise ValueError("nonce or NonceManager required")
+        with self._lock:
+            if self._bytes_processed + len(plaintext) > self._byte_limit:
+                raise KeyRotationRequired("byte limit reached")
+            self._bytes_processed += len(plaintext)
+        ciphertext = self._aesgcm.encrypt(nonce, plaintext, associated_data)
+        return nonce, ciphertext
+
+    def decrypt(
+        self,
+        ciphertext: bytes,
+        *,
+        nonce: bytes,
+        associated_data: Optional[bytes] = None,
+        nm: Optional[NonceManager] = None,
+    ) -> bytes:
+        """Decrypt ``ciphertext`` using ``nonce``."""
+        if nm is not None:
+            nm.remember(nonce)
+        with self._lock:
+            if self._bytes_processed + len(ciphertext) > self._byte_limit:
+                raise KeyRotationRequired("byte limit reached")
+            self._bytes_processed += len(ciphertext)
+        return self._aesgcm.decrypt(nonce, ciphertext, associated_data)

--- a/cryptography_suite/exceptions.py
+++ b/cryptography_suite/exceptions.py
@@ -1,0 +1,12 @@
+"""Custom exceptions for cryptographic misuse detection."""
+from __future__ import annotations
+
+__all__ = ["NonceReuseError", "KeyRotationRequired"]
+
+
+class NonceReuseError(RuntimeError):
+    """Raised when a nonce is reused."""
+
+
+class KeyRotationRequired(RuntimeError):
+    """Raised when cryptographic keys must be rotated."""

--- a/cryptography_suite/nonce.py
+++ b/cryptography_suite/nonce.py
@@ -1,0 +1,50 @@
+"""Nonce management utilities."""
+from __future__ import annotations
+
+import threading
+
+from .exceptions import KeyRotationRequired, NonceReuseError
+
+NONCE_SIZE = 12
+
+__all__ = ["NonceManager"]
+
+
+class NonceManager:
+    """Manage monotonically increasing nonces and detect reuse.
+
+    Parameters
+    ----------
+    start:
+        Initial counter value.
+    limit:
+        Maximum number of nonces allowed before requiring key rotation.
+    """
+
+    def __init__(self, *, start: int = 0, limit: int = 2**32) -> None:
+        if start < 0:
+            raise ValueError("start must be non-negative")
+        if limit <= start:
+            raise ValueError("limit must be greater than start")
+        self._counter = start
+        self._limit = limit
+        self._seen: set[bytes] = set()
+        self._lock = threading.Lock()
+
+    def next(self) -> bytes:
+        """Return the next 12-byte big-endian counter value."""
+        with self._lock:
+            if self._counter >= self._limit:
+                raise KeyRotationRequired("nonce limit reached")
+            value = self._counter
+            self._counter += 1
+        return value.to_bytes(NONCE_SIZE, "big")
+
+    def remember(self, nonce: bytes) -> None:
+        """Record ``nonce`` and ensure it has not been used before."""
+        if len(nonce) != NONCE_SIZE:
+            raise ValueError("nonce must be 12 bytes")
+        with self._lock:
+            if nonce in self._seen:
+                raise NonceReuseError("nonce reuse detected")
+            self._seen.add(nonce)


### PR DESCRIPTION
## Summary
- add `NonceManager` and misuse exceptions
- enforce nonce reuse and byte limits in `AESGCMContext`
- cover nonce manager lifecycle with tests

## Testing
- `pytest tests/test_nonce_manager.py -q`
- `pytest -q` *(fails: FileNotFoundError for console scripts)*
