### PR TITLE
Tighten Kyber decrypt parsing and deterministic malformed-ciphertext errors

### DIFF
--- a/cryptography_suite/pqc/__init__.py
+++ b/cryptography_suite/pqc/__init__.py
@@ -171,7 +171,9 @@ def kyber_decrypt(
         raise DecryptionError("Invalid ciphertext") from exc
 
 
-def generate_dilithium_keypair(*, sensitive: bool = True) -> Tuple[bytes, KeyVault | bytes]:
+def generate_dilithium_keypair(
+    *, sensitive: bool = True
+) -> Tuple[bytes, KeyVault | bytes]:
     """Generate a Dilithium key pair using level 2 parameters.
 
     When ``sensitive`` is ``True`` (default) the private key is wrapped in
@@ -225,7 +227,9 @@ def dilithium_verify(
         return False
 
 
-def generate_sphincs_keypair(*, sensitive: bool = True) -> Tuple[bytes, KeyVault | bytes]:
+def generate_sphincs_keypair(
+    *, sensitive: bool = True
+) -> Tuple[bytes, KeyVault | bytes]:
     """Generate a SPHINCS+ key pair using a 128-bit security level.
 
     When ``sensitive`` is ``True`` (default) the private key is wrapped in

--- a/cryptography_suite/pqc/__init__.py
+++ b/cryptography_suite/pqc/__init__.py
@@ -8,14 +8,15 @@ implementations from PQClean.
 
 from __future__ import annotations
 
-from typing import Tuple
-from ..errors import EncryptionError, DecryptionError
+import base64
+import hmac
+import os
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from ..errors import DecryptionError, EncryptionError
 from ..symmetric.kdf import derive_hkdf
 from ..utils import KeyVault
-import os
-import hmac
-import base64
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 try:  # pragma: no cover - optional dependency
     from pqcrypto.kem import ml_kem_512, ml_kem_768, ml_kem_1024
@@ -54,7 +55,7 @@ _DILITHIUM_LEVEL_MAP = {2: ml_dsa_44, 3: ml_dsa_65, 5: ml_dsa_87}
 
 def generate_kyber_keypair(
     level: int = 512, *, sensitive: bool = True
-) -> Tuple[bytes, KeyVault | bytes]:
+) -> tuple[bytes, KeyVault | bytes]:
     """Generate a Kyber key pair for the given ``level``.
 
     Parameters
@@ -81,7 +82,7 @@ def kyber_encrypt(
     *,
     level: int = 512,
     raw_output: bool = False,
-) -> Tuple[str | bytes, str | bytes]:
+) -> tuple[str | bytes, str | bytes]:
     """Encrypt ``plaintext`` using Kyber and AES-GCM.
 
     ``level`` selects the ML-KEM security level (512, 768 or 1024).
@@ -173,7 +174,7 @@ def kyber_decrypt(
 
 def generate_dilithium_keypair(
     *, sensitive: bool = True
-) -> Tuple[bytes, KeyVault | bytes]:
+) -> tuple[bytes, KeyVault | bytes]:
     """Generate a Dilithium key pair using level 2 parameters.
 
     When ``sensitive`` is ``True`` (default) the private key is wrapped in
@@ -229,7 +230,7 @@ def dilithium_verify(
 
 def generate_sphincs_keypair(
     *, sensitive: bool = True
-) -> Tuple[bytes, KeyVault | bytes]:
+) -> tuple[bytes, KeyVault | bytes]:
     """Generate a SPHINCS+ key pair using a 128-bit security level.
 
     When ``sensitive`` is ``True`` (default) the private key is wrapped in

