### PR TITLE
Redesign PQC encryption API around sealed ML-KEM envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ ______________________________________________________________________
 ## 🔑 Key Features
 
 - **Comprehensive Functionality**: Symmetric and asymmetric encryption, digital signatures, key management, secret sharing, password-authenticated key exchange (PAKE), and one-time passwords (OTP).
-- **Post-Quantum Primitives**: Kyber KEM, Dilithium signatures, and **experimental SPHINCS+** support (enable via `pip install "cryptography-suite[pqc]"` – demo-only, not production-grade). These are available under `cryptography_suite.experimental`.
+- **Post-Quantum Primitives**: experimental ML-KEM/Kyber KEM, Dilithium signatures, and **experimental SPHINCS+** support (enable via `pip install "cryptography-suite[pqc]"` – demo-only, not production-grade). These are available under `cryptography_suite.experimental`.
 - **Signal Protocol Demo**: Minimal X3DH + Double Ratchet implementation located in `cryptography_suite.experimental.signal` (**experimental, not production-ready**).
 - **Homomorphic Encryption**: Pyfhel-based helpers exposed via `cryptography_suite.experimental` (**experimental, demo-only**).
 - **Zero-Knowledge Proof Helpers**: Bulletproof range proofs and zk-SNARK examples under `cryptography_suite.experimental` (**experimental**).
@@ -82,6 +82,8 @@ ______________________________________________________________________
 | KeyGraphWidget | cryptography_suite.viz.widgets | No | No | No | experimental | |
 | KyberDecrypt | cryptography_suite.pipeline | Yes | No | No | experimental | |
 | KyberEncrypt | cryptography_suite.pipeline | Yes | No | No | experimental | |
+| MLKEMDecrypt | cryptography_suite.pipeline | Yes | No | No | experimental | |
+| MLKEMEncrypt | cryptography_suite.pipeline | Yes | No | No | experimental | |
 | PQCRYPTO_AVAILABLE | | No | Yes | No | experimental | |
 | RSADecrypt | cryptography_suite.pipeline | Yes | No | No | stable | |
 | RSAEncrypt | cryptography_suite.pipeline | Yes | No | No | stable | |
@@ -110,10 +112,13 @@ ______________________________________________________________________
 | generate_dilithium_keypair | | No | Yes | No | experimental | |
 | generate_ed448_keypair | cryptography_suite.asymmetric.signatures | No | No | No | deprecated | |
 | generate_kyber_keypair | | No | Yes | No | experimental | |
+| generate_ml_kem_keypair | | No | Yes | No | experimental | |
 | generate_sphincs_keypair | | No | Yes | No | experimental | |
 | initialize_signal_session | cryptography_suite.experimental.signal | No | No | No | experimental | |
 | kyber_decrypt | | No | No | No | experimental | |
 | kyber_encrypt | | No | No | No | experimental | |
+| ml_kem_decrypt | | No | No | No | experimental | |
+| ml_kem_encrypt | | No | No | No | experimental | |
 | sign_message_ed448 | cryptography_suite.asymmetric.signatures | No | No | No | deprecated | |
 | sphincs_sign | | No | No | No | experimental | |
 | sphincs_verify | | No | No | No | experimental | |
@@ -200,7 +205,7 @@ print(p.to_proverif())    # formal model output
 
 ## ✨ Version 2.0.0 Highlights
 
-- **Post-Quantum Readiness**: Kyber KEM and Dilithium signature helpers.
+- **Post-Quantum Readiness**: experimental ML-KEM/Kyber KEM and Dilithium signature helpers.
 - **Hybrid Encryption**: Combine asymmetric encryption with AES-GCM.
 - **XChaCha20-Poly1305**: Modern stream cipher support when available.
 - **Key Management Enhancements**: `KeyVault` context manager and `KeyManager` utilities.
@@ -292,7 +297,7 @@ ______________________________________________________________________
 - **Key Management**: Secure generation, storage, loading, and rotation of cryptographic keys.
 - **Secret Sharing**: Implementation of Shamir's Secret Sharing scheme for splitting and reconstructing secrets.
 - **Hybrid Encryption**: Combine RSA/ECIES with AES-GCM for performance and security.
-- **Post-Quantum Cryptography**: Kyber key encapsulation and Dilithium signatures for quantum-safe workflows.
+- **Post-Quantum Cryptography**: experimental ML-KEM/Kyber key encapsulation and Dilithium signatures for quantum-safe demos.
 - **XChaCha20-Poly1305**: Modern stream cipher support when `cryptography` exposes `XChaCha20Poly1305`.
 - **Salsa20 and Ascon**: Deprecated and provided for reference only. **Not recommended for production**, removed from public imports, and scheduled for removal in v4.0.0. Use authenticated ciphers like `chacha20_encrypt`/`xchacha_encrypt` or `AESGCMEncrypt` instead.
 - **Audit Logging**: Decorators and helpers for encrypted audit trails.
@@ -624,22 +629,25 @@ print(zksnark.verify(hash_hex, proof_file))
 
 ### Post-Quantum Cryptography
 
