### PR TITLE
Add hardened build options and wheel CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,20 +24,18 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install build tools
-        env:
-          PIP_BREAK_SYSTEM_PACKAGES: "1"
         run: |
-          python3 -m ensurepip --upgrade
-          python3 -m pip install --upgrade pip
-          python3 -m pip install cibuildwheel==2.18 pip-audit
+          python3 -m ensurepip --upgrade --user
+          python3 -m pip install --upgrade pip --user --break-system-packages
+          python3 -m pip install --user cibuildwheel==2.18 pip-audit --break-system-packages
       - name: Build wheels
         run: python3 -m cibuildwheel --output-dir wheelhouse
       - name: Auditwheel repair
         run: |
-          python3 -m pip install auditwheel
+          python3 -m pip install --user auditwheel --break-system-packages
           mkdir -p dist
           for whl in wheelhouse/*.whl; do
-            auditwheel repair "$whl" -w dist
+            python3 -m auditwheel repair "$whl" -w dist
           done
       - name: pip audit
         run: python3 -m pip_audit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install build tools
+        env:
+          PIP_BREAK_SYSTEM_PACKAGES: "1"
         run: |
           python3 -m ensurepip --upgrade
           python3 -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
             python3 -m pip install --upgrade pip --user --break-system-packages
             python3 -m pip install --user cibuildwheel==2.18 pip-audit --break-system-packages
       - name: Build wheels
+        env:
+          CFLAGS: -O2 -fstack-protector-strong -fPIC
         run: python3 -m cibuildwheel --output-dir wheelhouse
       - name: Auditwheel repair
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,12 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, manylinux_x86_64, musllinux_x86_64]
         include:
+          - os: ubuntu-latest
           - os: manylinux_x86_64
             container: quay.io/pypa/manylinux_2_28_x86_64
           - os: musllinux_x86_64
             container: quay.io/pypa/musllinux_1_2_x86_64
-          - os: ubuntu-latest
-            container: ubuntu:22.04
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     steps:
@@ -39,7 +37,7 @@ jobs:
             auditwheel repair "$whl" -w dist
           done
       - name: pip audit
-        run: python3 -m pip audit
+        run: python3 -m pip_audit
       - name: Install Trivy
         run: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,28 +16,30 @@ jobs:
           - os: musllinux_x86_64
             container: quay.io/pypa/musllinux_1_2_x86_64
           - os: ubuntu-latest
+            container: ubuntu:22.04
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        if: matrix.os == 'ubuntu-latest'
         with:
           python-version: '3.12'
       - name: Install build tools
         run: |
-          python -m pip install --upgrade pip
-          pip install cibuildwheel==2.18 pip-audit
+          python3 -m pip install --upgrade pip
+          python3 -m pip install cibuildwheel==2.18 pip-audit
       - name: Build wheels
-        run: cibuildwheel --output-dir wheelhouse
+        run: python3 -m cibuildwheel --output-dir wheelhouse
       - name: Auditwheel repair
         run: |
-          pip install auditwheel
+          python3 -m pip install auditwheel
           mkdir -p dist
           for whl in wheelhouse/*.whl; do
             auditwheel repair "$whl" -w dist
           done
       - name: pip audit
-        run: pip audit
+        run: python3 -m pip audit
       - name: Install Trivy
         run: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,13 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         with:
           python-version: '3.12'
-      - name: Install build tools
-        run: |
-          python3 -m ensurepip --upgrade --user
-          python3 -m pip install --upgrade pip --user --break-system-packages
-          python3 -m pip install --user cibuildwheel==2.18 pip-audit --break-system-packages
+        - name: Install build tools
+          env:
+            PIP_BREAK_SYSTEM_PACKAGES: "1"
+          run: |
+            python3 -m ensurepip --upgrade --user
+            python3 -m pip install --upgrade pip --user --break-system-packages
+            python3 -m pip install --user cibuildwheel==2.18 pip-audit --break-system-packages
       - name: Build wheels
         run: python3 -m cibuildwheel --output-dir wheelhouse
       - name: Auditwheel repair

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, manylinux_x86_64, musllinux_x86_64]
+        include:
+          - os: manylinux_x86_64
+            container: quay.io/pypa/manylinux_2_28_x86_64
+          - os: musllinux_x86_64
+            container: quay.io/pypa/musllinux_1_2_x86_64
+          - os: ubuntu-latest
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install cibuildwheel==2.18 pip-audit
+      - name: Build wheels
+        run: cibuildwheel --output-dir wheelhouse
+      - name: Auditwheel repair
+        run: |
+          pip install auditwheel
+          mkdir -p dist
+          for whl in wheelhouse/*.whl; do
+            auditwheel repair "$whl" -w dist
+          done
+      - name: pip audit
+        run: pip audit
+      - name: Install Trivy
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+      - name: Trivy fs scan
+        run: trivy fs --severity HIGH,CRITICAL --exit-code 1 .
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }}-wheels
+          path: dist/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Trivy fs scan
         run: trivy fs --severity HIGH,CRITICAL --exit-code 1 .
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-wheels
           path: dist/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
           python-version: '3.12'
       - name: Install build tools
         run: |
+          python3 -m ensurepip --upgrade
           python3 -m pip install --upgrade pip
           python3 -m pip install cibuildwheel==2.18 pip-audit
       - name: Build wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cryptography-suite"
-requires = ["setuptools>=68", "wheel"]
 dynamic = ["version"]
 description = "A comprehensive and secure cryptographic toolkit."
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ dependencies = [
     , "requests"
 ]
 
+[project.entry-points."cryptosuite.aead"]
+"gcm-sst" = "crypto_suite.experimental.aes_gcm_sst:aes_gcm_sst_encrypt"
+
 [project.optional-dependencies]
 pqc = ["pqcrypto"]
 fhe = ["Pyfhel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cryptography-suite"
-version = "3.0.0"
+requires = ["setuptools>=68", "wheel"]
+dynamic = ["version"]
 description = "A comprehensive and secure cryptographic toolkit."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -39,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "cryptography==42.0.4",
+    "cryptography>=44.0.1",
     "py_ecc",
     "spake2",
     "blake3",
@@ -80,6 +81,9 @@ Homepage = "https://github.com/Psychevus/cryptography-suite"
 Documentation = "https://psychevus.github.io/cryptography-suite"
 Source = "https://github.com/Psychevus/cryptography-suite"
 Tracker = "https://github.com/Psychevus/cryptography-suite/issues"
+
+[tool.setuptools.dynamic]
+version = {attr = "cryptography_suite.__version__"}
 
 [tool.setuptools]
 include-package-data = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,8 +70,10 @@ ignore_missing_imports = True
 [mypy-rich.*]
 ignore_missing_imports = True
 
-[metadata]
-version = 3.0.0
+
+[build_ext]
+define = -D_FORTIFY_SOURCE=2
+extra_compile_args = -O2 -fstack-protector-strong -fPIC
 
 [options.entry_points]
 cryptosuite.aead =

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,8 +73,3 @@ ignore_missing_imports = True
 
 [build_ext]
 define = -D_FORTIFY_SOURCE=2
-extra_compile_args = -O2 -fstack-protector-strong -fPIC
-
-[options.entry_points]
-cryptosuite.aead =
-    gcm-sst = crypto_suite.experimental.aes_gcm_sst:aes_gcm_sst_encrypt


### PR DESCRIPTION
## Summary
- add PEP 621 dynamic version metadata and require setuptools and wheel
- enable stack protector and FORTIFY flags for extensions
- build wheels for manylinux and musllinux with security scans

## Testing
- `pip-audit`
- `trivy fs --severity HIGH,CRITICAL --exit-code 1 .`
