### PR TITLE
Use libc memset for PyPy zeroization

### DIFF
--- a/tests/test_zeroize_pypy.py
+++ b/tests/test_zeroize_pypy.py
@@ -5,25 +5,18 @@ import pytest
 
 from crypto_suite.utils.zeroize import secure_zero
 
-
-def _get_bytearray_offset() -> int:
-    sample = bytearray(b"x")
-    buf = (ctypes.c_char * len(sample)).from_buffer(sample)
-    offset = ctypes.addressof(buf) - id(sample)
-    if hasattr(buf, "release"):
-        buf.release()
-    return offset
+pytestmark = pytest.mark.skipif(
+    platform.python_implementation() != "PyPy", reason="PyPy specific"
+)
 
 
-PYOBJECT_OFFSET = _get_bytearray_offset()
-
-
-def test_secure_zero_wipes_pypy_frame():
-    if platform.python_implementation() != "PyPy":
-        pytest.xfail("PyPy specific")
-    buf = bytearray(b"secret")
+def test_secure_zero_wipes_pypy_frame() -> None:
+    buf = bytearray(b"TOPSECRET")
     size = len(buf)
-    addr = id(buf)
+    view = (ctypes.c_char * size).from_buffer(buf)
+    addr = ctypes.addressof(view)
     secure_zero(buf)
-    dump = ctypes.string_at(addr + PYOBJECT_OFFSET, size)
+    dump = ctypes.string_at(addr, size)
+    if hasattr(view, "release"):
+        view.release()
     assert dump == b"\x00" * size


### PR DESCRIPTION
## Summary
- Add _pypy_memset that directly invokes libc.memset
- Zeroize PyPy bytearrays via _pypy_memset and cleanup
- Add PyPy-specific test confirming secure_zero wipes frame memory

## Testing
- `pytest tests/test_zeroize.py tests/test_zeroize_pypy.py -q`