-Leverage Kyber and Dilithium for quantum-resistant operations. See
-[`tests/test_pqc.py`](tests/test_pqc.py) for thorough unit tests.
+Explore experimental ML-KEM (formerly Kyber) and Dilithium helpers for
+quantum-resistant demos. These PQC helpers are not production audited. Safe
+ML-KEM encryption returns a sealed envelope; KEM shared secrets remain internal
+and are never returned by the safe APIs. See [`tests/test_pqc.py`](tests/test_pqc.py)
+for regression tests.
 
 ```python
 from cryptography_suite.pqc import (
-    generate_kyber_keypair,
-    kyber_encrypt,
-    kyber_decrypt,
+    generate_ml_kem_keypair,
+    ml_kem_encrypt,
+    ml_kem_decrypt,
     generate_dilithium_keypair,
     dilithium_sign,
     dilithium_verify,
 )
 
-ky_pub, ky_priv = generate_kyber_keypair()
-ct, ss = kyber_encrypt(ky_pub, b"hello pqc")
-assert kyber_decrypt(ky_priv, ct, ss) == b"hello pqc"
+ml_kem_pub, ml_kem_priv = generate_ml_kem_keypair()
+envelope = ml_kem_encrypt(ml_kem_pub, b"hello pqc")
+assert ml_kem_decrypt(ml_kem_priv, envelope) == b"hello pqc"
 
 dl_pub, dl_priv = generate_dilithium_keypair()
 sig = dilithium_sign(dl_priv, b"package")
@@ -835,7 +843,7 @@ ______________________________________________________________________
   CLI passwords. Environment variables are supported for automation but are less
   safe because they can be inherited or exposed by process tooling.
 - **Regular Updates**: Keep dependencies up to date to benefit from the latest security patches.
-- **Post-Quantum Algorithms**: Use Kyber and Dilithium for data requiring long-term secrecy, noting their larger key sizes.
+- **Post-Quantum Algorithms**: ML-KEM/Kyber and Dilithium helpers are experimental/demo-only and not production audited; note their larger key sizes.
 - **Hybrid Encryption**: Combine classical and PQC schemes during migration to mitigate potential weaknesses.
 
 ______________________________________________________________________
@@ -965,9 +973,11 @@ ______________________________________________________________________
   `raw_output=True`.
 - **Audit and Key Vault**: Use `audit_log` and `KeyVault` for logging and
   secure key handling.
-- **Kyber API Updates**: `kyber_encrypt` and `kyber_decrypt` accept a
-  `level` parameter (512/768/1024). `kyber_decrypt` now computes the shared
-  secret automatically when omitted.
+- **ML-KEM/Kyber API Updates**: `ml_kem_encrypt` returns a sealed envelope and
+  `ml_kem_decrypt` opens it without caller-visible KEM shared secrets. The old
+  `kyber_encrypt`/`kyber_decrypt` names are compatibility wrappers; this breaks
+  code that unpacked `(ciphertext, shared_secret)` or passed `shared_secret` to
+  decrypt.
 - **Key Management**: `KeyManager` now provides `generate_rsa_keypair_and_save`.
   The standalone `generate_rsa_keypair_and_save` helper is deprecated and will
   be removed in v4.0.0.

--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -376,7 +376,7 @@ def keygen_cli(argv: list[str] | None = None) -> None:
         else:
             generate_sphincs_keypair()
         _emit(
-            f"{args.scheme} key pair generated; key material was not printed.",
+            f"{args.scheme} private key material was generated but not printed.",
             {
                 "private_key_output": "suppressed",
                 "public_key_output": "suppressed",

--- a/cryptography_suite/experimental/__init__.py
+++ b/cryptography_suite/experimental/__init__.py
@@ -6,14 +6,6 @@ import os
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING or os.getenv("CRYPTOSUITE_ALLOW_EXPERIMENTAL"):
-    from .signal_demo import (
-        SIGNAL_AVAILABLE,
-        SignalSender,
-        SignalReceiver,
-        initialize_signal_session,
-        x3dh_initiator,
-        x3dh_responder,
-    )
     from .fhe import (
         FHE_AVAILABLE,
         fhe_add,
@@ -24,12 +16,21 @@ if TYPE_CHECKING or os.getenv("CRYPTOSUITE_ALLOW_EXPERIMENTAL"):
         fhe_multiply,
         fhe_serialize_context,
     )
+    from .signal_demo import (
+        SIGNAL_AVAILABLE,
+        SignalReceiver,
+        SignalSender,
+        initialize_signal_session,
+        x3dh_initiator,
+        x3dh_responder,
+    )
     from .zk import (
         BULLETPROOF_AVAILABLE,
         ZKSNARK_AVAILABLE,
         bulletproof,
         zksnark,
     )
+
     try:  # pragma: no cover - optional dependency
         from ..pqc import (
             PQCRYPTO_AVAILABLE,
@@ -38,9 +39,12 @@ if TYPE_CHECKING or os.getenv("CRYPTOSUITE_ALLOW_EXPERIMENTAL"):
             dilithium_verify,
             generate_dilithium_keypair,
             generate_kyber_keypair,
+            generate_ml_kem_keypair,
             generate_sphincs_keypair,
             kyber_decrypt,
             kyber_encrypt,
+            ml_kem_decrypt,
+            ml_kem_encrypt,
             sphincs_sign,
             sphincs_verify,
         )
@@ -49,15 +53,17 @@ if TYPE_CHECKING or os.getenv("CRYPTOSUITE_ALLOW_EXPERIMENTAL"):
         SPHINCS_AVAILABLE = False
         dilithium_sign = dilithium_verify = None  # type: ignore
         generate_dilithium_keypair = None  # type: ignore
+        generate_ml_kem_keypair = None  # type: ignore
         generate_kyber_keypair = None  # type: ignore
         generate_sphincs_keypair = None  # type: ignore
         kyber_decrypt = kyber_encrypt = None  # type: ignore
+        ml_kem_decrypt = ml_kem_encrypt = None  # type: ignore
         sphincs_sign = sphincs_verify = None  # type: ignore
 
     try:  # pragma: no cover - optional dependency
         from ..viz import HandshakeFlowWidget, KeyGraphWidget, SessionTimelineWidget
     except Exception:  # pragma: no cover - widgets may be unavailable
-        HandshakeFlowWidget = KeyGraphWidget = SessionTimelineWidget = None  # type: ignore
+        HandshakeFlowWidget = KeyGraphWidget = SessionTimelineWidget = None
 
     DEPRECATED_MSG = (
         "This function is deprecated and will be removed in v4.0.0. "
@@ -71,10 +77,13 @@ if TYPE_CHECKING or os.getenv("CRYPTOSUITE_ALLOW_EXPERIMENTAL"):
         "dilithium_sign",
         "dilithium_verify",
         "generate_dilithium_keypair",
+        "generate_ml_kem_keypair",
         "generate_kyber_keypair",
         "generate_sphincs_keypair",
         "kyber_decrypt",
         "kyber_encrypt",
+        "ml_kem_decrypt",
+        "ml_kem_encrypt",
         "sphincs_sign",
         "sphincs_verify",
         # Signal
@@ -105,9 +114,15 @@ if TYPE_CHECKING or os.getenv("CRYPTOSUITE_ALLOW_EXPERIMENTAL"):
     ]
 
     def __getattr__(name: str) -> Any:
-        if name in {"salsa20_encrypt", "salsa20_decrypt", "ascon_encrypt", "ascon_decrypt"}:
+        if name in {
+            "salsa20_encrypt",
+            "salsa20_decrypt",
+            "ascon_encrypt",
+            "ascon_decrypt",
+        }:
             raise RuntimeError(DEPRECATED_MSG)
         raise AttributeError(name)
+
 else:  # pragma: no cover - executed when experimental disabled
     raise ImportError(
         "Experimental features require CRYPTOSUITE_ALLOW_EXPERIMENTAL=1 to import."

--- a/cryptography_suite/pipeline.py
+++ b/cryptography_suite/pipeline.py
@@ -500,54 +500,87 @@ class HybridDecrypt(CryptoModule[Any, bytes]):
 
 @register_module
 @dataclass
-class KyberEncrypt(CryptoModule[bytes, tuple[str | bytes, str | bytes]]):
-    """Encrypt data using Kyber and AES-GCM."""
+class MLKEMEncrypt(CryptoModule[bytes, str | bytes]):
+    """Encrypt data as a sealed ML-KEM/AES-GCM envelope."""
 
     public_key: bytes
     level: int = 512
     raw_output: bool = False
 
-    def run(self, data: bytes) -> tuple[str | bytes, str | bytes]:
+    def run(self, data: bytes) -> str | bytes:
         import warnings
 
-        from .pqc import kyber_encrypt
+        from .pqc import ml_kem_encrypt
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
-            return kyber_encrypt(
+            return ml_kem_encrypt(
                 self.public_key, data, level=self.level, raw_output=self.raw_output
             )
 
     def to_proverif(self) -> str:  # pragma: no cover - simple serialization
-        return f"kyber_encrypt({self.level})"
+        return f"ml_kem_encrypt({self.level})"
 
     def to_tamarin(self) -> str:  # pragma: no cover - simple serialization
-        return f"kyber_encrypt({self.level})"
+        return f"ml_kem_encrypt({self.level})"
 
 
 @register_module
 @dataclass
-class KyberDecrypt(CryptoModule[tuple[str | bytes, str | bytes], bytes]):
-    """Decrypt data produced by :class:`KyberEncrypt`."""
+class MLKEMDecrypt(CryptoModule[str | bytes, bytes]):
+    """Decrypt data produced by :class:`MLKEMEncrypt`."""
 
     private_key: Any
     level: int = 512
 
-    def run(self, data: tuple[str | bytes, str | bytes]) -> bytes:
+    def run(self, data: str | bytes) -> bytes:
         import warnings
 
-        from .pqc import kyber_decrypt
+        from .pqc import ml_kem_decrypt
 
-        ct, ss = data
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
-            return kyber_decrypt(self.private_key, ct, ss, level=self.level)
+            return ml_kem_decrypt(self.private_key, data, level=self.level)
 
     def to_proverif(self) -> str:  # pragma: no cover - simple serialization
-        return f"kyber_decrypt({self.level})"
+        return f"ml_kem_decrypt({self.level})"
 
     def to_tamarin(self) -> str:  # pragma: no cover - simple serialization
-        return f"kyber_decrypt({self.level})"
+        return f"ml_kem_decrypt({self.level})"
+
+
+@register_module
+@dataclass
+class KyberEncrypt(MLKEMEncrypt):
+    """Deprecated compatibility wrapper for :class:`MLKEMEncrypt`."""
+
+    def run(self, data: bytes) -> str | bytes:
+        import warnings
+
+        warnings.warn(
+            "KyberEncrypt is deprecated; use MLKEMEncrypt. It returns only a "
+            "sealed ML-KEM envelope and never returns a KEM shared secret.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return super().run(data)
+
+
+@register_module
+@dataclass
+class KyberDecrypt(MLKEMDecrypt):
+    """Deprecated compatibility wrapper for :class:`MLKEMDecrypt`."""
+
+    def run(self, data: str | bytes) -> bytes:
+        import warnings
+
+        warnings.warn(
+            "KyberDecrypt is deprecated; use MLKEMDecrypt with a sealed "
+            "ML-KEM envelope.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return super().run(data)
 
 
 __all__ = [
@@ -564,6 +597,8 @@ __all__ = [
     "ECIESX25519Decrypt",
     "HybridEncrypt",
     "HybridDecrypt",
+    "MLKEMEncrypt",
+    "MLKEMDecrypt",
     "KyberEncrypt",
     "KyberDecrypt",
 ]

--- a/cryptography_suite/pqc/__init__.py
+++ b/cryptography_suite/pqc/__init__.py
@@ -1,16 +1,19 @@
-"""Post-quantum cryptography wrappers using pqcrypto.
+"""Experimental post-quantum cryptography wrappers using pqcrypto.
 
-This module provides simple interfaces for the NIST CRYSTALS-Kyber
-(KEM) and CRYSTALS-Dilithium (signature) algorithms using the
-``pqcrypto`` Python bindings. The functions rely on constant-time
-implementations from PQClean.
+This module provides simple interfaces for ML-KEM (formerly CRYSTALS-Kyber)
+and ML-DSA/Dilithium using the ``pqcrypto`` Python bindings. These helpers are
+for demos and interoperability experiments only; they are not production
+audited. ML-KEM encryption returns sealed envelopes and never exposes KEM
+shared secrets through the public API.
 """
 
 from __future__ import annotations
 
 import base64
-import hmac
 import os
+import struct
+import warnings
+from typing import Any
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
@@ -51,29 +54,194 @@ except Exception:  # pragma: no cover - fallback
 
 _KYBER_LEVEL_MAP = {512: ml_kem_512, 768: ml_kem_768, 1024: ml_kem_1024}
 _DILITHIUM_LEVEL_MAP = {2: ml_dsa_44, 3: ml_dsa_65, 5: ml_dsa_87}
+_ML_KEM_ENVELOPE_MAGIC = b"CSKEM1"
+_ML_KEM_HEADER = struct.Struct(">HIII")
+_ML_KEM_HEADER_SIZE = len(_ML_KEM_ENVELOPE_MAGIC) + _ML_KEM_HEADER.size
+_ML_KEM_SALT_SIZE = 16
+_ML_KEM_NONCE_SIZE = 12
+_ML_KEM_TAG_SIZE = 16
+
+
+def _get_ml_kem_algorithm(
+    level: int, error_type: type[EncryptionError] | type[DecryptionError]
+) -> Any:
+    if not PQCRYPTO_AVAILABLE:
+        raise ImportError("pqcrypto is required for ML-KEM functions")
+
+    alg = _KYBER_LEVEL_MAP.get(level)
+    if alg is None:
+        raise error_type("Invalid ML-KEM level")
+    return alg
+
+
+def _ml_kem_hkdf_info(level: int) -> bytes:
+    return b"cryptography-suite ml-kem aes-gcm envelope v1 level=" + str(level).encode(
+        "ascii"
+    )
+
+
+def _decode_ml_kem_envelope(envelope: bytes | str) -> bytes:
+    if isinstance(envelope, str):
+        try:
+            return base64.b64decode(envelope, validate=True)
+        except Exception as exc:
+            raise DecryptionError("Invalid ML-KEM envelope") from exc
+    if not isinstance(envelope, bytes):
+        raise DecryptionError("Invalid ML-KEM envelope")
+    if envelope.startswith(_ML_KEM_ENVELOPE_MAGIC):
+        return envelope
+    try:
+        decoded = base64.b64decode(envelope, validate=True)
+    except Exception as exc:
+        raise DecryptionError("Invalid ML-KEM envelope") from exc
+    if not decoded.startswith(_ML_KEM_ENVELOPE_MAGIC):
+        raise DecryptionError("Invalid ML-KEM envelope")
+    return decoded
+
+
+def _parse_ml_kem_envelope(
+    envelope: bytes | str, *, level: int
+) -> tuple[bytes, bytes, bytes, bytes, bytes]:
+    envelope_bytes = _decode_ml_kem_envelope(envelope)
+    if len(envelope_bytes) < _ML_KEM_HEADER_SIZE:
+        raise DecryptionError("Invalid ML-KEM envelope")
+    if not envelope_bytes.startswith(_ML_KEM_ENVELOPE_MAGIC):
+        raise DecryptionError("Invalid ML-KEM envelope")
+
+    alg = _get_ml_kem_algorithm(level, DecryptionError)
+    try:
+        envelope_level, kem_ct_len, salt_len, nonce_len = _ML_KEM_HEADER.unpack_from(
+            envelope_bytes, len(_ML_KEM_ENVELOPE_MAGIC)
+        )
+    except struct.error as exc:
+        raise DecryptionError("Invalid ML-KEM envelope") from exc
+
+    if envelope_level != level:
+        raise DecryptionError("Invalid ML-KEM envelope")
+    if kem_ct_len != alg.CIPHERTEXT_SIZE:
+        raise DecryptionError("Invalid ML-KEM envelope")
+    if salt_len != _ML_KEM_SALT_SIZE or nonce_len != _ML_KEM_NONCE_SIZE:
+        raise DecryptionError("Invalid ML-KEM envelope")
+
+    body_len = len(envelope_bytes) - _ML_KEM_HEADER_SIZE
+    prefix_len = kem_ct_len + salt_len + nonce_len
+    if prefix_len > body_len or body_len - prefix_len < _ML_KEM_TAG_SIZE:
+        raise DecryptionError("Invalid ML-KEM envelope")
+
+    offset = _ML_KEM_HEADER_SIZE
+    kem_ciphertext = envelope_bytes[offset : offset + kem_ct_len]
+    offset += kem_ct_len
+    salt = envelope_bytes[offset : offset + salt_len]
+    offset += salt_len
+    nonce = envelope_bytes[offset : offset + nonce_len]
+    offset += nonce_len
+    aes_ciphertext = envelope_bytes[offset:]
+    aad = envelope_bytes[:_ML_KEM_HEADER_SIZE]
+    return aad, kem_ciphertext, salt, nonce, aes_ciphertext
+
+
+def generate_ml_kem_keypair(
+    level: int = 512, *, sensitive: bool = True
+) -> tuple[bytes, KeyVault | bytes]:
+    """Generate an experimental ML-KEM key pair for the given ``level``.
+
+    Parameters
+    ----------
+    level : int
+        ML-KEM security level (512, 768 or 1024).
+    sensitive : bool, optional
+        If ``True`` (default) the private key is wrapped in :class:`KeyVault`
+        so it can be securely erased after use.
+    """
+    alg = _get_ml_kem_algorithm(level, EncryptionError)
+    pk, sk = alg.generate_keypair()
+    return pk, KeyVault(sk) if sensitive else sk
 
 
 def generate_kyber_keypair(
     level: int = 512, *, sensitive: bool = True
 ) -> tuple[bytes, KeyVault | bytes]:
-    """Generate a Kyber key pair for the given ``level``.
+    """Deprecated compatibility wrapper for :func:`generate_ml_kem_keypair`."""
+    warnings.warn(
+        "generate_kyber_keypair is deprecated; use generate_ml_kem_keypair.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return generate_ml_kem_keypair(level=level, sensitive=sensitive)
 
-    Parameters
-    ----------
-    level : int
-        Kyber security level (512, 768 or 1024).
-    sensitive : bool, optional
-        If ``True`` (default) the private key is wrapped in :class:`KeyVault`
-        so it can be securely erased after use.
+
+def ml_kem_encrypt(
+    public_key: bytes,
+    plaintext: bytes,
+    *,
+    level: int = 512,
+    raw_output: bool = False,
+) -> str | bytes:
+    """Encrypt ``plaintext`` as a sealed ML-KEM/AES-GCM envelope.
+
+    The returned envelope contains the KEM ciphertext, salt, nonce, and
+    AES-GCM ciphertext/tag needed for decryption. The KEM shared secret remains
+    internal and is never returned by this API.
     """
-    if not PQCRYPTO_AVAILABLE:
-        raise ImportError("pqcrypto is required for Kyber functions")
+    alg = _get_ml_kem_algorithm(level, EncryptionError)
 
-    alg = _KYBER_LEVEL_MAP.get(level)
-    if alg is None:
-        raise EncryptionError("Invalid Kyber level")
-    pk, sk = alg.generate_keypair()
-    return pk, KeyVault(sk) if sensitive else sk
+    try:
+        kem_ciphertext, kem_secret = alg.encrypt(public_key)
+    except Exception as exc:
+        raise EncryptionError("ML-KEM encryption failed") from exc
+    if len(kem_ciphertext) != alg.CIPHERTEXT_SIZE:
+        raise EncryptionError("ML-KEM encryption failed")
+
+    salt = os.urandom(_ML_KEM_SALT_SIZE)
+    nonce = os.urandom(_ML_KEM_NONCE_SIZE)
+    aad = _ML_KEM_ENVELOPE_MAGIC + _ML_KEM_HEADER.pack(
+        level, len(kem_ciphertext), len(salt), len(nonce)
+    )
+    try:
+        with KeyVault(kem_secret) as secret_buf:
+            key = derive_hkdf(bytes(secret_buf), salt, _ml_kem_hkdf_info(level), 32)
+        with KeyVault(key) as key_buf:
+            aesgcm = AESGCM(bytes(key_buf))
+            aes_ciphertext = aesgcm.encrypt(nonce, plaintext, aad)
+    except Exception as exc:
+        raise EncryptionError("ML-KEM envelope encryption failed") from exc
+
+    envelope = aad + kem_ciphertext + salt + nonce + aes_ciphertext
+    if raw_output:
+        return envelope
+    return base64.b64encode(envelope).decode()
+
+
+def ml_kem_decrypt(
+    private_key: bytes | KeyVault,
+    envelope: bytes | str,
+    *,
+    level: int = 512,
+) -> bytes:
+    """Decrypt a sealed ML-KEM envelope.
+
+    ``private_key`` may be raw bytes or a :class:`KeyVault` returned by
+    :func:`generate_ml_kem_keypair`. Malformed envelopes, level mismatches,
+    decapsulation failures, and AES-GCM authentication failures all raise
+    :class:`DecryptionError` without exposing KEM shared secrets.
+    """
+    alg = _get_ml_kem_algorithm(level, DecryptionError)
+    aad, kem_ciphertext, salt, nonce, aes_ciphertext = _parse_ml_kem_envelope(
+        envelope, level=level
+    )
+    priv = bytes(private_key) if isinstance(private_key, KeyVault) else private_key
+    try:
+        kem_secret = alg.decrypt(priv, kem_ciphertext)
+    except Exception as exc:
+        raise DecryptionError("Invalid ML-KEM envelope") from exc
+    try:
+        with KeyVault(kem_secret) as secret_buf:
+            key = derive_hkdf(bytes(secret_buf), salt, _ml_kem_hkdf_info(level), 32)
+        with KeyVault(key) as key_buf:
+            aesgcm = AESGCM(bytes(key_buf))
+            return aesgcm.decrypt(nonce, aes_ciphertext, aad)
+    except Exception as exc:
+        raise DecryptionError("Invalid ML-KEM envelope") from exc
 
 
 def kyber_encrypt(
@@ -82,33 +250,19 @@ def kyber_encrypt(
     *,
     level: int = 512,
     raw_output: bool = False,
-) -> tuple[str | bytes, str | bytes]:
-    """Encrypt ``plaintext`` using Kyber and AES-GCM.
+) -> str | bytes:
+    """Deprecated compatibility wrapper for :func:`ml_kem_encrypt`.
 
-    ``level`` selects the ML-KEM security level (512, 768 or 1024).
-    The function encapsulates a shared secret with the chosen level and then
-    derives an AES key from that secret to encrypt the plaintext. The returned
-    tuple contains the Kyber ciphertext followed by the AES-GCM output and the
-    shared secret used for encryption.
+    Breaking change: this wrapper now returns only the sealed envelope. It does
+    not return a KEM shared secret.
     """
-    if not PQCRYPTO_AVAILABLE:
-        raise ImportError("pqcrypto is required for Kyber functions")
-
-    alg = _KYBER_LEVEL_MAP.get(level)
-    if alg is None:
-        raise EncryptionError("Invalid Kyber level")
-
-    kem_ct, ss = alg.encrypt(public_key)
-    salt = os.urandom(16)
-    key = derive_hkdf(ss, salt, b"kyber-aes-key", 32)
-    with KeyVault(key) as key_buf:
-        aesgcm = AESGCM(bytes(key_buf))
-        nonce = os.urandom(12)
-        enc = nonce + aesgcm.encrypt(nonce, plaintext, None)
-    ct = kem_ct + salt + enc
-    if raw_output:
-        return ct, ss
-    return base64.b64encode(ct).decode(), base64.b64encode(ss).decode()
+    warnings.warn(
+        "kyber_encrypt is deprecated; use ml_kem_encrypt. It now returns only "
+        "a sealed ML-KEM envelope and never returns the KEM shared secret.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return ml_kem_encrypt(public_key, plaintext, level=level, raw_output=raw_output)
 
 
 def kyber_decrypt(
@@ -118,58 +272,26 @@ def kyber_decrypt(
     *,
     level: int = 512,
 ) -> bytes:
-    """Decrypt data encrypted by :func:`kyber_encrypt`.
+    """Deprecated compatibility wrapper for :func:`ml_kem_decrypt`.
 
-    ``private_key`` may be raw bytes or a :class:`KeyVault` returned by
-    :func:`generate_kyber_keypair`. ``shared_secret`` becomes optional; when
-    omitted the function decapsulates it from ``ciphertext``.
+    ``shared_secret`` is ignored when provided. New-format envelopes contain
+    the KEM ciphertext needed for decapsulation and do not require callers to
+    handle shared secrets.
     """
-    if not PQCRYPTO_AVAILABLE:
-        raise ImportError("pqcrypto is required for Kyber functions")
-
-    alg = _KYBER_LEVEL_MAP.get(level)
-    if alg is None:
-        raise DecryptionError("Invalid Kyber level")
-
-    ct_size = alg.CIPHERTEXT_SIZE
-    if isinstance(ciphertext, str):
-        try:
-            ciphertext = base64.b64decode(ciphertext)
-        except Exception as exc:  # pragma: no cover - defensive
-            raise DecryptionError(f"Invalid ciphertext: {exc}") from exc
-
-    if isinstance(shared_secret, str):
-        try:
-            shared_secret = base64.b64decode(shared_secret)
-        except Exception as exc:  # pragma: no cover - defensive
-            raise DecryptionError(f"Invalid shared secret: {exc}") from exc
-
-    min_ct_len = ct_size + 16 + 12 + 16
-    if len(ciphertext) < min_ct_len:
-        raise DecryptionError("Invalid ciphertext")
-
-    kem_ct = ciphertext[:ct_size]
-    salt = ciphertext[ct_size : ct_size + 16]
-    enc = ciphertext[ct_size + 16 :]
-    priv = bytes(private_key) if isinstance(private_key, KeyVault) else private_key
-    try:
-        ss_check = alg.decrypt(priv, kem_ct)
-    except Exception as exc:  # pragma: no cover - defensive
-        raise DecryptionError("Invalid ciphertext") from exc
-    if shared_secret is None:
-        shared_secret = ss_check
-    elif not hmac.compare_digest(ss_check, shared_secret):
-        raise DecryptionError("Shared secret mismatch")
-
-    key = derive_hkdf(shared_secret, salt, b"kyber-aes-key", 32)
-    try:
-        with KeyVault(key) as key_buf:
-            aesgcm = AESGCM(bytes(key_buf))
-            nonce = enc[:12]
-            ct = enc[12:]
-            return aesgcm.decrypt(nonce, ct, None)
-    except Exception as exc:
-        raise DecryptionError("Invalid ciphertext") from exc
+    warnings.warn(
+        "kyber_decrypt is deprecated; use ml_kem_decrypt with a sealed "
+        "ML-KEM envelope.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    if shared_secret is not None:
+        warnings.warn(
+            "kyber_decrypt(shared_secret=...) is deprecated and ignored; "
+            "safe ML-KEM envelopes do not require caller-provided shared secrets.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    return ml_kem_decrypt(private_key, ciphertext, level=level)
 
 
 def generate_dilithium_keypair(
@@ -274,3 +396,21 @@ def sphincs_verify(public_key: bytes, message: bytes, signature: bytes | str) ->
         return bool(_sphincs_module.verify(public_key, message, signature))
     except Exception:
         return False
+
+
+__all__ = [
+    "PQCRYPTO_AVAILABLE",
+    "SPHINCS_AVAILABLE",
+    "generate_ml_kem_keypair",
+    "generate_kyber_keypair",
+    "ml_kem_encrypt",
+    "ml_kem_decrypt",
+    "kyber_encrypt",
+    "kyber_decrypt",
+    "generate_dilithium_keypair",
+    "dilithium_sign",
+    "dilithium_verify",
+    "generate_sphincs_keypair",
+    "sphincs_sign",
+    "sphincs_verify",
+]

--- a/cryptography_suite/pqc/__init__.py
+++ b/cryptography_suite/pqc/__init__.py
@@ -182,6 +182,10 @@ def ml_kem_encrypt(
     The returned envelope contains the KEM ciphertext, salt, nonce, and
     AES-GCM ciphertext/tag needed for decryption. The KEM shared secret remains
     internal and is never returned by this API.
+
+    Note: shared-secret cleanup is best-effort in Python because KEM backends
+    return immutable ``bytes`` before this function can wrap them in
+    :class:`KeyVault`.
     """
     alg = _get_ml_kem_algorithm(level, EncryptionError)
 
@@ -224,6 +228,10 @@ def ml_kem_decrypt(
     :func:`generate_ml_kem_keypair`. Malformed envelopes, level mismatches,
     decapsulation failures, and AES-GCM authentication failures all raise
     :class:`DecryptionError` without exposing KEM shared secrets.
+
+    Note: shared-secret cleanup is best-effort in Python because KEM backends
+    return immutable ``bytes`` before this function can wrap them in
+    :class:`KeyVault`.
     """
     alg = _get_ml_kem_algorithm(level, DecryptionError)
     aad, kem_ciphertext, salt, nonce, aes_ciphertext = _parse_ml_kem_envelope(

--- a/docs/api/public_api_table.rst
+++ b/docs/api/public_api_table.rst
@@ -355,16 +355,25 @@ Public API Inventory
      - Generate a Dilithium key pair using level 2 parameters.
      - Experimental
    * - ``generate_kyber_keypair``
-     - Generate a Kyber key pair for the given ``level``.
+     - Deprecated compatibility wrapper for :func:`generate_ml_kem_keypair`.
+     - Experimental
+   * - ``generate_ml_kem_keypair``
+     - Generate an experimental ML-KEM key pair for the given ``level``.
      - Experimental
    * - ``generate_sphincs_keypair``
      - Generate a SPHINCS+ key pair using a 128-bit security level.
      - Experimental
    * - ``kyber_decrypt``
-     - Decrypt data encrypted by :func:`kyber_encrypt`.
+     - Deprecated compatibility wrapper for :func:`ml_kem_decrypt`.
      - Experimental
    * - ``kyber_encrypt``
-     - Encrypt ``plaintext`` using Kyber and AES-GCM.
+     - Deprecated compatibility wrapper for :func:`ml_kem_encrypt`.
+     - Experimental
+   * - ``ml_kem_decrypt``
+     - Decrypt a sealed ML-KEM envelope.
+     - Experimental
+   * - ``ml_kem_encrypt``
+     - Encrypt ``plaintext`` as a sealed ML-KEM/AES-GCM envelope.
      - Experimental
    * - ``sphincs_sign``
      - Sign ``message`` with SPHINCS+ returning Base64 by default.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ formally verified, misuse-resistant workflows.
 - Fuzzing Harness & Property-Based Testing
 - Supply-Chain Attestation, SLSA, and Reproducible Builds
 - Signal Protocol components (X3DH + Double Ratchet) for demo use (*experimental, not production-ready*)
-- Post-Quantum primitives: Kyber KEM, Dilithium signatures, and *experimental* SPHINCS+ (requires `pip install "cryptography-suite[pqc]"`)
+- Post-Quantum primitives: *experimental/demo-only* ML-KEM/Kyber envelopes, Dilithium signatures, and SPHINCS+ (requires `pip install "cryptography-suite[pqc]"`)
 - Homomorphic encryption helpers via Pyfhel under ``cryptography_suite.experimental.fhe`` (*experimental, opt-in only, no pickle context loading*)
 - Zero-knowledge proof demos (Bulletproofs, zk-SNARK) (*experimental*)
 

--- a/docs/pipeline_catalog.md
+++ b/docs/pipeline_catalog.md
@@ -12,5 +12,7 @@ Quick reference of built-in modules for the `Pipeline` DSL.
 | ECIESX25519Decrypt | Decrypt ECIES X25519 ciphertext. |
 | HybridEncrypt | Encrypt using hybrid RSA/ECIES + AES-GCM. |
 | HybridDecrypt | Decrypt data produced by HybridEncrypt. |
-| KyberEncrypt | Encrypt data using Kyber and AES-GCM. |
-| KyberDecrypt | Decrypt data produced by KyberEncrypt. |
+| MLKEMEncrypt | Encrypt data as a sealed ML-KEM/AES-GCM envelope. |
+| MLKEMDecrypt | Decrypt data produced by MLKEMEncrypt. |
+| KyberEncrypt | Deprecated compatibility wrapper for MLKEMEncrypt. |
+| KyberDecrypt | Deprecated compatibility wrapper for MLKEMDecrypt. |

--- a/docs/pipeline_coverage.md
+++ b/docs/pipeline_coverage.md
@@ -8,6 +8,8 @@
 | `ec_decrypt` | `ECIESX25519Decrypt` |
 | `hybrid_encrypt` | `HybridEncrypt` |
 | `hybrid_decrypt` | `HybridDecrypt` |
+| `ml_kem_encrypt` | `MLKEMEncrypt` |
+| `ml_kem_decrypt` | `MLKEMDecrypt` |
 | `kyber_encrypt` | `KyberEncrypt` |
 | `kyber_decrypt` | `KyberDecrypt` |
 | `rsa_encrypt` | `RSAEncrypt`    |

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -47,9 +47,10 @@ def test_keygen_pqc_does_not_print_private_key(monkeypatch, capsys):
     cli.keygen_cli(["kyber"])
 
     captured = capsys.readouterr()
-    assert "key material was not printed" in captured.out
+    assert "private key material was generated but not printed" in captured.out
     assert "7075626c6963" not in captured.out
     assert "70726976617465" not in captured.out
+    assert "shared secret" not in captured.out.lower()
     assert captured.err == ""
 
 

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -1,15 +1,15 @@
 import unittest
 
 from cryptography_suite import hybrid_decrypt, hybrid_encrypt
+from cryptography_suite.asymmetric import generate_rsa_keypair, generate_x25519_keypair
+from cryptography_suite.errors import CryptographySuiteError
 from cryptography_suite.hybrid import EncryptedHybridMessage
 from cryptography_suite.pqc import (
     PQCRYPTO_AVAILABLE,
-    generate_kyber_keypair,
-    kyber_encrypt,
-    kyber_decrypt,
+    generate_ml_kem_keypair,
+    ml_kem_decrypt,
+    ml_kem_encrypt,
 )
-from cryptography_suite.asymmetric import generate_rsa_keypair, generate_x25519_keypair
-from cryptography_suite.errors import CryptographySuiteError
 
 
 class TestHybrid(unittest.TestCase):
@@ -57,10 +57,11 @@ class TestHybrid(unittest.TestCase):
     def test_kyber_aes_gcm_roundtrip(self):
         msg = b"kyber hybrid"
         for lvl in (512, 768, 1024):
-            pk, sk = generate_kyber_keypair(level=lvl)
-            ct, ss = kyber_encrypt(pk, msg, level=lvl)
-            self.assertEqual(kyber_decrypt(sk, ct, ss, level=lvl), msg)
-            self.assertEqual(kyber_decrypt(sk, ct, level=lvl), msg)
+            pk, sk = generate_ml_kem_keypair(level=lvl)
+            envelope = ml_kem_encrypt(pk, msg, level=lvl)
+            self.assertIsInstance(envelope, str)
+            self.assertNotIsInstance(envelope, tuple)
+            self.assertEqual(ml_kem_decrypt(sk, envelope, level=lvl), msg)
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,20 +1,28 @@
-import unittest
 import json
-
-from cryptography_suite.pipeline import AESGCMEncrypt, Pipeline
+import unittest
 from typing import Protocol
 
+from cryptography_suite.pipeline import (
+    AESGCMEncrypt,
+    MLKEMDecrypt,
+    MLKEMEncrypt,
+    Pipeline,
+)
+
+
 class Upper(Protocol):
-    def run(self, data: bytes) -> bytes:
-        ...
+    def run(self, data: bytes) -> bytes: ...
+
 
 class UpperCase:
     def run(self, data: bytes) -> bytes:
         return data.upper()
 
+
 class Reverse:
     def run(self, data: bytes) -> bytes:
         return data[::-1]
+
 
 class TestPipeline(unittest.TestCase):
     def test_sequential_pipeline(self):
@@ -40,6 +48,28 @@ class TestPipeline(unittest.TestCase):
         self.assertEqual(parsed[0]["params"]["password"], "***REDACTED***")
         self.assertEqual(desc[0]["module"], "AESGCMEncrypt")
         self.assertEqual(desc[0]["params"]["kdf"], "argon2")
+
+    def test_ml_kem_describe_and_json_redact_key_material(self):
+        public_key = b"MLKEM_PUBLIC_KEY_MARKER"
+        private_key = b"MLKEM_PRIVATE_KEY_MARKER"
+        shared_secret_like = "DUMMY_KEM_SHARED_SECRET_MARKER"
+        p = Pipeline(
+            [
+                MLKEMEncrypt(public_key=public_key),
+                MLKEMDecrypt(private_key=private_key),
+            ]
+        )
+
+        desc = p.describe()
+        json_blob = p.to_json()
+        combined = f"{desc} {json_blob}"
+
+        self.assertEqual(desc[0]["params"]["public_key"], "***REDACTED***")
+        self.assertEqual(desc[1]["params"]["private_key"], "***REDACTED***")
+        self.assertNotIn(public_key.decode(), combined)
+        self.assertNotIn(private_key.decode(), combined)
+        self.assertNotIn(shared_secret_like, combined)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,9 +1,10 @@
 import json
 import unittest
-from typing import Protocol
+from typing import Any, Protocol, cast
 
 from cryptography_suite.pipeline import (
     AESGCMEncrypt,
+    CryptoModule,
     MLKEMDecrypt,
     MLKEMEncrypt,
     Pipeline,
@@ -18,20 +19,34 @@ class UpperCase:
     def run(self, data: bytes) -> bytes:
         return data.upper()
 
+    def to_proverif(self) -> str:
+        return "uppercase"
+
+    def to_tamarin(self) -> str:
+        return "uppercase"
+
 
 class Reverse:
     def run(self, data: bytes) -> bytes:
         return data[::-1]
 
+    def to_proverif(self) -> str:
+        return "reverse"
+
+    def to_tamarin(self) -> str:
+        return "reverse"
+
 
 class TestPipeline(unittest.TestCase):
     def test_sequential_pipeline(self):
-        p = Pipeline() >> UpperCase() >> Reverse()
+        p: Pipeline[Any, Any] = Pipeline()
+        p = p >> UpperCase() >> Reverse()
         result = p.run(b"abc")
         self.assertEqual(result, b"CBA")
 
     def test_describe(self):
-        p = Pipeline() >> UpperCase()
+        p: Pipeline[Any, Any] = Pipeline()
+        p = p >> UpperCase()
         desc = p.describe()
         self.assertEqual(desc[0]["module"], "UpperCase")
 
@@ -53,10 +68,10 @@ class TestPipeline(unittest.TestCase):
         public_key = b"MLKEM_PUBLIC_KEY_MARKER"
         private_key = b"MLKEM_PRIVATE_KEY_MARKER"
         shared_secret_like = "DUMMY_KEM_SHARED_SECRET_MARKER"
-        p = Pipeline(
+        p: Pipeline[Any, Any] = Pipeline(
             [
-                MLKEMEncrypt(public_key=public_key),
-                MLKEMDecrypt(private_key=private_key),
+                cast(CryptoModule[Any, Any], MLKEMEncrypt(public_key=public_key)),
+                cast(CryptoModule[Any, Any], MLKEMDecrypt(private_key=private_key)),
             ]
         )
 

--- a/tests/test_pipeline_roundtrip_property.py
+++ b/tests/test_pipeline_roundtrip_property.py
@@ -1,23 +1,24 @@
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
 
+from cryptography_suite.asymmetric import generate_rsa_keypair, generate_x25519_keypair
 from cryptography_suite.pipeline import (
-    Pipeline,
-    ECIESX25519Encrypt,
     ECIESX25519Decrypt,
-    HybridEncrypt,
+    ECIESX25519Encrypt,
     HybridDecrypt,
-    KyberEncrypt,
-    KyberDecrypt,
+    HybridEncrypt,
+    MLKEMDecrypt,
+    MLKEMEncrypt,
+    Pipeline,
 )
-from cryptography_suite.asymmetric import generate_x25519_keypair, generate_rsa_keypair
-from cryptography_suite.pqc import generate_kyber_keypair, PQCRYPTO_AVAILABLE
+from cryptography_suite.pqc import PQCRYPTO_AVAILABLE, generate_ml_kem_keypair
 
 PRIVATE_X25519, PUBLIC_X25519 = generate_x25519_keypair()
 RSA_PRIV, RSA_PUB = generate_rsa_keypair(key_size=2048)
 
 if PQCRYPTO_AVAILABLE:
-    KYBER_PUB, KYBER_PRIV = generate_kyber_keypair()
+    KYBER_PUB, KYBER_PRIV = generate_ml_kem_keypair()
 else:  # pragma: no cover - environment without pqcrypto
     KYBER_PUB = KYBER_PRIV = b""
 
@@ -35,7 +36,9 @@ def test_ecies_pipeline_roundtrip(message: bytes) -> None:
 @given(message=st.binary(min_size=1, max_size=256))
 def test_hybrid_pipeline_roundtrip(message: bytes) -> None:
     pipe = (
-        Pipeline() >> HybridEncrypt(public_key=RSA_PUB) >> HybridDecrypt(private_key=RSA_PRIV)
+        Pipeline()
+        >> HybridEncrypt(public_key=RSA_PUB)
+        >> HybridDecrypt(private_key=RSA_PRIV)
     )
     assert pipe.run(message) == message
 
@@ -44,6 +47,8 @@ def test_hybrid_pipeline_roundtrip(message: bytes) -> None:
 @given(message=st.binary(min_size=1, max_size=256))
 def test_kyber_pipeline_roundtrip(message: bytes) -> None:
     pipe = (
-        Pipeline() >> KyberEncrypt(public_key=KYBER_PUB) >> KyberDecrypt(private_key=KYBER_PRIV)
+        Pipeline()
+        >> MLKEMEncrypt(public_key=KYBER_PUB)
+        >> MLKEMDecrypt(private_key=KYBER_PRIV)
     )
     assert pipe.run(message) == message

--- a/tests/test_pqc.py
+++ b/tests/test_pqc.py
@@ -1,34 +1,229 @@
+import base64
+import re
 import unittest
+from pathlib import Path
 from typing import cast
 
-from cryptography_suite.errors import DecryptionError
+import pytest
+
+from cryptography_suite import pqc as pqc_module
+from cryptography_suite.errors import DecryptionError, EncryptionError
+from cryptography_suite.pipeline import (
+    KyberDecrypt,
+    KyberEncrypt,
+    MLKEMDecrypt,
+    MLKEMEncrypt,
+    Pipeline,
+)
 from cryptography_suite.pqc import (
     PQCRYPTO_AVAILABLE,
     SPHINCS_AVAILABLE,
     dilithium_sign,
     dilithium_verify,
     generate_dilithium_keypair,
-    generate_kyber_keypair,
+    generate_ml_kem_keypair,
     generate_sphincs_keypair,
     kyber_decrypt,
     kyber_encrypt,
+    ml_kem_decrypt,
+    ml_kem_encrypt,
     sphincs_sign,
     sphincs_verify,
 )
 
 
+class DummyEnvelopeKEM:
+    CIPHERTEXT_SIZE = 6
+    SHARED_SECRET = b"DUMMY_KEM_SHARED_SECRET_MARKER"
+
+    @staticmethod
+    def generate_keypair():
+        return b"dummy-public-key", b"dummy-private-key"
+
+    @staticmethod
+    def encrypt(public_key):
+        if public_key != b"dummy-public-key":
+            raise ValueError("bad public key")
+        return b"KEMCT1", DummyEnvelopeKEM.SHARED_SECRET
+
+    @staticmethod
+    def decrypt(private_key, ciphertext):
+        if private_key != b"dummy-private-key" or ciphertext != b"KEMCT1":
+            raise ValueError("bad ciphertext")
+        return DummyEnvelopeKEM.SHARED_SECRET
+
+
+@pytest.fixture()
+def dummy_ml_kem(monkeypatch):
+    monkeypatch.setattr(pqc_module, "PQCRYPTO_AVAILABLE", True)
+    for level in (512, 768, 1024):
+        monkeypatch.setitem(pqc_module._KYBER_LEVEL_MAP, level, DummyEnvelopeKEM)
+    return DummyEnvelopeKEM
+
+
+def test_ml_kem_encrypt_decrypt_round_trip(dummy_ml_kem):
+    public_key, private_key = pqc_module.generate_ml_kem_keypair(sensitive=False)
+
+    envelope = pqc_module.ml_kem_encrypt(public_key, b"pqc test")
+
+    assert isinstance(envelope, str)
+    assert pqc_module.ml_kem_decrypt(private_key, envelope) == b"pqc test"
+
+    raw_envelope = pqc_module.ml_kem_encrypt(
+        public_key, b"raw pqc test", raw_output=True
+    )
+    assert isinstance(raw_envelope, bytes)
+    assert raw_envelope.startswith(pqc_module._ML_KEM_ENVELOPE_MAGIC)
+    assert pqc_module.ml_kem_decrypt(private_key, raw_envelope) == b"raw pqc test"
+
+
+def test_kyber_encrypt_no_longer_returns_tuple_or_shared_secret(dummy_ml_kem):
+    public_key, private_key = pqc_module.generate_ml_kem_keypair(sensitive=False)
+
+    with pytest.warns(DeprecationWarning):
+        envelope = pqc_module.kyber_encrypt(public_key, b"compat pqc")
+
+    assert isinstance(envelope, str)
+    assert not isinstance(envelope, tuple)
+
+    with pytest.warns(DeprecationWarning):
+        assert pqc_module.kyber_decrypt(private_key, envelope) == b"compat pqc"
+
+
+def test_kyber_decrypt_ignores_old_shared_secret_argument(dummy_ml_kem):
+    public_key, private_key = pqc_module.generate_ml_kem_keypair(sensitive=False)
+    envelope = pqc_module.ml_kem_encrypt(public_key, b"compat decrypt")
+
+    with pytest.warns(DeprecationWarning):
+        decrypted = pqc_module.kyber_decrypt(
+            private_key, envelope, b"caller supplied secret is ignored"
+        )
+
+    assert decrypted == b"compat decrypt"
+
+
+def test_envelope_does_not_contain_shared_secret_directly(dummy_ml_kem):
+    public_key, _ = pqc_module.generate_ml_kem_keypair(sensitive=False)
+    secret = DummyEnvelopeKEM.SHARED_SECRET
+
+    text_envelope = pqc_module.ml_kem_encrypt(public_key, b"secret check")
+    raw_envelope = cast(
+        bytes, pqc_module.ml_kem_encrypt(public_key, b"secret check", raw_output=True)
+    )
+
+    assert text_envelope != secret.decode()
+    assert base64.b64encode(secret).decode() not in text_envelope
+    assert secret not in base64.b64decode(text_envelope, validate=True)
+    assert raw_envelope != secret
+    assert secret not in raw_envelope
+
+
+def test_malformed_and_truncated_envelopes_raise_decryption_error(dummy_ml_kem):
+    public_key, private_key = pqc_module.generate_ml_kem_keypair(sensitive=False)
+    raw_envelope = cast(
+        bytes, pqc_module.ml_kem_encrypt(public_key, b"truncated", raw_output=True)
+    )
+
+    for bad_envelope in (
+        b"not an envelope",
+        raw_envelope[: len(pqc_module._ML_KEM_ENVELOPE_MAGIC)],
+        raw_envelope[:-1],
+    ):
+        with pytest.raises(DecryptionError):
+            pqc_module.ml_kem_decrypt(private_key, bad_envelope)
+
+
+def test_corrupted_kem_ciphertext_nonce_or_tag_raises_decryption_error(dummy_ml_kem):
+    public_key, private_key = pqc_module.generate_ml_kem_keypair(sensitive=False)
+    raw_envelope = cast(
+        bytes, pqc_module.ml_kem_encrypt(public_key, b"corruption", raw_output=True)
+    )
+
+    kem_corrupt = bytearray(raw_envelope)
+    kem_corrupt[pqc_module._ML_KEM_HEADER_SIZE] ^= 0x01
+    with pytest.raises(DecryptionError):
+        pqc_module.ml_kem_decrypt(private_key, bytes(kem_corrupt))
+
+    nonce_corrupt = bytearray(raw_envelope)
+    nonce_index = (
+        pqc_module._ML_KEM_HEADER_SIZE
+        + DummyEnvelopeKEM.CIPHERTEXT_SIZE
+        + pqc_module._ML_KEM_SALT_SIZE
+    )
+    nonce_corrupt[nonce_index] ^= 0x01
+    with pytest.raises(DecryptionError):
+        pqc_module.ml_kem_decrypt(private_key, bytes(nonce_corrupt))
+
+    tag_corrupt = bytearray(raw_envelope)
+    tag_corrupt[-1] ^= 0x01
+    with pytest.raises(DecryptionError):
+        pqc_module.ml_kem_decrypt(private_key, bytes(tag_corrupt))
+
+
+def test_invalid_ml_kem_level_fails_deterministically(dummy_ml_kem):
+    public_key, private_key = pqc_module.generate_ml_kem_keypair(sensitive=False)
+    envelope = pqc_module.ml_kem_encrypt(public_key, b"level check")
+
+    with pytest.raises(EncryptionError):
+        pqc_module.ml_kem_encrypt(public_key, b"level check", level=999)
+    with pytest.raises(DecryptionError):
+        pqc_module.ml_kem_decrypt(private_key, envelope, level=999)
+    with pytest.raises(DecryptionError):
+        pqc_module.ml_kem_decrypt(private_key, envelope, level=768)
+
+
+def test_pipeline_ml_kem_and_kyber_wrappers_return_envelope_only(dummy_ml_kem):
+    public_key, private_key = pqc_module.generate_ml_kem_keypair(sensitive=False)
+
+    envelope = (Pipeline() >> MLKEMEncrypt(public_key=public_key)).run(b"pipeline")
+    assert isinstance(envelope, str)
+    assert not isinstance(envelope, tuple)
+    assert (
+        Pipeline()
+        >> MLKEMEncrypt(public_key=public_key)
+        >> MLKEMDecrypt(private_key=private_key)
+    ).run(b"pipeline") == b"pipeline"
+
+    with pytest.warns(DeprecationWarning):
+        compat_envelope = (Pipeline() >> KyberEncrypt(public_key=public_key)).run(
+            b"compat pipeline"
+        )
+    assert isinstance(compat_envelope, str)
+    assert not isinstance(compat_envelope, tuple)
+    with pytest.warns(DeprecationWarning):
+        assert KyberDecrypt(private_key=private_key).run(compat_envelope) == (
+            b"compat pipeline"
+        )
+
+
+def test_pqc_docs_do_not_show_shared_secret_kyber_examples():
+    repo_root = Path(__file__).resolve().parents[1]
+    paths = [repo_root / "README.md"]
+    paths.extend((repo_root / "docs").rglob("*.md"))
+    paths.extend((repo_root / "docs").rglob("*.rst"))
+    docs_text = "\n".join(path.read_text(encoding="utf-8") for path in paths)
+    old_unpack_example = "ct, " + "ss = kyber_encrypt"
+
+    assert old_unpack_example not in docs_text
+    assert not re.search(r"kyber_decrypt\([^)\n]*\bss\b", docs_text)
+
+
 @unittest.skipUnless(PQCRYPTO_AVAILABLE, "pqcrypto not installed")
 class TestPQC(unittest.TestCase):
-    def test_kyber_encrypt_decrypt_levels(self):
+    def test_ml_kem_encrypt_decrypt_levels(self):
         msg = b"pqc test"
         for lvl in (512, 768, 1024):
-            pk, sk = generate_kyber_keypair(level=lvl)
-            ct, ss = kyber_encrypt(pk, msg, level=lvl)
-            self.assertIsInstance(ct, str)
-            self.assertIsInstance(ss, str)
-            self.assertEqual(kyber_decrypt(sk, ct, ss, level=lvl), msg)
-            # also validate auto-decapsulation path
-            self.assertEqual(kyber_decrypt(sk, ct, level=lvl), msg)
+            pk, sk = generate_ml_kem_keypair(level=lvl)
+            envelope = ml_kem_encrypt(pk, msg, level=lvl)
+            self.assertIsInstance(envelope, str)
+            self.assertEqual(ml_kem_decrypt(sk, envelope, level=lvl), msg)
+
+            with self.assertWarns(DeprecationWarning):
+                compat_envelope = kyber_encrypt(pk, msg, level=lvl)
+            self.assertIsInstance(compat_envelope, str)
+            self.assertNotIsInstance(compat_envelope, tuple)
+            with self.assertWarns(DeprecationWarning):
+                self.assertEqual(kyber_decrypt(sk, compat_envelope, level=lvl), msg)
 
     def test_dilithium_signature(self):
         pk, sk = generate_dilithium_keypair()
@@ -37,30 +232,34 @@ class TestPQC(unittest.TestCase):
         self.assertIsInstance(sig, str)
         self.assertTrue(dilithium_verify(pk, msg, sig))
 
-    def test_kyber_decrypt_short_ciphertext_raises_decryption_error(self):
-        _, sk = generate_kyber_keypair(level=512)
+    def test_ml_kem_decrypt_short_ciphertext_raises_decryption_error(self):
+        _, sk = generate_ml_kem_keypair(level=512)
         with self.assertRaises(DecryptionError):
-            kyber_decrypt(sk, b"\x00" * 10, level=512)
+            ml_kem_decrypt(sk, b"\x00" * 10, level=512)
 
-    def test_kyber_decrypt_corrupt_nonce_or_tag_raises_decryption_error(self):
+    def test_ml_kem_decrypt_corrupt_kem_nonce_or_tag_raises_decryption_error(self):
         msg = b"nonce/tag corruption test"
-        pk, sk = generate_kyber_keypair(level=512)
-        ct, _ = kyber_encrypt(pk, msg, level=512, raw_output=True)
-        raw_ct = cast(bytes, ct)
+        pk, sk = generate_ml_kem_keypair(level=512)
+        raw_envelope = cast(bytes, ml_kem_encrypt(pk, msg, level=512, raw_output=True))
+        kem_ct_size = pqc_module._KYBER_LEVEL_MAP[512].CIPHERTEXT_SIZE
 
-        # Corrupt nonce byte (first byte after KEM ciphertext + salt).
-        nonce_corrupt = bytearray(raw_ct)
-        kem_ct_size = len(raw_ct) - (16 + 12 + len(msg) + 16)
-        nonce_index = kem_ct_size + 16
+        kem_corrupt = bytearray(raw_envelope)
+        kem_corrupt[pqc_module._ML_KEM_HEADER_SIZE] ^= 0x01
+        with self.assertRaises(DecryptionError):
+            ml_kem_decrypt(sk, bytes(kem_corrupt), level=512)
+
+        nonce_corrupt = bytearray(raw_envelope)
+        nonce_index = (
+            pqc_module._ML_KEM_HEADER_SIZE + kem_ct_size + pqc_module._ML_KEM_SALT_SIZE
+        )
         nonce_corrupt[nonce_index] ^= 0x01
         with self.assertRaises(DecryptionError):
-            kyber_decrypt(sk, bytes(nonce_corrupt), level=512)
+            ml_kem_decrypt(sk, bytes(nonce_corrupt), level=512)
 
-        # Corrupt tag byte (last byte of payload).
-        tag_corrupt = bytearray(raw_ct)
+        tag_corrupt = bytearray(raw_envelope)
         tag_corrupt[-1] ^= 0x01
         with self.assertRaises(DecryptionError):
-            kyber_decrypt(sk, bytes(tag_corrupt), level=512)
+            ml_kem_decrypt(sk, bytes(tag_corrupt), level=512)
 
     @unittest.skipUnless(SPHINCS_AVAILABLE, "SPHINCS+ not available")
     def test_sphincs_signature(self):

--- a/tests/test_pqc_stubs.py
+++ b/tests/test_pqc_stubs.py
@@ -1,37 +1,54 @@
 import importlib
 import sys
 import types
+from typing import Any
+
 import pytest
 
+
 class DummyKEM:
+    CIPHERTEXT = b"ct"
+    SECRET = b"stub shared secret marker"
+    CIPHERTEXT_SIZE = len(CIPHERTEXT)
+
     @staticmethod
     def generate_keypair():
         return b"pk", b"sk"
+
     @staticmethod
     def encrypt(pk):
-        return b"ct", b"ss"
+        return DummyKEM.CIPHERTEXT, DummyKEM.SECRET
+
     @staticmethod
     def decrypt(sk, ct):
-        return b"ss"
+        if sk != b"sk" or ct != DummyKEM.CIPHERTEXT:
+            raise ValueError("bad KEM ciphertext")
+        return DummyKEM.SECRET
 
-    CIPHERTEXT_SIZE = 2
 
 class DummySIG:
     @staticmethod
     def generate_keypair():
         return b"pk", b"sk"
+
     @staticmethod
     def sign(sk, msg):
         return b"sig"
+
     @staticmethod
     def verify(pk, msg, sig):
         return sig == b"sig"
 
-kem_mod = types.SimpleNamespace(ml_kem_512=DummyKEM, ml_kem_768=DummyKEM, ml_kem_1024=DummyKEM)
-sign_mod = types.SimpleNamespace(ml_dsa_44=DummySIG, ml_dsa_65=DummySIG, ml_dsa_87=DummySIG)
+
+kem_mod = types.SimpleNamespace(
+    ml_kem_512=DummyKEM, ml_kem_768=DummyKEM, ml_kem_1024=DummyKEM
+)
+sign_mod = types.SimpleNamespace(
+    ml_dsa_44=DummySIG, ml_dsa_65=DummySIG, ml_dsa_87=DummySIG
+)
 
 
-def reload_module(monkeypatch):
+def reload_module(monkeypatch: pytest.MonkeyPatch) -> Any:
     pq = types.SimpleNamespace(kem=kem_mod, sign=sign_mod)
     monkeypatch.setitem(sys.modules, "pqcrypto", pq)
     monkeypatch.setitem(sys.modules, "pqcrypto.kem", kem_mod)
@@ -43,6 +60,7 @@ def reload_module(monkeypatch):
     monkeypatch.setitem(sys.modules, "pqcrypto.sign.ml_dsa_65", DummySIG)
     monkeypatch.setitem(sys.modules, "pqcrypto.sign.ml_dsa_87", DummySIG)
     import cryptography_suite.pqc as pqc
+
     importlib.reload(pqc)
     return pqc
 
@@ -50,12 +68,19 @@ def reload_module(monkeypatch):
 def test_pqc_key_enc_sign(monkeypatch):
     pqc = reload_module(monkeypatch)
     for lvl in (512, 768, 1024):
-        pk, sk = pqc.generate_kyber_keypair(level=lvl)
-        ct, ss = pqc.kyber_encrypt(pk, b"m", level=lvl)
-        assert isinstance(ct, str)
-        assert isinstance(ss, str)
-        assert pqc.kyber_decrypt(sk, ct, ss, level=lvl) == b"m"
-        assert pqc.kyber_decrypt(sk, ct, level=lvl) == b"m"
+        pk, sk = pqc.generate_ml_kem_keypair(level=lvl)
+        envelope = pqc.ml_kem_encrypt(pk, b"m", level=lvl)
+        assert isinstance(envelope, str)
+        assert not isinstance(envelope, tuple)
+        assert DummyKEM.SECRET not in envelope.encode()
+        assert pqc.ml_kem_decrypt(sk, envelope, level=lvl) == b"m"
+
+        with pytest.warns(DeprecationWarning):
+            compat_envelope = pqc.kyber_encrypt(pk, b"m", level=lvl)
+        assert isinstance(compat_envelope, str)
+        assert not isinstance(compat_envelope, tuple)
+        with pytest.warns(DeprecationWarning):
+            assert pqc.kyber_decrypt(sk, compat_envelope, b"ignored", level=lvl) == b"m"
     pk2, sk2 = pqc.generate_dilithium_keypair()
     sig = pqc.dilithium_sign(sk2, b"m")
     assert isinstance(sig, str)
@@ -65,7 +90,8 @@ def test_pqc_key_enc_sign(monkeypatch):
 def test_pqc_import_error(monkeypatch):
     monkeypatch.setitem(sys.modules, "pqcrypto", None)
     import cryptography_suite.pqc as pqc
+
     importlib.reload(pqc)
     pqc.PQCRYPTO_AVAILABLE = False
     with pytest.raises(ImportError):
-        pqc.generate_kyber_keypair()
+        pqc.generate_ml_kem_keypair()

--- a/tests/test_root_exports.py
+++ b/tests/test_root_exports.py
@@ -4,10 +4,14 @@ import cryptography_suite as cs
 
 
 def test_root_exports_available():
-    from cryptography_suite.pipeline import AESGCMEncrypt, RSAEncrypt
+    from cryptography_suite.pipeline import AESGCMEncrypt, MLKEMEncrypt, RSAEncrypt
+    from cryptography_suite.pqc import ml_kem_decrypt, ml_kem_encrypt
 
     assert callable(AESGCMEncrypt)
     assert callable(RSAEncrypt)
+    assert callable(MLKEMEncrypt)
+    assert callable(ml_kem_encrypt)
+    assert callable(ml_kem_decrypt)
     assert callable(cs.KeyVault)
     assert callable(cs.to_pem)
     assert callable(cs.to_public_pem)


### PR DESCRIPTION
## Summary
- Adds `ml_kem_encrypt` / `ml_kem_decrypt` safe envelope APIs for experimental ML-KEM encryption.
- Introduces a versioned `CSKEM1` binary envelope carrying level, KEM ciphertext length, salt length, nonce length, KEM ciphertext, salt, nonce, and AES-GCM ciphertext+tag.
- Adds `MLKEMEncrypt` / `MLKEMDecrypt` pipeline modules and keeps Kyber names as deprecated compatibility wrappers.
- Updates PQC docs/examples and regression tests so normal paths no longer return, print, log, or serialize KEM shared secrets.

## Security Behavior Changes
- Encryption now returns a single sealed envelope, never `(ciphertext, shared_secret)`.
- AES-GCM authenticates the envelope header as AAD.
- AES keys are derived with HKDF-SHA256 from the internal KEM shared secret and random salt using explicit domain separation: `cryptography-suite ml-kem aes-gcm envelope v1 level=<level>`.
- Malformed, truncated, corrupted, bad-level, bad-tag, and decapsulation failures raise `DecryptionError` without exposing shared secrets.
- CLI PQC keygen continues to suppress key material and does not produce or print shared secrets.

## Compatibility Impact
- Breaking change: `kyber_encrypt` now returns only the sealed envelope, not a tuple containing a shared secret.
- Breaking change: `kyber_decrypt` decrypts new envelopes without a shared secret; the old `shared_secret` argument is deprecated and ignored if supplied.
- Old pre-envelope Kyber ciphertext/shared-secret workflows are not preserved through normal APIs.
- PQC helpers remain experimental/demo-only and are not production audited.

## Tests
- Added deterministic dummy-KEM regression tests for envelope round trips, no tuple/shared-secret return, ignored old shared-secret argument, malformed/truncated envelopes, corrupted KEM ciphertext/nonce/tag, invalid levels, pipeline wrappers, docs examples, and CLI keygen output.
- Updated existing PQC, hybrid, pipeline property, root export, CLI, and stub tests for the ML-KEM envelope behavior.

## Verification
- `python -m pytest -q tests/test_pqc.py tests/test_cli_main.py tests/test_root_exports.py` -> 20 passed, 6 skipped.
- `python -m pytest -q tests/test_pipeline.py tests/test_pqc.py` -> 12 passed, 6 skipped.
- `python -m pytest -q tests/test_pqc_stubs.py tests/test_hybrid.py tests/test_pipeline_roundtrip_property.py` -> 9 passed, 2 skipped.
- `python -m ruff check --fix <changed python files>` -> passed.
- `python -m ruff format <changed python files>` -> passed.
- `python -m black <changed python files>` -> passed.
- Scoped `python -m mypy ... <changed python files>` -> success, no issues found.
- `python -m pytest -q` -> 473 passed, 15 skipped, 21 existing warnings.
- `git diff --check` -> passed; only Git CRLF normalization warnings were printed.

## Grep Results and Interpretation
- `ct, ss = kyber_encrypt` -> no matches.
- `kyber_decrypt(.*ss` -> no matches.
- `shared_secret` -> only compatibility/deprecation text in README/PQC wrapper and negative/regression test names.
- `return .*ss` over `cryptography_suite/pqc` and `cryptography_suite/pipeline.py` -> false positives in unrelated `password`/`sphincs` returns; no PQC/Kyber/ML-KEM encryption path returns a shared secret.
- `private key material was generated but not printed` -> CLI output string and CLI regression test.

## Remaining Risks
- PQC/ML-KEM helpers remain experimental/demo-only and not production audited.
- Local verification skipped real `pqcrypto`-backed PQC tests because `pqcrypto` is not installed in the local environment; dummy-KEM tests exercise the envelope contract deterministically.