### PR TITLE
Add explicit KEM negotiation with downgrade protection

### DIFF
--- a/protocol/handshake.proto
+++ b/protocol/handshake.proto
@@ -3,7 +3,11 @@ package crypto_suite;
 
 message HandshakeHello {
   // Ordered by preference (strongest first).
-  repeated string supported_kem = 1;
+  repeated string supported_kem = 5;
+}
+
+message HandshakeSelected {
+  string chosen_kem = 6;
 }
 
 enum Alert {

--- a/src/crypto_suite/handshake.py
+++ b/src/crypto_suite/handshake.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 import hashlib
 import hmac
@@ -25,10 +25,22 @@ class HandshakeError(Exception):
 class HandshakeHello:
     """Client or server hello message containing supported KEMs."""
 
-    supported_kem: List[str]
+    supported_kem: List[str] = field(
+        default_factory=lambda: ["Dilithium3", "Kyber512", "X25519"]
+    )
 
     def serialize(self) -> bytes:
         return ",".join(self.supported_kem).encode()
+
+
+@dataclass
+class HandshakeSelected:
+    """Server's selection of the agreed KEM."""
+
+    chosen_kem: str
+
+    def serialize(self) -> bytes:
+        return self.chosen_kem.encode()
 
 
 class HandshakeContext:
@@ -40,19 +52,21 @@ class HandshakeContext:
     def add_hello(self, hello: HandshakeHello) -> None:
         self._hash.update(hello.serialize())
 
-    def finished_mac(self, secret: bytes, chosen_kem: str) -> bytes:
-        self._hash.update(chosen_kem.encode())
+    def add_selected(self, selected: HandshakeSelected) -> None:
+        self._hash.update(selected.serialize())
+
+    def finished_mac(self, secret: bytes) -> bytes:
         return hmac.new(secret, self._hash.digest(), hashlib.sha256).digest()
 
 
 def negotiate_kem(client: HandshakeHello, server: HandshakeHello) -> str:
-    """Return the first common KEM in server preference order.
+    """Return the first common KEM in client preference order.
 
     Raises:
         HandshakeError: if no common KEM exists.
     """
 
-    for kem in server.supported_kem:
-        if kem in client.supported_kem:
+    for kem in client.supported_kem:
+        if kem in server.supported_kem:
             return kem
     raise HandshakeError(Alert.NoCommonKEM)

--- a/tests/test_kem_negotiation.py
+++ b/tests/test_kem_negotiation.py
@@ -2,11 +2,26 @@ import pytest
 
 from crypto_suite.handshake import (
     HandshakeHello,
+    HandshakeSelected,
     HandshakeContext,
     HandshakeError,
     Alert,
     negotiate_kem,
 )
+
+
+def test_intersection_picks_strongest():
+    client = HandshakeHello()
+    server = HandshakeHello(["X25519", "Kyber512", "Dilithium3"])
+    assert client.supported_kem == ["Dilithium3", "Kyber512", "X25519"]
+    chosen = negotiate_kem(client, server)
+    assert chosen == "Dilithium3"
+    ctx = HandshakeContext()
+    ctx.add_hello(client)
+    ctx.add_hello(server)
+    ctx.add_selected(HandshakeSelected(chosen))
+    mac = ctx.finished_mac(b"secret")
+    assert isinstance(mac, bytes)
 
 
 def test_mismatched_lists_abort():
@@ -17,13 +32,22 @@ def test_mismatched_lists_abort():
     assert exc.value.alert is Alert.NoCommonKEM
 
 
-def test_intersection_picks_strongest():
-    client = HandshakeHello(["X25519", "Kyber512", "Dilithium3"])
-    server = HandshakeHello(["Dilithium3", "Kyber512", "X25519"])
+def test_transcript_mac_detects_tampered_kem():
+    client = HandshakeHello()
+    server = HandshakeHello(["Dilithium3", "Kyber512"])
     chosen = negotiate_kem(client, server)
-    assert chosen == "Dilithium3"
-    ctx = HandshakeContext()
-    ctx.add_hello(client)
-    ctx.add_hello(server)
-    mac = ctx.finished_mac(b"secret", chosen)
-    assert isinstance(mac, bytes)
+
+    ctx_ok = HandshakeContext()
+    ctx_ok.add_hello(client)
+    ctx_ok.add_hello(server)
+    ctx_ok.add_selected(HandshakeSelected(chosen))
+    mac_ok = ctx_ok.finished_mac(b"secret")
+
+    tampered = "Kyber512"
+    ctx_bad = HandshakeContext()
+    ctx_bad.add_hello(client)
+    ctx_bad.add_hello(server)
+    ctx_bad.add_selected(HandshakeSelected(tampered))
+    mac_bad = ctx_bad.finished_mac(b"secret")
+
+    assert mac_ok != mac_bad


### PR DESCRIPTION
## Summary
- define `supported_kem` and `chosen_kem` fields in handshake proto messages
- negotiate KEM from client preference order and bind selection into transcript
- test KEM negotiation, no-overlap alert, and tampering detection

## Testing
- `HYPOTHESIS_DISABLE_DEADLINES=1 pytest --cov=crypto_suite.handshake --cov-report=term-missing -q`
