### PR TITLE
Enforce AES-GCM message cap and require nonce manager

### DIFF
--- a/cryptography_suite/exceptions.py
+++ b/cryptography_suite/exceptions.py
@@ -9,4 +9,8 @@ class NonceReuseError(RuntimeError):
 
 
 class KeyRotationRequired(RuntimeError):
-    """Raised when cryptographic keys must be rotated."""
+    """Raised when cryptographic keys must be rotated.
+
+    Used when either the byte limit or message cap for an AEAD key has
+    been reached.
+    """

--- a/cryptography_suite/nonce.py
+++ b/cryptography_suite/nonce.py
@@ -19,6 +19,12 @@ class NonceManager:
         Initial counter value.
     limit:
         Maximum number of nonces allowed before requiring key rotation.
+
+    Notes
+    -----
+    The default ``limit`` of :math:`2^{32}` matches the AES-GCM message
+    cap and ensures callers rotate keys before exceeding the safe
+    number of encryptions.
     """
 
     def __init__(self, *, start: int = 0, limit: int = 2**32) -> None:

--- a/tests/test_gcm_limits.py
+++ b/tests/test_gcm_limits.py
@@ -1,0 +1,92 @@
+import pytest
+from hypothesis import given, strategies as st
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from cryptography_suite.aead import (
+    AESGCMContext,
+    chacha20_decrypt_aead,
+    chacha20_encrypt_aead,
+)
+from cryptography_suite.nonce import (
+    KeyRotationRequired,
+    NonceManager,
+    NonceReuseError,
+)
+
+
+@given(st.binary())
+def test_reuse_nonce_raises(pt: bytes) -> None:
+    key = AESGCM.generate_key(bit_length=128)
+    ctx = AESGCMContext(key)
+    nm = NonceManager()
+    nonce, ct = ctx.encrypt(nm=nm, plaintext=pt)
+    with pytest.raises(NonceReuseError):
+        ctx.decrypt(nm=nm, nonce=nonce, ciphertext=ct)
+
+
+@given(st.binary(min_size=0, max_size=32))
+def test_message_cap_enforced(pt: bytes) -> None:
+    key = AESGCM.generate_key(bit_length=128)
+    ctx = AESGCMContext(key)
+    nm = NonceManager(limit=2**33)
+    ctx._msg_counter = 2**32
+    with pytest.raises(KeyRotationRequired):
+        ctx.encrypt(nm=nm, plaintext=pt)
+
+
+@given(st.binary(min_size=1, max_size=16))
+def test_message_cap_independent_of_byte_limit(pt: bytes) -> None:
+    key = AESGCM.generate_key(bit_length=128)
+    ctx = AESGCMContext(key, byte_limit=1024)
+    nm = NonceManager(limit=2**33)
+    ctx._msg_counter = 2**32
+    with pytest.raises(KeyRotationRequired):
+        ctx.encrypt(nm=nm, plaintext=pt)
+    # verify byte accounting still below limit
+    assert ctx.bytes_processed == len(pt)
+
+
+def test_chacha20_aead_roundtrip() -> None:
+    key = b"\x01" * 32
+    nonce = b"\x02" * 12
+    pt = b"hello"
+    ct = chacha20_encrypt_aead(pt, key, nonce)
+    assert chacha20_decrypt_aead(ct, key, nonce) == pt
+
+
+def test_chacha20_aead_validation() -> None:
+    key = b"\x00" * 32
+    nonce = b"\x00" * 12
+    with pytest.raises(ValueError):
+        chacha20_encrypt_aead(b"", key[:-1], nonce)
+    with pytest.raises(ValueError):
+        chacha20_encrypt_aead(b"", key, nonce[:-1])
+    with pytest.raises(ValueError):
+        chacha20_decrypt_aead(b"", key[:-1], nonce)
+    with pytest.raises(ValueError):
+        chacha20_decrypt_aead(b"", key, nonce[:-1])
+
+
+def test_aesgcmcontext_rejects_bad_key() -> None:
+    with pytest.raises(ValueError):
+        AESGCMContext(b"short")
+
+
+def test_aesgcmcontext_decrypt_roundtrip() -> None:
+    key = AESGCM.generate_key(bit_length=128)
+    ctx = AESGCMContext(key)
+    nm_enc = NonceManager()
+    nonce, ct = ctx.encrypt(nm=nm_enc, plaintext=b"msg")
+    nm_dec = NonceManager()
+    pt = ctx.decrypt(nm=nm_dec, nonce=nonce, ciphertext=ct)
+    assert pt == b"msg"
+
+
+def test_aesgcmcontext_decrypt_byte_limit() -> None:
+    key = AESGCM.generate_key(bit_length=128)
+    ctx = AESGCMContext(key, byte_limit=1)
+    nm_enc = NonceManager()
+    nonce, ct = ctx.encrypt(nm=nm_enc, plaintext=b"a")
+    nm_dec = NonceManager()
+    with pytest.raises(KeyRotationRequired):
+        ctx.decrypt(nm=nm_dec, nonce=nonce, ciphertext=ct)


### PR DESCRIPTION
## Summary
- track message count in AESGCMContext and require NonceManager for nonce generation
- document nonce manager's 2^32 limit and expand KeyRotationRequired
- add comprehensive tests covering nonce reuse and message/byte caps

## Testing
- `pytest tests/test_nonce_manager.py tests/test_gcm_limits.py --cov=cryptography_suite.aead --cov=cryptography_suite.nonce --cov=cryptography_suite.exceptions --cov-report=term-missing`