--- a/cryptography_suite/pqc/__init__.py
+++ b/cryptography_suite/pqc/__init__.py
@@ -143,25 +143,32 @@ def kyber_decrypt(
         except Exception as exc:  # pragma: no cover - defensive
             raise DecryptionError(f"Invalid shared secret: {exc}") from exc
 
-    if len(ciphertext) < ct_size + 12 + 16:
+    min_ct_len = ct_size + 16 + 12 + 16
+    if len(ciphertext) < min_ct_len:
         raise DecryptionError("Invalid ciphertext")
 
     kem_ct = ciphertext[:ct_size]
     salt = ciphertext[ct_size : ct_size + 16]
     enc = ciphertext[ct_size + 16 :]
     priv = bytes(private_key) if isinstance(private_key, KeyVault) else private_key
-    ss_check = alg.decrypt(priv, kem_ct)
+    try:
+        ss_check = alg.decrypt(priv, kem_ct)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise DecryptionError("Invalid ciphertext") from exc
     if shared_secret is None:
         shared_secret = ss_check
     elif not hmac.compare_digest(ss_check, shared_secret):
         raise DecryptionError("Shared secret mismatch")
 
     key = derive_hkdf(shared_secret, salt, b"kyber-aes-key", 32)
-    with KeyVault(key) as key_buf:
-        aesgcm = AESGCM(bytes(key_buf))
-        nonce = enc[:12]
-        ct = enc[12:]
-        return aesgcm.decrypt(nonce, ct, None)
+    try:
+        with KeyVault(key) as key_buf:
+            aesgcm = AESGCM(bytes(key_buf))
+            nonce = enc[:12]
+            ct = enc[12:]
+            return aesgcm.decrypt(nonce, ct, None)
+    except Exception as exc:
+        raise DecryptionError("Invalid ciphertext") from exc
 
 
 def generate_dilithium_keypair(*, sensitive: bool = True) -> Tuple[bytes, KeyVault | bytes]:

--- a/tests/test_pqc.py
+++ b/tests/test_pqc.py
@@ -4,13 +4,13 @@ from cryptography_suite.errors import DecryptionError
 from cryptography_suite.pqc import (
     PQCRYPTO_AVAILABLE,
     SPHINCS_AVAILABLE,
-    generate_kyber_keypair,
-    kyber_encrypt,
-    kyber_decrypt,
-    generate_dilithium_keypair,
     dilithium_sign,
     dilithium_verify,
+    generate_dilithium_keypair,
+    generate_kyber_keypair,
     generate_sphincs_keypair,
+    kyber_decrypt,
+    kyber_encrypt,
     sphincs_sign,
     sphincs_verify,
 )

--- a/tests/test_pqc.py
+++ b/tests/test_pqc.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import cast
 
 from cryptography_suite.errors import DecryptionError
 from cryptography_suite.pqc import (
@@ -45,17 +46,18 @@ class TestPQC(unittest.TestCase):
         msg = b"nonce/tag corruption test"
         pk, sk = generate_kyber_keypair(level=512)
         ct, _ = kyber_encrypt(pk, msg, level=512, raw_output=True)
+        raw_ct = cast(bytes, ct)
 
         # Corrupt nonce byte (first byte after KEM ciphertext + salt).
-        nonce_corrupt = bytearray(ct)
-        kem_ct_size = len(ct) - (16 + 12 + len(msg) + 16)
+        nonce_corrupt = bytearray(raw_ct)
+        kem_ct_size = len(raw_ct) - (16 + 12 + len(msg) + 16)
         nonce_index = kem_ct_size + 16
         nonce_corrupt[nonce_index] ^= 0x01
         with self.assertRaises(DecryptionError):
             kyber_decrypt(sk, bytes(nonce_corrupt), level=512)
 
         # Corrupt tag byte (last byte of payload).
-        tag_corrupt = bytearray(ct)
+        tag_corrupt = bytearray(raw_ct)
         tag_corrupt[-1] ^= 0x01
         with self.assertRaises(DecryptionError):
             kyber_decrypt(sk, bytes(tag_corrupt), level=512)

--- a/tests/test_pqc.py
+++ b/tests/test_pqc.py
@@ -1,5 +1,6 @@
 import unittest
 
+from cryptography_suite.errors import DecryptionError
 from cryptography_suite.pqc import (
     PQCRYPTO_AVAILABLE,
     SPHINCS_AVAILABLE,
@@ -34,6 +35,30 @@ class TestPQC(unittest.TestCase):
         sig = dilithium_sign(sk, msg)
         self.assertIsInstance(sig, str)
         self.assertTrue(dilithium_verify(pk, msg, sig))
+
+    def test_kyber_decrypt_short_ciphertext_raises_decryption_error(self):
+        _, sk = generate_kyber_keypair(level=512)
+        with self.assertRaises(DecryptionError):
+            kyber_decrypt(sk, b"\x00" * 10, level=512)
+
+    def test_kyber_decrypt_corrupt_nonce_or_tag_raises_decryption_error(self):
+        msg = b"nonce/tag corruption test"
+        pk, sk = generate_kyber_keypair(level=512)
+        ct, _ = kyber_encrypt(pk, msg, level=512, raw_output=True)
+
+        # Corrupt nonce byte (first byte after KEM ciphertext + salt).
+        nonce_corrupt = bytearray(ct)
+        kem_ct_size = len(ct) - (16 + 12 + len(msg) + 16)
+        nonce_index = kem_ct_size + 16
+        nonce_corrupt[nonce_index] ^= 0x01
+        with self.assertRaises(DecryptionError):
+            kyber_decrypt(sk, bytes(nonce_corrupt), level=512)
+
+        # Corrupt tag byte (last byte of payload).
+        tag_corrupt = bytearray(ct)
+        tag_corrupt[-1] ^= 0x01
+        with self.assertRaises(DecryptionError):
+            kyber_decrypt(sk, bytes(tag_corrupt), level=512)
 
     @unittest.skipUnless(SPHINCS_AVAILABLE, "SPHINCS+ not available")
     def test_sphincs_signature(self):


### PR DESCRIPTION
### Motivation
- Ensure `kyber_decrypt` strictly validates ciphertext structure to prevent out-of-bounds parsing and avoid accepting truncated inputs.
- Make error reporting deterministic: malformed ciphertext must raise `DecryptionError` rather than leaking lower-level exceptions like `ValueError` or `InvalidTag`.

### Description
- Enforced a minimum ciphertext length by requiring `ct_size + 16 + 12 + 16` (KEM ciphertext + salt(16) + nonce(12) + tag(16)) before parsing.
- Wrapped KEM decapsulation (`alg.decrypt`) errors and AES-GCM decryption errors in `DecryptionError("Invalid ciphertext")` to normalize failure reporting.
- Added tests that assert malformed inputs produce `DecryptionError`, and imported `DecryptionError` into the test module.
- New tests cover short ciphertext rejection and corruption of the nonce and tag regions in the Kyber payload.

### Testing
- Ran `pytest -q tests/test_pqc.py`, which completed successfully with `6 passed`.
- New negative tests added: short ciphertext path and corrupted nonce/tag paths each assert `DecryptionError` is raised (these tests passed).
