### PR TITLE
Add coverage config, badge, and HTML report artifact

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,6 @@ omit =
 
 [report]
 fail_under = 99
+
+[html]
+directory = htmlcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Generate HTML coverage report
         run: coverage html
       - name: Upload coverage HTML
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-html
           path: htmlcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,10 @@ jobs:
           rate = float(ET.parse('coverage.xml').getroot().attrib['line-rate'])
           sys.exit(0 if rate >= 0.99 else 1)
           PY
+      - name: Generate HTML coverage report
+        run: coverage html
+      - name: Upload coverage HTML
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-html
+          path: htmlcov

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PyPI Version](https://img.shields.io/pypi/v/cryptography-suite)](https://pypi.org/project/cryptography-suite/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/cryptography-suite)](https://pypi.org/project/cryptography-suite/)
 [![Build Status](https://github.com/Psychevus/cryptography-suite/actions/workflows/python-app.yml/badge.svg)](https://github.com/Psychevus/cryptography-suite/actions)
-[![Coverage Status](https://coveralls.io/repos/github/Psychevus/cryptography-suite/badge.svg?branch=main)](https://coveralls.io/github/Psychevus/cryptography-suite?branch=main)
+[![Coverage](https://img.shields.io/badge/Coverage-99%25-brightgreen)](docs/testing.md)
 [![Provenance](https://img.shields.io/badge/provenance-signed-blue)](docs/release_process.md)
 [![Signed Releases](https://img.shields.io/badge/releases-signed-brightgreen)](docs/release_process.md)
 [![Fuzzed & Property-Tested](https://img.shields.io/badge/fuzzed--property--tested-true-brightgreen)](docs/fuzzing.md)


### PR DESCRIPTION
## Summary
- configure coverage HTML output via `.coveragerc`
- show coverage badge in README
- upload HTML coverage report as a workflow artifact

## Testing
- `coverage run -m pytest -p no:cov tests/test_audit.py`
- `coverage html || true`


------
https://chatgpt.com/codex/tasks/task_e_6895d306a6e8832a9ff383d961e35049