### PR TITLE
Improve fuzz CI matrix and artifact handling

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -2,32 +2,63 @@ name: Fuzzing
 
 on:
   schedule:
-    - cron: '0 5 * * 0'
+    - cron: "0 5 * * 0"
   workflow_dispatch:
+    inputs:
+      runs:
+        description: "Atheris -runs value per harness"
+        required: false
+        default: "2000"
+      timeout_seconds:
+        description: "Timeout in seconds per harness"
+        required: false
+        default: "180"
 
 jobs:
   fuzz:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12']
+        python-version: ["3.11", "3.12"]
+        harness:
+          - fuzz_aes
+          - fuzz_rsa
+          - fuzz_ecies
+          - fuzz_pipeline
+    env:
+      FUZZ_RUNS: ${{ github.event.inputs.runs || '2000' }}
+      FUZZ_TIMEOUT_SECONDS: ${{ github.event.inputs.timeout_seconds || '180' }}
+      FUZZ_ARTIFACT_DIR: fuzz/artifacts
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev]
           pip install atheris
-      - name: Run fuzzing
+
+      - name: Run ${{ matrix.harness }}
+        shell: bash
         run: |
-          python fuzz/fuzz_aes.py -runs=1000
-      - name: Upload Crashers
+          set -euo pipefail
+          mkdir -p "$FUZZ_ARTIFACT_DIR/${{ matrix.harness }}"
+          pushd "$FUZZ_ARTIFACT_DIR/${{ matrix.harness }}" >/dev/null
+          timeout "$FUZZ_TIMEOUT_SECONDS"s \
+            python "$GITHUB_WORKSPACE/fuzz/${{ matrix.harness }}.py" "-runs=$FUZZ_RUNS"
+          popd >/dev/null
+
+      - name: Upload crash artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: fuzz-crashers-${{ matrix.python-version }}
-          path: | 
-            fuzz/crash* || true
+          name: fuzz-artifacts-${{ matrix.harness }}-py${{ matrix.python-version }}
+          path: |
+            ${{ env.FUZZ_ARTIFACT_DIR }}/${{ matrix.harness }}/crash-*
+            ${{ env.FUZZ_ARTIFACT_DIR }}/${{ matrix.harness }}/leak-*
+            ${{ env.FUZZ_ARTIFACT_DIR }}/${{ matrix.harness }}/timeout-*
+          if-no-files-found: ignore

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,13 @@
+# Fuzzing harnesses
+
+Run one harness locally as a smoke check:
+
+```bash
+python fuzz/fuzz_aes.py -runs=100
+```
+
+Run all harnesses locally:
+
+```bash
+for h in aes rsa ecies pipeline; do python "fuzz/fuzz_${h}.py" -runs=100; done
+```


### PR DESCRIPTION
### Motivation

- Ensure the fuzz CI runs all harnesses (AES, RSA, ECIES, pipeline) across supported Python versions on schedule and manual dispatch.
- Make artifact uploads reliable so the workflow succeeds even when no crashes or timeouts are produced.
- Expose simple tuning inputs for runs/timeouts and move to current-major Actions for better long-term stability.

### Description

- Expand the workflow matrix to run `fuzz_aes`, `fuzz_rsa`, `fuzz_ecies`, and `fuzz_pipeline` across Python `3.11` and `3.12` with `fail-fast: false` so harnesses run independently.
- Add `workflow_dispatch` inputs `runs` and `timeout_seconds` and wire them to environment variables `FUZZ_RUNS` and `FUZZ_TIMEOUT_SECONDS` for easy tuning without editing the YAML.
- Run each harness in a per-harness artifact directory under `fuzz/artifacts/<harness>` with a `timeout` wrapper so crash/leak/timeout files are colocated and discoverable for upload.
- Upgrade Actions to `actions/checkout@v4`, `actions/setup-python@v5`, and `actions/upload-artifact@v4`, and use `if-no-files-found: ignore` for upload to avoid failures when no artifact files exist.
- Add `fuzz/README.md` with simple smoke commands to run one harness or all harnesses locally.

### Testing

- Ran a local smoke invocation `python fuzz/fuzz_aes.py -runs=1`, which failed in this environment with `ModuleNotFoundError: No module named 'atheris'` as expected when dependencies are not installed, indicating the harness script runs but requires the Atheris dependency to execute successfully.
