### PR TITLE
Ensure PyPy zeroization and add PyPy-specific test

### DIFF
--- a/tests/test_zeroize_pypy.py
+++ b/tests/test_zeroize_pypy.py
@@ -1,0 +1,29 @@
+import ctypes
+import platform
+
+import pytest
+
+from crypto_suite.utils.zeroize import secure_zero
+
+
+def _get_bytearray_offset() -> int:
+    sample = bytearray(b"x")
+    buf = (ctypes.c_char * len(sample)).from_buffer(sample)
+    offset = ctypes.addressof(buf) - id(sample)
+    if hasattr(buf, "release"):
+        buf.release()
+    return offset
+
+
+PYOBJECT_OFFSET = _get_bytearray_offset()
+
+
+def test_secure_zero_wipes_pypy_frame():
+    if platform.python_implementation() != "PyPy":
+        pytest.xfail("PyPy specific")
+    buf = bytearray(b"secret")
+    size = len(buf)
+    addr = id(buf)
+    secure_zero(buf)
+    dump = ctypes.string_at(addr + PYOBJECT_OFFSET, size)
+    assert dump == b"\x00" * size


### PR DESCRIPTION
## Summary
- implement libc-backed `_memset` helper and use it for PyPy frame wiping
- zeroize PyPy bytearrays via `_memset`, slice deletion, GC, and yield
- add PyPy-specific test that verifies memory is wiped and xfails on CPython

## Testing
- `pytest tests/test_zeroize.py tests/test_zeroize_pypy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689246587e74832abf6e59463c446a34