### PR TITLE
Add RFC HOTP/TOTP vectors and negative-edge verification tests

### DIFF
--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -115,3 +115,67 @@ class TestOTP(unittest.TestCase):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", UserWarning)
                 generate_totp('%%%%')
+
+    def test_hotp_rfc4226_vectors(self):
+        """Validate HOTP values against RFC 4226 test vectors."""
+        secret = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+        expected = [
+            "755224",
+            "287082",
+            "359152",
+            "969429",
+            "338314",
+            "254676",
+            "287922",
+            "162583",
+            "399871",
+            "520489",
+        ]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            for counter, otp in enumerate(expected):
+                self.assertEqual(generate_hotp(secret, counter, digits=6, algorithm="sha1"), otp)
+
+    def test_totp_rfc6238_vectors(self):
+        """Validate TOTP values against RFC 6238 Appendix B vectors."""
+        timestamps = [59, 1111111109, 1111111111, 1234567890, 2000000000, 20000000000]
+        vectors = {
+            "sha1": {
+                "secret": base64.b32encode(b"12345678901234567890").decode("utf-8"),
+                "expected": ["94287082", "07081804", "14050471", "89005924", "69279037", "65353130"],
+            },
+            "sha256": {
+                "secret": base64.b32encode(b"12345678901234567890123456789012").decode("utf-8"),
+                "expected": ["46119246", "68084774", "67062674", "91819424", "90698825", "77737706"],
+            },
+            "sha512": {
+                "secret": base64.b32encode(
+                    b"1234567890123456789012345678901234567890123456789012345678901234"
+                ).decode("utf-8"),
+                "expected": ["90693936", "25091201", "99943326", "93441116", "38618901", "47863826"],
+            },
+        }
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            for algorithm, vector in vectors.items():
+                for timestamp, otp in zip(timestamps, vector["expected"]):
+                    self.assertEqual(
+                        generate_totp(
+                            vector["secret"],
+                            interval=30,
+                            digits=8,
+                            algorithm=algorithm,
+                            timestamp=timestamp,
+                        ),
+                        otp,
+                    )
+
+    def test_verify_hotp_with_negative_counter_is_fail_safe(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            self.assertFalse(verify_hotp("123456", self.secret, counter=-5, window=2))
+
+    def test_verify_totp_with_negative_timestamp_is_fail_safe(self):
+        self.assertFalse(verify_totp("123456", self.secret, timestamp=-1, window=1))

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -14,7 +14,7 @@ from cryptography_suite.protocols import (
 
 class TestOTP(unittest.TestCase):
     def setUp(self):
-        self.secret = base64.b32encode(b'secret_key').decode('utf-8')
+        self.secret = base64.b32encode(b"secret_key").decode("utf-8")
         self.digits = 6
         self.interval = 30
         self.counter = 1
@@ -23,8 +23,12 @@ class TestOTP(unittest.TestCase):
         """Test TOTP generation and verification."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
-            totp_code = generate_totp(self.secret, interval=self.interval, digits=self.digits)
-        is_valid = verify_totp(totp_code, self.secret, interval=self.interval, digits=self.digits)
+            totp_code = generate_totp(
+                self.secret, interval=self.interval, digits=self.digits
+            )
+        is_valid = verify_totp(
+            totp_code, self.secret, interval=self.interval, digits=self.digits
+        )
         self.assertTrue(is_valid)
 
     def test_verify_totp_with_invalid_code(self):
@@ -49,16 +53,18 @@ class TestOTP(unittest.TestCase):
 
     def test_totp_with_stronger_hash_algorithms(self):
         """Test TOTP with SHA-256 and SHA-512."""
-        for algorithm in ['sha256', 'sha512']:
+        for algorithm in ["sha256", "sha512"]:
             totp_code = generate_totp(self.secret, algorithm=algorithm)
             is_valid = verify_totp(totp_code, self.secret, algorithm=algorithm)
             self.assertTrue(is_valid)
 
     def test_hotp_with_stronger_hash_algorithms(self):
         """Test HOTP with SHA-256 and SHA-512."""
-        for algorithm in ['sha256', 'sha512']:
+        for algorithm in ["sha256", "sha512"]:
             hotp_code = generate_hotp(self.secret, self.counter, algorithm=algorithm)
-            is_valid = verify_hotp(hotp_code, self.secret, self.counter, algorithm=algorithm)
+            is_valid = verify_hotp(
+                hotp_code, self.secret, self.counter, algorithm=algorithm
+            )
             self.assertTrue(is_valid)
 
     def test_default_sha1_warning(self):
@@ -82,7 +88,6 @@ class TestOTP(unittest.TestCase):
                 generate_hotp(invalid_secret, self.counter)
         self.assertIn("Invalid secret", str(context.exception))
 
-
     def test_invalid_algorithm(self):
         with self.assertRaises(CryptographySuiteError):
             generate_totp(self.secret, algorithm="md5")
@@ -97,7 +102,7 @@ class TestOTP(unittest.TestCase):
         self.assertTrue(verify_totp(code, self.secret, timestamp=ts))
 
     def test_totp_with_missing_padding(self):
-        secret = base64.b32encode(b'123456789').decode('utf-8').rstrip('=')
+        secret = base64.b32encode(b"123456789").decode("utf-8").rstrip("=")
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
             code = generate_totp(secret)
@@ -114,7 +119,7 @@ class TestOTP(unittest.TestCase):
         with self.assertRaises(CryptographySuiteError):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", UserWarning)
-                generate_totp('%%%%')
+                generate_totp("%%%%")
 
     def test_hotp_rfc4226_vectors(self):
         """Validate HOTP values against RFC 4226 test vectors."""
@@ -135,7 +140,9 @@ class TestOTP(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
             for counter, otp in enumerate(expected):
-                self.assertEqual(generate_hotp(secret, counter, digits=6, algorithm="sha1"), otp)
+                self.assertEqual(
+                    generate_hotp(secret, counter, digits=6, algorithm="sha1"), otp
+                )
 
     def test_totp_rfc6238_vectors(self):
         """Validate TOTP values against RFC 6238 Appendix B vectors."""
@@ -143,17 +150,40 @@ class TestOTP(unittest.TestCase):
         vectors = {
             "sha1": {
                 "secret": base64.b32encode(b"12345678901234567890").decode("utf-8"),
-                "expected": ["94287082", "07081804", "14050471", "89005924", "69279037", "65353130"],
+                "expected": [
+                    "94287082",
+                    "07081804",
+                    "14050471",
+                    "89005924",
+                    "69279037",
+                    "65353130",
+                ],
             },
             "sha256": {
-                "secret": base64.b32encode(b"12345678901234567890123456789012").decode("utf-8"),
-                "expected": ["46119246", "68084774", "67062674", "91819424", "90698825", "77737706"],
+                "secret": base64.b32encode(b"12345678901234567890123456789012").decode(
+                    "utf-8"
+                ),
+                "expected": [
+                    "46119246",
+                    "68084774",
+                    "67062674",
+                    "91819424",
+                    "90698825",
+                    "77737706",
+                ],
             },
             "sha512": {
                 "secret": base64.b32encode(
                     b"1234567890123456789012345678901234567890123456789012345678901234"
                 ).decode("utf-8"),
-                "expected": ["90693936", "25091201", "99943326", "93441116", "38618901", "47863826"],
+                "expected": [
+                    "90693936",
+                    "25091201",
+                    "99943326",
+                    "93441116",
+                    "38618901",
+                    "47863826",
+                ],
             },
         }
 

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -3,12 +3,11 @@ import unittest
 import warnings
 
 from cryptography_suite.errors import CryptographySuiteError
-
 from cryptography_suite.protocols import (
-    generate_totp,
-    verify_totp,
     generate_hotp,
+    generate_totp,
     verify_hotp,
+    verify_totp,
 )
 
 
@@ -190,7 +189,7 @@ class TestOTP(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
             for algorithm, vector in vectors.items():
-                for timestamp, otp in zip(timestamps, vector["expected"]):
+                for timestamp, otp in zip(timestamps, vector["expected"], strict=False):
                     self.assertEqual(
                         generate_totp(
                             vector["secret"],


### PR DESCRIPTION
### Motivation
- Provide authoritative interoperability tests using RFC 4226 HOTP vectors and RFC 6238 TOTP appendix B vectors to ensure correct OTP generation across algorithms.
- Ensure verification functions behave fail-safe on negative counters/timestamps and window edge-cases to avoid exceptions in hostile or malformed inputs.

### Description
- Added RFC 4226 HOTP test vectors for counters `0..9` and assert exact 6-digit OTPs in `tests/test_otp.py` using `generate_hotp`.
- Added RFC 6238 Appendix B TOTP vectors for `sha1`, `sha256`, and `sha512` with canonical timestamps and assert exact 8-digit OTPs using `generate_totp` with base32 secrets.
- Added negative-edge tests that call `verify_hotp` with a negative `counter` and `verify_totp` with a negative `timestamp` to assert they return `False` (fail-safe) rather than throwing.
- Kept warnings suppression around default SHA-1 warnings to avoid test noise while exercising default behavior.

### Testing
- Ran `python -m pytest -q tests/test_otp.py` and all tests passed (`18 passed`).
- The only modified file is `tests/test_otp.py` which contains the added vector and negative-edge tests.
