### PR TITLE
Move optional feature dependencies into extras

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,13 @@ jobs:
       - name: pip-audit
         run: python3 -m pip_audit --ignore-vuln CVE-2026-3219
       - name: Install Trivy
-        uses: aquasecurity/setup-trivy@e07451d2e059ed86c2870430ea286b3a9e0bf241
-        with:
-          version: v0.68.2
+        env:
+          TRIVY_VERSION: v0.70.0
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -sfL "https://raw.githubusercontent.com/aquasecurity/trivy/${TRIVY_VERSION}/contrib/install.sh" | sh -s -- -b "$HOME/.local/bin" "${TRIVY_VERSION}"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/trivy" --version
       - name: Trivy fs scan
         run: trivy fs --severity HIGH,CRITICAL --exit-code 1 .
       - name: Upload wheels

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,9 @@ jobs:
       - name: pip-audit
         run: python3 -m pip_audit --ignore-vuln CVE-2026-3219
       - name: Install Trivy
-        run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+        uses: aquasecurity/setup-trivy@e07451d2e059ed86c2870430ea286b3a9e0bf241
+        with:
+          version: v0.68.2
       - name: Trivy fs scan
         run: trivy fs --severity HIGH,CRITICAL --exit-code 1 .
       - name: Upload wheels

--- a/README.md
+++ b/README.md
@@ -242,10 +242,20 @@ Install the latest published release from PyPI:
 pip install cryptography-suite
 ```
 
-For optional functionality install extras:
+The default install is intentionally minimal: it installs the core educational
+APIs and default examples without pulling in optional research, notebook,
+code-generation, cloud, HSM, or developer tooling dependencies.
+
+Install extras only for the feature families you need:
 
 ```bash
-pip install "cryptography-suite[pqc,fhe,zk]"
+pip install "cryptography-suite[cli]"
+pip install "cryptography-suite[hashing-extra]"
+pip install "cryptography-suite[pqc]"
+pip install "cryptography-suite[fhe]"
+pip install "cryptography-suite[bls,pake,viz,codegen]"
+pip install "cryptography-suite[kms,hsm,async]"
+pip install "cryptography-suite[dev]"
 ```
 
 To include deprecated stream ciphers:
@@ -253,6 +263,8 @@ To include deprecated stream ciphers:
 > pip install cryptography-suite[legacy]
 
 The **SPHINCS+** signature helpers are included in the `pqc` extra and are experimental/demo-only.
+PQC, FHE, ZK, BLS, Signal/demo, and visualization extras remain experimental
+and are not independently audited.
 
 > **Note**: Requires Python 3.10 or higher. Homomorphic encryption features are disabled by default, require `CRYPTOSUITE_ALLOW_EXPERIMENTAL=1`, and need `Pyfhel` installed separately if the `fhe` extra is not used.
 
@@ -264,14 +276,14 @@ Clone the repository and install manually:
 git clone https://github.com/Psychevus/cryptography-suite.git
 cd cryptography-suite
 pip install .
-# Optional extras for development (pytest, mypy, etc.) and PQC
-pip install -e ".[dev,pqc]"
+# Optional extras for development and selected feature tests
+pip install -e ".[dev,pqc,bls,pake,hashing-extra]"
 ```
 
 ### Quick Start CLI
 
 ```bash
-pip install cryptography-suite
+pip install "cryptography-suite[cli]"
 
 # Encrypt a file
 cryptography-suite file encrypt --in input.txt --out encrypted.bin
@@ -348,7 +360,7 @@ ______________________________________________________________________
 | RSA, ECDSA, Ed25519, Ed448 | pyca/cryptography | Primary backend |
 | BLS12-381 | py_ecc | Optional |
 | SHA-2, SHA-3, BLAKE2b | pyca/cryptography | Primary backend |
-| BLAKE3 | blake3 | Primary backend |
+| BLAKE3 | blake3 (optional) | Optional |
 | Argon2id, Scrypt, PBKDF2, HKDF | pyca/cryptography | Primary backend |
 | Kyber, Dilithium (PQC) | pqcrypto (optional) | Optional |
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ pip install "cryptography-suite[hashing-extra]"
 pip install "cryptography-suite[pqc]"
 pip install "cryptography-suite[fhe]"
 pip install "cryptography-suite[bls,pake,viz,codegen]"
-pip install "cryptography-suite[kms,hsm,async]"
+pip install "cryptography-suite[kms,hsm,network,async]"
 pip install "cryptography-suite[dev]"
 ```
 

--- a/cryptography_suite/_mypy_crypto_checker.py
+++ b/cryptography_suite/_mypy_crypto_checker.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 
-from typing import Callable, Optional
-
-from mypy.plugin import Plugin, FunctionContext
 from mypy.nodes import StrExpr
+from mypy.plugin import FunctionContext, Plugin
 from mypy.types import Type
 
 
@@ -12,10 +11,13 @@ class CryptoCheckerPlugin(Plugin):
     """Static analysis checks for insecure crypto usage."""
 
     insecure_hashes = {"hashlib.md5", "hashlib.sha1"}
+    insecure_hash_message = (
+        "Insecure hash function '{alg}' used; use SHA-256 or stronger."
+    )
 
     def get_function_hook(
         self, fullname: str
-    ) -> Optional[Callable[[FunctionContext], Type]]:
+    ) -> Callable[[FunctionContext], Type] | None:
         if (
             fullname in self.insecure_hashes
             or fullname == "hashlib.new"
@@ -24,7 +26,7 @@ class CryptoCheckerPlugin(Plugin):
             or fullname.endswith("openssl_sha1")
         ):
 
-            def hook(ctx: FunctionContext, fname=fullname) -> Type:
+            def hook(ctx: FunctionContext, fname: str = fullname) -> Type:
                 return self._check_call(ctx, fname)
 
             return hook
@@ -38,7 +40,7 @@ class CryptoCheckerPlugin(Plugin):
         ):
             alg = fullname.split(".")[-1]
             ctx.api.fail(
-                f"Insecure hash function '{alg}' used; use SHA-256 or stronger.",
+                self.insecure_hash_message.format(alg=alg),
                 ctx.context,
             )
         elif fullname == "hashlib.new":
@@ -46,7 +48,7 @@ class CryptoCheckerPlugin(Plugin):
                 alg = ctx.args[0][0].value.lower()
                 if alg in {"md5", "sha1"}:
                     ctx.api.fail(
-                        f"Insecure hash function '{alg}' used; use SHA-256 or stronger.",
+                        self.insecure_hash_message.format(alg=alg),
                         ctx.context,
                     )
         elif fullname == "Crypto.Cipher.AES.new":

--- a/cryptography_suite/asymmetric/bls.py
+++ b/cryptography_suite/asymmetric/bls.py
@@ -11,11 +11,28 @@ from __future__ import annotations
 import base64
 from collections.abc import Iterable, Sequence
 from os import urandom
+from typing import Any
 
-from py_ecc.bls import G2Basic
+try:  # pragma: no cover - optional dependency
+    from py_ecc.bls import G2Basic
+except Exception:  # pragma: no cover - dependency missing
+    G2Basic = None
 
-from ..errors import KeyDerivationError, SignatureVerificationError
+from ..errors import (
+    KeyDerivationError,
+    MissingDependencyError,
+    SignatureVerificationError,
+)
 from ..utils import KeyVault
+
+
+def _require_py_ecc() -> Any:
+    if G2Basic is None:
+        raise MissingDependencyError(
+            "BLS signatures require py_ecc. "
+            "Install cryptography-suite[bls] to use this feature."
+        )
+    return G2Basic
 
 
 def generate_bls_keypair(
@@ -42,9 +59,10 @@ def generate_bls_keypair(
     if seed is not None and len(seed) == 0:
         raise KeyDerivationError("Seed cannot be empty.")
 
+    g2_basic = _require_py_ecc()
     ikm = seed if seed is not None else urandom(32)
-    sk = G2Basic.KeyGen(ikm)
-    pk = G2Basic.SkToPk(sk)
+    sk = g2_basic.KeyGen(ikm)
+    pk = g2_basic.SkToPk(sk)
     if sensitive:
         sk_bytes = sk.to_bytes(32, "big")
         return KeyVault(sk_bytes), pk
@@ -80,7 +98,7 @@ def bls_sign(
         private_key = int.from_bytes(private_key, "big")
     if not isinstance(private_key, int):
         raise TypeError("Private key must be an int or bytes.")
-    sig = G2Basic.Sign(private_key, message)
+    sig = _require_py_ecc().Sign(private_key, message)
     if raw_output:
         return sig
     return base64.b64encode(sig).decode()
@@ -114,11 +132,11 @@ def bls_verify(message: bytes, signature: bytes | str, public_key: bytes) -> boo
             signature = base64.b64decode(signature)
         except Exception:
             return False
-    return G2Basic.Verify(public_key, message, signature)
+    return _require_py_ecc().Verify(public_key, message, signature)
 
 
 def bls_aggregate(
-    signatures: Iterable[bytes], *, raw_output: bool = False
+    signatures: Iterable[bytes | str], *, raw_output: bool = False
 ) -> str | bytes:
     """Aggregate multiple BLS signatures into one.
 
@@ -142,7 +160,7 @@ def bls_aggregate(
         sig_list.append(sig)
     if not sig_list:
         raise SignatureVerificationError("No signatures provided for aggregation.")
-    agg = G2Basic.Aggregate(sig_list)
+    agg = _require_py_ecc().Aggregate(sig_list)
     if raw_output:
         return agg
     return base64.b64encode(agg).decode()
@@ -182,4 +200,6 @@ def bls_aggregate_verify(
             signature = base64.b64decode(signature)
         except Exception:
             return False
-    return G2Basic.AggregateVerify(list(public_keys), list(messages), signature)
+    return _require_py_ecc().AggregateVerify(
+        list(public_keys), list(messages), signature
+    )

--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -1101,10 +1101,10 @@ def main(argv: list[str] | None = None) -> None:
         try:
             spec.loader.exec_module(module)
         except ModuleNotFoundError as exc:
-            if exc.name in {"requests", "rich"}:
+            if exc.name == "rich":
                 _handle_missing_dependency_and_exit(
                     MissingDependencyError(
-                        "Key migration CLI support requires rich and requests. "
+                        "Key migration CLI support requires rich. "
                         "Install cryptography-suite[cli] to use this feature."
                     )
                 )

--- a/cryptography_suite/cli.py
+++ b/cryptography_suite/cli.py
@@ -12,8 +12,6 @@ import sys
 from pathlib import Path
 from typing import Any, Protocol, cast
 
-from blake3 import blake3
-
 from . import __version__
 from .core.logging import configure_structured_logging, get_structured_logger, log_event
 from .core.operations import (
@@ -24,13 +22,6 @@ from .core.operations import (
 from .crypto_backends import available_backends
 from .debug import redact_message
 from .errors import DecryptionError, MissingDependencyError
-from .pqc import (
-    PQCRYPTO_AVAILABLE,
-    SPHINCS_AVAILABLE,
-    generate_dilithium_keypair,
-    generate_kyber_keypair,
-    generate_sphincs_keypair,
-)
 from .protocols import generate_totp
 from .protocols.key_management import KeyManager
 from .symmetric.kdf import DEFAULT_KDF
@@ -49,12 +40,61 @@ from .zk.bulletproof import (
 )
 
 _OUTPUT_FORMAT = "text"
+PQCRYPTO_AVAILABLE = False
+SPHINCS_AVAILABLE = False
+generate_dilithium_keypair = None
+generate_kyber_keypair = None
+generate_sphincs_keypair = None
 
 
 class _HasherLike(Protocol):
     def update(self, data: bytes) -> object: ...
 
     def hexdigest(self) -> str: ...
+
+
+def _load_blake3_hasher() -> _HasherLike:
+    try:
+        from blake3 import blake3
+    except Exception as exc:  # pragma: no cover - dependency missing
+        raise MissingDependencyError(
+            "BLAKE3 hashing requires blake3. "
+            "Install cryptography-suite[hashing-extra] to use this feature."
+        ) from exc
+    return cast(_HasherLike, blake3())
+
+
+def _load_pqc_keygen_helpers() -> None:
+    global PQCRYPTO_AVAILABLE
+    global SPHINCS_AVAILABLE
+    global generate_dilithium_keypair
+    global generate_kyber_keypair
+    global generate_sphincs_keypair
+
+    if generate_kyber_keypair is not None:
+        return
+
+    from .pqc import (
+        PQCRYPTO_AVAILABLE as pqcrypto_available,
+    )
+    from .pqc import (
+        SPHINCS_AVAILABLE as sphincs_available,
+    )
+    from .pqc import (
+        generate_dilithium_keypair as dilithium_keypair,
+    )
+    from .pqc import (
+        generate_kyber_keypair as kyber_keypair,
+    )
+    from .pqc import (
+        generate_sphincs_keypair as sphincs_keypair,
+    )
+
+    PQCRYPTO_AVAILABLE = pqcrypto_available
+    SPHINCS_AVAILABLE = sphincs_available
+    generate_dilithium_keypair = dilithium_keypair
+    generate_kyber_keypair = kyber_keypair
+    generate_sphincs_keypair = sphincs_keypair
 
 
 def _set_output_format(fmt: str) -> None:
@@ -178,10 +218,16 @@ def zksnark_cli(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="SHA256 pre-image proof")
     parser.add_argument("preimage", help="Preimage string")
     if not ZKSNARK_AVAILABLE and argv and not any(a in ("-h", "--help") for a in argv):
-        raise MissingDependencyError("PySNARK not installed")
+        raise MissingDependencyError(
+            "PySNARK is required for zk-SNARK proofs. "
+            "Install cryptography-suite[zk] to use this feature."
+        )
     args = parser.parse_args(argv)
     if not ZKSNARK_AVAILABLE:
-        raise MissingDependencyError("PySNARK not installed")
+        raise MissingDependencyError(
+            "PySNARK is required for zk-SNARK proofs. "
+            "Install cryptography-suite[zk] to use this feature."
+        )
     zksnark.setup()
     hash_hex, proof_path = zksnark.prove(args.preimage.encode())
     valid = zksnark.verify(hash_hex, proof_path)
@@ -301,6 +347,11 @@ def _handle_cli_error(exc: Exception) -> None:
         )
 
 
+def _handle_missing_dependency_and_exit(exc: MissingDependencyError) -> None:
+    _handle_cli_error(exc)
+    raise SystemExit(1) from exc
+
+
 def _validate_regular_file(path_str: str, label: str) -> None:
     path = Path(path_str)
     if not path.exists() or not path.is_file():
@@ -355,11 +406,9 @@ def keygen_cli(argv: list[str] | None = None) -> None:
     rsa_p.add_argument("--public", required=True, help="Public key path")
     _add_password_source_args(rsa_p)
 
-    if PQCRYPTO_AVAILABLE:
-        sub.add_parser("dilithium", help="Generate a Dilithium key pair")
-        sub.add_parser("kyber", help="Generate a Kyber key pair")
-        if SPHINCS_AVAILABLE:
-            sub.add_parser("sphincs", help="Generate a SPHINCS+ key pair")
+    sub.add_parser("dilithium", help="Generate a Dilithium key pair")
+    sub.add_parser("kyber", help="Generate a Kyber key pair")
+    sub.add_parser("sphincs", help="Generate a SPHINCS+ key pair")
 
     args = parser.parse_args(argv)
 
@@ -369,11 +418,37 @@ def keygen_cli(argv: list[str] | None = None) -> None:
         km.generate_rsa_keypair_and_save(args.private, args.public, password)
         print(f"RSA keys saved to {args.private} and {args.public}")
     else:
+        _load_pqc_keygen_helpers()
+        if not PQCRYPTO_AVAILABLE:
+            raise MissingDependencyError(
+                "PQC key generation requires pqcrypto. "
+                "Install cryptography-suite[pqc] to use this feature."
+            )
+        if args.scheme == "sphincs" and not SPHINCS_AVAILABLE:
+            raise MissingDependencyError(
+                "SPHINCS+ key generation requires pqcrypto with SPHINCS+ support. "
+                "Install cryptography-suite[pqc] to use this feature."
+            )
         if args.scheme == "dilithium":
+            if generate_dilithium_keypair is None:
+                raise MissingDependencyError(
+                    "Dilithium key generation requires pqcrypto. "
+                    "Install cryptography-suite[pqc] to use this feature."
+                )
             generate_dilithium_keypair()
         elif args.scheme == "kyber":
+            if generate_kyber_keypair is None:
+                raise MissingDependencyError(
+                    "ML-KEM key generation requires pqcrypto. "
+                    "Install cryptography-suite[pqc] to use this feature."
+                )
             generate_kyber_keypair()
         else:
+            if generate_sphincs_keypair is None:
+                raise MissingDependencyError(
+                    "SPHINCS+ key generation requires pqcrypto. "
+                    "Install cryptography-suite[pqc] to use this feature."
+                )
             generate_sphincs_keypair()
         _emit(
             f"{args.scheme} private key material was generated but not printed.",
@@ -408,7 +483,7 @@ def hash_cli(argv: list[str] | None = None) -> None:
     elif args.algorithm == "blake2b":
         hasher = hashlib.blake2b()
     else:
-        hasher = blake3()
+        hasher = _load_blake3_hasher()
 
     with open(args.file, "rb") as file_handle:
         while chunk := file_handle.read(8192):
@@ -653,7 +728,13 @@ def export_cli(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
     _validate_regular_file(args.pipeline, "pipeline")
 
-    yaml = __import__("yaml")
+    try:
+        yaml = __import__("yaml")
+    except Exception as exc:
+        raise MissingDependencyError(
+            "Pipeline export requires PyYAML. "
+            "Install cryptography-suite[cli] to use this feature."
+        ) from exc
 
     from .pipeline import CryptoModule, Pipeline
 
@@ -948,19 +1029,31 @@ def main(argv: list[str] | None = None) -> None:
         if args.public:
             argv2.extend(["--public", args.public])
         _append_password_source_args(argv2, args)
-        keygen_cli(argv2)
+        try:
+            keygen_cli(argv2)
+        except MissingDependencyError as exc:
+            _handle_missing_dependency_and_exit(exc)
     elif args.cmd == "hash":
-        hash_cli([args.file, f"--algorithm={args.algorithm}"])
+        try:
+            hash_cli([args.file, f"--algorithm={args.algorithm}"])
+        except MissingDependencyError as exc:
+            _handle_missing_dependency_and_exit(exc)
     elif args.cmd == "export":
         argv2 = [args.pipeline, f"--format={args.format}"]
         for sec in args.track:
             argv2.extend(["--track", sec])
-        export_cli(argv2)
+        try:
+            export_cli(argv2)
+        except MissingDependencyError as exc:
+            _handle_missing_dependency_and_exit(exc)
     elif args.cmd == "gen":
         argv2 = [f"--target={args.target}", f"--pipeline={args.pipeline}"]
         if args.output:
             argv2.extend(["--output", args.output])
-        gen_cli(argv2)
+        try:
+            gen_cli(argv2)
+        except MissingDependencyError as exc:
+            _handle_missing_dependency_and_exit(exc)
     elif args.cmd == "keystore":
         argv2 = [args.action]
         if args.src:
@@ -1005,7 +1098,17 @@ def main(argv: list[str] | None = None) -> None:
         if spec is None or spec.loader is None:
             raise RuntimeError("Unable to load migrate_keys module")
         module = util.module_from_spec(spec)
-        spec.loader.exec_module(module)
+        try:
+            spec.loader.exec_module(module)
+        except ModuleNotFoundError as exc:
+            if exc.name in {"requests", "rich"}:
+                _handle_missing_dependency_and_exit(
+                    MissingDependencyError(
+                        "Key migration CLI support requires rich and requests. "
+                        "Install cryptography-suite[cli] to use this feature."
+                    )
+                )
+            raise
         argv2 = ["--from", args.src, "--to", args.dst]
         if getattr(args, "batch", False):
             argv2.append("--batch")
@@ -1013,7 +1116,10 @@ def main(argv: list[str] | None = None) -> None:
             argv2.append("--ignore-errors")
         if getattr(args, "dry_run", False):
             argv2.append("--dry-run")
-        module.wizard_cli(argv2)
+        try:
+            module.wizard_cli(argv2)
+        except MissingDependencyError as exc:
+            _handle_missing_dependency_and_exit(exc)
     elif args.cmd in ("file", "encrypt", "decrypt"):
         if args.cmd == "file":
             mode = args.file_cmd

--- a/cryptography_suite/codegen/__init__.py
+++ b/cryptography_suite/codegen/__init__.py
@@ -1,25 +1,45 @@
 """Code generation utilities for cryptosuite."""
+
 from __future__ import annotations
 
+from collections.abc import Iterable
 from importlib import resources
 from pathlib import Path
-from typing import Iterable
+from typing import Any
 
-import yaml
-from jinja2 import Environment, FileSystemLoader
+from ..errors import MissingDependencyError
+
+
+def _load_codegen_dependencies() -> tuple[Any, type[Any], type[Any]]:
+    try:
+        import yaml
+    except Exception as exc:  # pragma: no cover - dependency missing
+        raise MissingDependencyError(
+            "Code generation requires PyYAML. "
+            "Install cryptography-suite[codegen] to use this feature."
+        ) from exc
+    try:
+        from jinja2 import Environment, FileSystemLoader
+    except Exception as exc:  # pragma: no cover - dependency missing
+        raise MissingDependencyError(
+            "Code generation requires Jinja2. "
+            "Install cryptography-suite[codegen] to use this feature."
+        ) from exc
+    return yaml, Environment, FileSystemLoader
 
 
 def generate(target: str, pipeline_file: str, out_dir: str | None = None) -> Path:
     """Generate an application skeleton for the given target."""
+    yaml, environment_cls, file_system_loader_cls = _load_codegen_dependencies()
     out_path = Path(out_dir or f"generated_{target}")
     out_path.mkdir(parents=True, exist_ok=True)
 
-    with open(pipeline_file, "r", encoding="utf-8") as fh:
+    with open(pipeline_file, encoding="utf-8") as fh:
         steps: Iterable[str] = yaml.safe_load(fh) or []
 
     # Load templates
     with resources.path(__name__, "templates") as tpl_dir:
-        env = Environment(loader=FileSystemLoader(str(tpl_dir)))
+        env = environment_cls(loader=file_system_loader_cls(str(tpl_dir)))
         if target == "fastapi":
             template = env.get_template("fastapi/app.py.j2")
             fname = "app.py"

--- a/cryptography_suite/experimental/fhe.py
+++ b/cryptography_suite/experimental/fhe.py
@@ -77,7 +77,8 @@ class PyfhelBackend(HEBackend):
     def __init__(self) -> None:
         if Pyfhel is None:  # pragma: no cover - dependency missing
             raise MissingDependencyError(
-                "Pyfhel is required for experimental homomorphic encryption features"
+                "Pyfhel is required for experimental homomorphic encryption "
+                "features. Install cryptography-suite[fhe] to use this feature."
             )
 
     _CKKS_DEFAULTS: dict[str, Any] = {

--- a/cryptography_suite/hashing/__init__.py
+++ b/cryptography_suite/hashing/__init__.py
@@ -5,16 +5,37 @@ SHA and BLAKE2b use :mod:`pyca/cryptography`. BLAKE3 relies on the standalone
 project.
 """
 
-from cryptography.hazmat.primitives import hashes
-from blake3 import blake3
+from typing import Protocol, cast
 
+from cryptography.hazmat.primitives import hashes
+
+from ..errors import MissingDependencyError
 from ..symmetric.kdf import (  # noqa: F401
-    derive_key_scrypt,
-    verify_derived_key_scrypt,
     derive_key_pbkdf2,
-    verify_derived_key_pbkdf2,
+    derive_key_scrypt,
     generate_salt,
+    verify_derived_key_pbkdf2,
+    verify_derived_key_scrypt,
 )
+
+
+class _Blake3Digest(Protocol):
+    def hexdigest(self) -> str: ...
+
+
+class _Blake3Factory(Protocol):
+    def __call__(self, data: bytes) -> _Blake3Digest: ...
+
+
+def _load_blake3() -> _Blake3Factory:
+    try:
+        from blake3 import blake3
+    except Exception as exc:  # pragma: no cover - dependency missing
+        raise MissingDependencyError(
+            "BLAKE3 hashing requires blake3. "
+            "Install cryptography-suite[hashing-extra] to use this feature."
+        ) from exc
+    return cast(_Blake3Factory, blake3)
 
 
 def sha256_hash(data: str) -> str:
@@ -69,10 +90,12 @@ def blake2b_hash(data: str) -> str:
 
 def blake3_hash(data: str) -> str:
     """Generates a BLAKE3 hash of the given data."""
+    blake3 = _load_blake3()
     return blake3(data.encode()).hexdigest()
 
 
 def blake3_hash_v2(data: str) -> str:
     """Another BLAKE3 hash helper used for testing."""
+    blake3 = _load_blake3()
     digest = blake3(data.encode())
     return digest.hexdigest()

--- a/cryptography_suite/keystores/aws_kms.py
+++ b/cryptography_suite/keystores/aws_kms.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from ..audit import audit_log
 from ..core.logging import get_structured_logger
 from ..core.operations import RetryPolicy, retry_with_backoff
+from ..errors import MissingDependencyError
 from . import register_keystore
 from .base import KeyStoreCapability
 
@@ -57,7 +58,10 @@ class AWSKMSKeyStore:
         try:
             boto3_mod = import_module("boto3")
         except Exception as exc:
-            raise RuntimeError("boto3 is required for AWSKMSKeyStore") from exc
+            raise MissingDependencyError(
+                "AWS KMS keystore support requires boto3. "
+                "Install cryptography-suite[kms] to use this feature."
+            ) from exc
         self.client = boto3_mod.client("kms", region_name=region_name)
         self._logger_name = "cryptography_suite.keystores.aws_kms"
         self._retry = RetryPolicy(

--- a/cryptography_suite/keystores/pkcs11.py
+++ b/cryptography_suite/keystores/pkcs11.py
@@ -25,6 +25,7 @@ except Exception:  # pragma: no cover - dependency missing
     pkcs11 = None
 
 from ..audit import audit_log
+from ..errors import MissingDependencyError
 from . import register_keystore
 from .base import KeyStoreCapability
 
@@ -57,7 +58,10 @@ class PKCS11KeyStore:
         pin: str | None = None,
     ) -> None:
         if pkcs11 is None:  # pragma: no cover - dependency missing
-            raise ImportError("python-pkcs11>=0.8.1 is required for PKCS11KeyStore")
+            raise MissingDependencyError(
+                "PKCS#11 keystore support requires python-pkcs11>=0.8.1. "
+                "Install cryptography-suite[hsm] to use this feature."
+            )
 
         library_path, token_label, pin = self._load_config(
             library_path, token_label, pin

--- a/cryptography_suite/legacy/__init__.py
+++ b/cryptography_suite/legacy/__init__.py
@@ -5,21 +5,20 @@ recommended public interface. Prefer alternatives in the core API for new
 code.
 """
 
-from ..asymmetric.bls import (
-    bls_aggregate,
-    bls_aggregate_verify,
-    bls_sign,
-    bls_verify,
-    generate_bls_keypair,
-)
-
 from ..asymmetric.signatures import (
     generate_ed448_keypair,
     sign_message_ed448,
     verify_signature_ed448,
 )
-
 from ..hashing import blake3_hash_v2
+
+_BLS_EXPORTS = {
+    "generate_bls_keypair",
+    "bls_sign",
+    "bls_verify",
+    "bls_aggregate",
+    "bls_aggregate_verify",
+}
 
 __all__ = [
     "generate_bls_keypair",
@@ -32,3 +31,11 @@ __all__ = [
     "verify_signature_ed448",
     "blake3_hash_v2",
 ]
+
+
+def __getattr__(name: str):
+    if name in _BLS_EXPORTS:
+        from ..asymmetric import bls
+
+        return getattr(bls, name)
+    raise AttributeError(name)

--- a/cryptography_suite/pqc/__init__.py
+++ b/cryptography_suite/pqc/__init__.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
-from ..errors import DecryptionError, EncryptionError
+from ..errors import DecryptionError, EncryptionError, MissingDependencyError
 from ..symmetric.kdf import derive_hkdf
 from ..utils import KeyVault
 
@@ -66,7 +66,10 @@ def _get_ml_kem_algorithm(
     level: int, error_type: type[EncryptionError] | type[DecryptionError]
 ) -> Any:
     if not PQCRYPTO_AVAILABLE:
-        raise ImportError("pqcrypto is required for ML-KEM functions")
+        raise MissingDependencyError(
+            "ML-KEM functions require pqcrypto. "
+            "Install cryptography-suite[pqc] to use this feature."
+        )
 
     alg = _KYBER_LEVEL_MAP.get(level)
     if alg is None:
@@ -311,7 +314,10 @@ def generate_dilithium_keypair(
     :class:`KeyVault`.
     """
     if not PQCRYPTO_AVAILABLE:
-        raise ImportError("pqcrypto is required for Dilithium functions")
+        raise MissingDependencyError(
+            "Dilithium functions require pqcrypto. "
+            "Install cryptography-suite[pqc] to use this feature."
+        )
 
     pk, sk = ml_dsa_44.generate_keypair()
     return pk, KeyVault(sk) if sensitive else sk
@@ -328,7 +334,10 @@ def dilithium_sign(
     ``private_key`` may be provided as raw bytes or a :class:`KeyVault`.
     """
     if not PQCRYPTO_AVAILABLE:
-        raise ImportError("pqcrypto is required for Dilithium functions")
+        raise MissingDependencyError(
+            "Dilithium functions require pqcrypto. "
+            "Install cryptography-suite[pqc] to use this feature."
+        )
 
     key = bytes(private_key) if isinstance(private_key, KeyVault) else private_key
     sig = ml_dsa_44.sign(key, message)
@@ -344,7 +353,10 @@ def dilithium_verify(
 ) -> bool:
     """Verify a Dilithium signature using level 2."""
     if not PQCRYPTO_AVAILABLE:
-        raise ImportError("pqcrypto is required for Dilithium functions")
+        raise MissingDependencyError(
+            "Dilithium functions require pqcrypto. "
+            "Install cryptography-suite[pqc] to use this feature."
+        )
 
     if isinstance(signature, str):
         try:
@@ -367,7 +379,10 @@ def generate_sphincs_keypair(
     :class:`KeyVault`.
     """
     if not PQCRYPTO_AVAILABLE or not SPHINCS_AVAILABLE:
-        raise ImportError("pqcrypto with SPHINCS+ support is required")
+        raise MissingDependencyError(
+            "SPHINCS+ functions require pqcrypto with SPHINCS+ support. "
+            "Install cryptography-suite[pqc] to use this feature."
+        )
 
     pk, sk = _sphincs_module.generate_keypair()
     return pk, KeyVault(sk) if sensitive else sk
@@ -381,7 +396,10 @@ def sphincs_sign(
     ``private_key`` may be a byte string or :class:`KeyVault`.
     """
     if not PQCRYPTO_AVAILABLE or not SPHINCS_AVAILABLE:
-        raise ImportError("pqcrypto with SPHINCS+ support is required")
+        raise MissingDependencyError(
+            "SPHINCS+ functions require pqcrypto with SPHINCS+ support. "
+            "Install cryptography-suite[pqc] to use this feature."
+        )
 
     key = bytes(private_key) if isinstance(private_key, KeyVault) else private_key
     sig = _sphincs_module.sign(key, message)
@@ -393,7 +411,10 @@ def sphincs_sign(
 def sphincs_verify(public_key: bytes, message: bytes, signature: bytes | str) -> bool:
     """Verify a SPHINCS+ signature."""
     if not PQCRYPTO_AVAILABLE or not SPHINCS_AVAILABLE:
-        raise ImportError("pqcrypto with SPHINCS+ support is required")
+        raise MissingDependencyError(
+            "SPHINCS+ functions require pqcrypto with SPHINCS+ support. "
+            "Install cryptography-suite[pqc] to use this feature."
+        )
 
     if isinstance(signature, str):
         try:

--- a/cryptography_suite/protocols/pake.py
+++ b/cryptography_suite/protocols/pake.py
@@ -1,8 +1,29 @@
+from typing import Any
+
 from cryptography.exceptions import InvalidKey
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import x25519
-from spake2 import SPAKE2_A, SPAKE2_B, SPAKEError
-from ..errors import ProtocolError
+
+from ..errors import MissingDependencyError, ProtocolError
+
+SPAKE2_A: Any | None = None
+SPAKE2_B: Any | None = None
+
+
+def _require_spake2() -> tuple[Any, Any]:
+    global SPAKE2_A, SPAKE2_B
+    if SPAKE2_A is None or SPAKE2_B is None:
+        try:
+            from spake2 import SPAKE2_A as spake2_a
+            from spake2 import SPAKE2_B as spake2_b
+        except Exception as exc:  # pragma: no cover - dependency missing
+            raise MissingDependencyError(
+                "SPAKE2 PAKE support requires spake2. "
+                "Install cryptography-suite[pake] to use this feature."
+            ) from exc
+        SPAKE2_A = spake2_a
+        SPAKE2_B = spake2_b
+    return SPAKE2_A, SPAKE2_B
 
 
 class SPAKE2Party:
@@ -14,17 +35,19 @@ class SPAKE2Party:
         if not password:
             raise ProtocolError("Password cannot be empty.")
         self.password = password
-        self.private_key = None
-        self.public_key = None
-        self.shared_key = None
+        self.private_key: x25519.X25519PrivateKey | None = None
+        self.public_key: x25519.X25519PublicKey | bytes | None = None
+        self.shared_key: bytes | None = None
 
     def generate_message(self) -> bytes:
         """
         Generates the party's public key to send to the other party.
         """
-        self.private_key = x25519.X25519PrivateKey.generate()
-        self.public_key = self.private_key.public_key()
-        return self.public_key.public_bytes(
+        private_key = x25519.X25519PrivateKey.generate()
+        public_key = private_key.public_key()
+        self.private_key = private_key
+        self.public_key = public_key
+        return public_key.public_bytes(
             encoding=serialization.Encoding.Raw,
             format=serialization.PublicFormat.Raw,
         )
@@ -38,11 +61,14 @@ class SPAKE2Party:
                 "generate_message() must be called before compute_shared_key()."
             )
         try:
-            peer_public_key = x25519.X25519PublicKey.from_public_bytes(peer_public_bytes)
-        except (ValueError, TypeError) as e:
-            raise InvalidKey(f"Invalid peer public key: {e}")
-        self.shared_key = self.private_key.exchange(peer_public_key)
-        return self.shared_key
+            peer_public_key = x25519.X25519PublicKey.from_public_bytes(
+                peer_public_bytes
+            )
+        except (ValueError, TypeError) as exc:
+            raise InvalidKey(f"Invalid peer public key: {exc}") from exc
+        shared_key = self.private_key.exchange(peer_public_key)
+        self.shared_key = shared_key
+        return shared_key
 
     def get_shared_key(self) -> bytes:
         """
@@ -57,14 +83,17 @@ class SPAKE2Client(SPAKE2Party):
     """
     Client-side implementation of the SPAKE2 protocol.
     """
+
     def __init__(self, password: str):
         super().__init__(password)
-        self._spake = SPAKE2_A(password.encode())
+        spake2_a, _ = _require_spake2()
+        self._spake = spake2_a(password.encode())
 
     def generate_message(self) -> bytes:
         """Generates the client's SPAKE2 message."""
-        self.public_key = self._spake.start()
-        return self.public_key
+        public_message = self._spake.start()
+        self.public_key = public_message
+        return bytes(public_message)
 
     def compute_shared_key(self, peer_public_bytes: bytes) -> bytes:
         """Computes the shared key using the server's message."""
@@ -73,9 +102,10 @@ class SPAKE2Client(SPAKE2Party):
                 "generate_message() must be called before compute_shared_key()."
             )
         try:
-            self.shared_key = self._spake.finish(peer_public_bytes)
-        except SPAKEError as e:
-            raise InvalidKey(str(e))
+            shared_key = self._spake.finish(peer_public_bytes)
+        except Exception as exc:
+            raise InvalidKey(str(exc)) from exc
+        self.shared_key = bytes(shared_key)
         return self.shared_key
 
 
@@ -83,14 +113,17 @@ class SPAKE2Server(SPAKE2Party):
     """
     Server-side implementation of the SPAKE2 protocol.
     """
+
     def __init__(self, password: str):
         super().__init__(password)
-        self._spake = SPAKE2_B(password.encode())
+        _, spake2_b = _require_spake2()
+        self._spake = spake2_b(password.encode())
 
     def generate_message(self) -> bytes:
         """Generates the server's SPAKE2 message."""
-        self.public_key = self._spake.start()
-        return self.public_key
+        public_message = self._spake.start()
+        self.public_key = public_message
+        return bytes(public_message)
 
     def compute_shared_key(self, peer_public_bytes: bytes) -> bytes:
         """Computes the shared key using the client's message."""
@@ -99,7 +132,8 @@ class SPAKE2Server(SPAKE2Party):
                 "generate_message() must be called before compute_shared_key()."
             )
         try:
-            self.shared_key = self._spake.finish(peer_public_bytes)
-        except SPAKEError as e:
-            raise InvalidKey(str(e))
+            shared_key = self._spake.finish(peer_public_bytes)
+        except Exception as exc:
+            raise InvalidKey(str(exc)) from exc
+        self.shared_key = bytes(shared_key)
         return self.shared_key

--- a/cryptography_suite/rich_logging.py
+++ b/cryptography_suite/rich_logging.py
@@ -4,21 +4,43 @@ from __future__ import annotations
 
 import logging
 from logging import Logger
-
-from rich.logging import RichHandler
-from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
+from typing import Any
 
 from .core.logging import configure_structured_logging
+from .errors import MissingDependencyError
+
+
+def _load_rich_logging() -> type[Any]:
+    try:
+        from rich.logging import RichHandler
+    except Exception as exc:  # pragma: no cover - dependency missing
+        raise MissingDependencyError(
+            "Rich logging requires rich. "
+            "Install cryptography-suite[cli] to use this feature."
+        ) from exc
+    return RichHandler
+
+
+def _load_rich_progress() -> tuple[type[Any], type[Any], type[Any], type[Any]]:
+    try:
+        from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
+    except Exception as exc:  # pragma: no cover - dependency missing
+        raise MissingDependencyError(
+            "Rich progress output requires rich. "
+            "Install cryptography-suite[cli] to use this feature."
+        ) from exc
+    return BarColumn, Progress, SpinnerColumn, TextColumn
 
 
 def get_rich_logger(
     name: str = "cryptography-suite", level: int = logging.INFO
 ) -> Logger:
     """Return a configured Rich logger."""
+    rich_handler_cls = _load_rich_logging()
     configure_structured_logging(level)
     logger = logging.getLogger(name)
-    if not any(isinstance(h, RichHandler) for h in logger.handlers):
-        handler = RichHandler(rich_tracebacks=True, show_path=False)
+    if not any(isinstance(h, rich_handler_cls) for h in logger.handlers):
+        handler = rich_handler_cls(rich_tracebacks=True, show_path=False)
         logger.addHandler(handler)
         logger.setLevel(level)
     return logger
@@ -28,14 +50,15 @@ class PipelineProgress:
     """Context manager to display pipeline progress."""
 
     def __init__(self, total: int) -> None:
-        self._progress = Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
+        bar_column, progress_cls, spinner_column, text_column = _load_rich_progress()
+        self._progress = progress_cls(
+            spinner_column(),
+            text_column("[progress.description]{task.description}"),
+            bar_column(),
         )
         self._task = self._progress.add_task("pipeline", total=total)
 
-    def __enter__(self) -> "PipelineProgress":
+    def __enter__(self) -> PipelineProgress:
         self._progress.start()
         return self
 

--- a/cryptography_suite/symmetric/aes.py
+++ b/cryptography_suite/symmetric/aes.py
@@ -239,7 +239,8 @@ def _import_aiofiles() -> Any:
         return aiofiles
     except Exception as exc:  # pragma: no cover - fallback when aiofiles missing
         raise MissingDependencyError(
-            "aiofiles is required for async operations"
+            "aiofiles is required for async file operations. "
+            "Install cryptography-suite[async] to use this feature."
         ) from exc
 
 

--- a/cryptography_suite/viz/export.py
+++ b/cryptography_suite/viz/export.py
@@ -6,6 +6,8 @@ from importlib.util import find_spec
 from pathlib import Path
 from typing import Any
 
+from ..errors import MissingDependencyError
+
 _HAS_WIDGETS = find_spec("ipywidgets") is not None
 
 if _HAS_WIDGETS:
@@ -22,10 +24,9 @@ def export_widget_html(widget: Widget, path: str | Path) -> None:
         embed_minimal_html(str(output_path), views=[widget], title="Widget Export")
         return
 
-    output_path.write_text(
-        "<html><body><h1>Widget Export</h1>"
-        "<p>ipywidgets is not installed.</p></body></html>",
-        encoding="utf-8",
+    raise MissingDependencyError(
+        "Widget export requires ipywidgets. "
+        "Install cryptography-suite[viz] to use this feature."
     )
 
 

--- a/cryptography_suite/viz/widgets.py
+++ b/cryptography_suite/viz/widgets.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+from ..errors import MissingDependencyError
+
+_VIZ_IMPORT_ERROR: Exception | None = None
+
 try:
     import networkx as nx
     from IPython.display import display
@@ -9,8 +13,9 @@ try:
     from networkx.readwrite import json_graph
 
     _HAS_VIZ_DEPS = True
-except Exception:  # pragma: no cover - optional visualization dependencies
+except Exception as exc:  # pragma: no cover - optional dependency
     _HAS_VIZ_DEPS = False
+    _VIZ_IMPORT_ERROR = exc
 
     class HTML:  # type: ignore[no-redef]
         def __init__(self, value: str = "") -> None:
@@ -60,10 +65,19 @@ except Exception:  # pragma: no cover - optional visualization dependencies
         return None
 
 
+def _require_viz_deps() -> None:
+    if not _HAS_VIZ_DEPS:
+        raise MissingDependencyError(
+            "Visualization widgets require ipywidgets and networkx. "
+            "Install cryptography-suite[viz] to use this feature."
+        ) from _VIZ_IMPORT_ERROR
+
+
 class HandshakeFlowWidget(VBox):
     """Animated visualization of a handshake protocol."""
 
     def __init__(self, steps: Iterable[str]):
+        _require_viz_deps()
         self._steps = list(steps)
         self._index = 0
         self.output = HTML()
@@ -84,6 +98,7 @@ class KeyGraphWidget(VBox):
     """Display key relationships as a graph."""
 
     def __init__(self, edges: Iterable[tuple[str, str]] = ()):  # simple graph
+        _require_viz_deps()
         super().__init__()
         self._edges = list(edges)
         self.output = Output()
@@ -112,6 +127,7 @@ class SessionTimelineWidget(VBox):
     """Visualize message and key events over time."""
 
     def __init__(self, events: Iterable[str] = ()):  # simple timeline
+        _require_viz_deps()
         self._events = list(events)
         self.output = HTML("<br>".join(self._events))
         super().__init__([self.output])

--- a/docs/mypy_plugin.md
+++ b/docs/mypy_plugin.md
@@ -10,7 +10,7 @@ Detected issues include:
 - Use of weak hash functions like `md5` or `sha1`.
 - Creating AES ciphers in `ECB` mode.
 
-To enable the plugin manually add `tools.mypy_crypto_checker` to the
+To enable the plugin manually add `cryptography_suite._mypy_crypto_checker` to the
 `plugins` option in your `mypy` configuration. The repository has this
 enabled by default via ``setup.cfg``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,21 +45,20 @@ classifiers = [
 
 dependencies = [
     "cryptography>=46.0.5",
-    "py_ecc",
-    "spake2",
-    "blake3",
-    "PyYAML",
-    "Jinja2",
-    "rich",
 ]
 
 [project.entry-points."cryptosuite.aead"]
 "gcm-sst" = "cryptography_suite.aead_plugins:aes_gcm_sst_encrypt"
 
 [project.optional-dependencies]
+cli = ["PyYAML", "rich", "requests"]
+hashing-extra = ["blake3"]
+bls = ["py_ecc"]
+pake = ["spake2"]
 pqc = ["pqcrypto"]
 fhe = ["Pyfhel"]
 zk = ["pybulletproofs", "PySNARK"]
+codegen = ["Jinja2", "PyYAML"]
 dev = [
     "pytest",
     "pytest-cov",
@@ -73,6 +72,7 @@ dev = [
 async = ["aiofiles"]
 docs = ["sphinx", "furo", "myst-parser", "sphinxcontrib-mermaid"]
 viz = ["ipywidgets", "networkx"]
+kms = ["boto3"]
 aws = ["boto3"]
 hsm = ["python-pkcs11>=0.8.1"]
 legacy = ["salsa20>=0.9", "ascon>=1.2"]
@@ -96,7 +96,7 @@ license-files = ["LICENSE"]
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["cryptography_suite*", "tools*"]
+include = ["cryptography_suite*"]
 exclude = ["tests*", "docs*", "examples*", "demo*"]
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 "gcm-sst" = "cryptography_suite.aead_plugins:aes_gcm_sst_encrypt"
 
 [project.optional-dependencies]
-cli = ["PyYAML", "rich", "requests"]
+cli = ["PyYAML", "rich"]
 hashing-extra = ["blake3"]
 bls = ["py_ecc"]
 pake = ["spake2"]
@@ -59,6 +59,7 @@ pqc = ["pqcrypto"]
 fhe = ["Pyfhel"]
 zk = ["pybulletproofs", "PySNARK"]
 codegen = ["Jinja2", "PyYAML"]
+network = ["requests"]
 dev = [
     "pytest",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ python_version = "3.10"
 strict = true
 warn_unused_configs = true
 exclude = ["^tests/"]
-plugins = ["tools.mypy_crypto_checker"]
+plugins = ["cryptography_suite._mypy_crypto_checker"]
 
 
 [tool.pytest.ini_options]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,1 @@
 cryptography>=46.0.5
-pqcrypto
-py_ecc
-spake2
-blake3
-PyYAML
-rich
-ipywidgets
-networkx
-jinja2
-requests
-hypothesis

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ per-file-ignores =
 
 [mypy]
 python_version = 3.12
-plugins = tools.mypy_crypto_checker
+plugins = cryptography_suite._mypy_crypto_checker
 
 [mypy-Pyfhel.*]
 ignore_missing_imports = True

--- a/src/cryptography_suite/cli/migrate_keys.py
+++ b/src/cryptography_suite/cli/migrate_keys.py
@@ -13,18 +13,29 @@ import datetime as dt
 import hashlib
 import json
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
 from logging.handlers import SysLogHandler
 from pathlib import Path
-from typing import Dict, Iterable, Optional
 
-import requests
-
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa
 from rich.console import Console
 from rich.prompt import Prompt
 from rich.table import Table
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa
+
+from cryptography_suite.errors import MissingDependencyError
+
+
+def _post_webhook(url: str, payload: dict[str, str]) -> None:
+    try:
+        import requests  # type: ignore[import-untyped]
+    except Exception as exc:  # pragma: no cover - optional dependency missing
+        raise MissingDependencyError(
+            "Webhook audit export requires requests. "
+            "Install cryptography-suite[network] to use this feature."
+        ) from exc
+    requests.post(url, json=payload, timeout=5)
 
 
 class PQPublicKey:
@@ -86,7 +97,7 @@ class KeyInfo:
 
     @property
     def fingerprint(self) -> str:
-        pub = self.key_obj.public_key().public_bytes(
+        pub = self.key_obj.public_key().public_bytes(  # type: ignore[attr-defined]
             serialization.Encoding.DER,
             serialization.PublicFormat.SubjectPublicKeyInfo,
         )
@@ -95,12 +106,11 @@ class KeyInfo:
     @property
     def insecure(self) -> bool:
         return (
-            isinstance(self.key_obj, rsa.RSAPrivateKey)
-            and self.key_obj.key_size < 2048
+            isinstance(self.key_obj, rsa.RSAPrivateKey) and self.key_obj.key_size < 2048
         )
 
     @property
-    def pq_mode(self) -> Optional[str]:
+    def pq_mode(self) -> str | None:
         if isinstance(self.key_obj, PQPrivateKey):
             return self.key_obj.mode
         return None
@@ -109,13 +119,13 @@ class KeyInfo:
 class InMemoryBackend:
     """Simple in-memory backend for demonstration."""
 
-    def __init__(self, name: str, keys: Optional[Dict[str, object]] = None) -> None:
+    def __init__(self, name: str, keys: dict[str, object] | None = None) -> None:
         self.name = name
-        self._keys: Dict[str, object] = keys or {}
+        self._keys: dict[str, object] = keys or {}
 
     @classmethod
-    def with_sample_keys(cls, name: str) -> "InMemoryBackend":
-        keys: Dict[str, object] = {
+    def with_sample_keys(cls, name: str) -> InMemoryBackend:
+        keys: dict[str, object] = {
             "rsa": rsa.generate_private_key(public_exponent=65537, key_size=2048),
             "ecc": ec.generate_private_key(ec.SECP256R1()),
             "ed": ed25519.Ed25519PrivateKey.generate(),
@@ -132,7 +142,7 @@ class InMemoryBackend:
         self._keys[info.identifier] = info.key_obj
 
 
-BACKENDS: Dict[str, InMemoryBackend] = {
+BACKENDS: dict[str, InMemoryBackend] = {
     "file": InMemoryBackend.with_sample_keys("file"),
     "vault": InMemoryBackend.with_sample_keys("vault"),
     "hsm": InMemoryBackend.with_sample_keys("hsm"),
@@ -147,7 +157,7 @@ class AuditLogger:
         path: Path,
         *,
         syslog: bool = False,
-        webhook: Optional[str] = None,
+        webhook: str | None = None,
     ) -> None:
         self.path = path
         self.webhook = webhook
@@ -157,7 +167,7 @@ class AuditLogger:
             encoding=serialization.Encoding.Raw,
             format=serialization.PublicFormat.Raw,
         )
-        self._syslog_logger: Optional[logging.Logger] = None
+        self._syslog_logger: logging.Logger | None = None
         if syslog:
             logger = logging.getLogger("migrate_keys.siem")
             handler = SysLogHandler(address=("localhost", 514))
@@ -192,11 +202,12 @@ class AuditLogger:
                 pass
         if self.webhook:
             try:
-                requests.post(
+                _post_webhook(
                     self.webhook,
-                    json={"entry": entry, "digest": digest, "signature": sig_b64},
-                    timeout=5,
+                    {"entry": entry, "digest": digest, "signature": sig_b64},
                 )
+            except MissingDependencyError:
+                raise
             except Exception:  # pragma: no cover - network best effort
                 pass
 
@@ -259,11 +270,13 @@ def migrate_wizard(
         if info.insecure:
             console.print("[red]Warning: RSA key <2048 bits[/red]")
         if info.pq_mode in {"hybrid", "legacy"}:
-            console.print(
-                f"[yellow]Warning: PQ key in {info.pq_mode} mode[/yellow]"
+            console.print(f"[yellow]Warning: PQ key in {info.pq_mode} mode[/yellow]")
+        choice = (
+            "y"
+            if migrate_all
+            else Prompt.ask(
+                "Migrate this key?", choices=["y", "n", "all", "skip"], default="n"
             )
-        choice = "y" if migrate_all else Prompt.ask(
-            "Migrate this key?", choices=["y", "n", "all", "skip"], default="n"
         )
         if choice in {"y", "all"}:
             action = "dry-run" if dry_run else "migrate"
@@ -345,7 +358,7 @@ def migrate_batch(
     console.print(table)
 
 
-def wizard_cli(argv: Optional[list[str]] = None) -> None:
+def wizard_cli(argv: list[str] | None = None) -> None:
     """CLI wrapper for key migration modes."""
 
     parser = argparse.ArgumentParser(description="Migrate keys between backends")
@@ -371,16 +384,12 @@ def wizard_cli(argv: Optional[list[str]] = None) -> None:
     parser.add_argument(
         "--syslog", action="store_true", help="Mirror audit log to syslog"
     )
-    parser.add_argument(
-        "--webhook", help="POST audit entries to a webhook URL"
-    )
+    parser.add_argument("--webhook", help="POST audit entries to a webhook URL")
     args = parser.parse_args(argv)
 
     source = BACKENDS[args.src]
     target = BACKENDS[args.dst]
-    logger = AuditLogger(
-        Path("audit.log"), syslog=args.syslog, webhook=args.webhook
-    )
+    logger = AuditLogger(Path("audit.log"), syslog=args.syslog, webhook=args.webhook)
 
     if args.batch:
         migrate_batch(

--- a/tests/test_bls.py
+++ b/tests/test_bls.py
@@ -1,12 +1,21 @@
 import unittest
+from importlib.util import find_spec
+
+import pytest
+
 from cryptography_suite.asymmetric.bls import (
-    generate_bls_keypair,
-    bls_sign,
-    bls_verify,
     bls_aggregate,
     bls_aggregate_verify,
+    bls_sign,
+    bls_verify,
+    generate_bls_keypair,
 )
 from cryptography_suite.errors import CryptographySuiteError
+
+pytestmark = pytest.mark.skipif(
+    find_spec("py_ecc") is None,
+    reason="py_ecc not installed; install cryptography-suite[bls]",
+)
 
 
 class TestBLS(unittest.TestCase):
@@ -29,7 +38,7 @@ class TestBLS(unittest.TestCase):
         sk, _ = generate_bls_keypair()
         sig = bls_sign(self.message1, sk)
         with self.assertRaises(TypeError):
-            bls_verify(self.message1, sig, "not_bytes")
+            bls_verify(self.message1, sig, "not_bytes")  # type: ignore[arg-type]
 
     def test_aggregate_and_verify(self):
         sk1, pk1 = generate_bls_keypair()
@@ -51,15 +60,12 @@ class TestBLS(unittest.TestCase):
     def test_known_vector(self):
         """Verify implementation against a deterministic test vector."""
         seed = b"\x11" * 32
-        expected_sk = 23657700540186605117143072292512185602964840914375503215744843051745997498405
+        expected_sk = int(
+            "23657700540186605117143072292512185602964840914375503215744843051745997498405"
+        )
         expected_pk = bytes.fromhex(
             "8e5a712e4cb2c51893c27ae19afb3455f3efcc66030dc25e13eb1afc2edf3973"
             "17a0bb2d28a55513a32d7dcc404be3ba"
-        )
-        expected_sig = bytes.fromhex(
-            "a008c7df216b75c7497dbde10d2188fb6b943f999b654df82a064c10723b9249"
-            "93d9d4933c4670e7e2e536ddc87b9a7a0e0f8ecf5faedbeda5ee2ea7bee4065f"
-            "4aefed8f4d665569ec636b04f36ff6fd853f66283d413843761acbda652fd43d"
         )
 
         sk, pk = generate_bls_keypair(seed, sensitive=False)

--- a/tests/test_cli_gen.py
+++ b/tests/test_cli_gen.py
@@ -1,22 +1,34 @@
 import importlib
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
 import cryptography_suite.cli as cli
 
 
-def reload_cli():
+def reload_cli() -> ModuleType:
     importlib.reload(cli)
     return cli
 
 
-def test_gen_cli_fastapi(tmp_path):
+def test_gen_cli_fastapi(tmp_path: Path) -> None:
+    pytest.importorskip("yaml", reason="requires codegen extra")
+    pytest.importorskip("jinja2", reason="requires codegen extra")
+
     c = reload_cli()
     pipeline = tmp_path / "pipe.yaml"
     pipeline.write_text("- StepA\n- StepB\n")
     out_dir = tmp_path / "gen"
-    c.gen_cli([
-        "--target", "fastapi",
-        "--pipeline", str(pipeline),
-        "--output", str(out_dir),
-    ])
+    c.gen_cli(
+        [
+            "--target",
+            "fastapi",
+            "--pipeline",
+            str(pipeline),
+            "--output",
+            str(out_dir),
+        ]
+    )
     assert (out_dir / "app.py").exists()
     assert (out_dir / "README.md").exists()
-

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -2,11 +2,23 @@ import hashlib
 import importlib
 import io
 from types import ModuleType
+from typing import Any
 
 import pytest
-from blake3 import blake3
 
 import cryptography_suite.cli as cli
+
+blake3: Any = None
+try:
+    blake3 = importlib.import_module("blake3").blake3
+except Exception:  # pragma: no cover - optional dependency missing
+    pass
+
+BLAKE3_AVAILABLE = blake3 is not None
+requires_blake3 = pytest.mark.skipif(
+    not BLAKE3_AVAILABLE,
+    reason="blake3 not installed; install cryptography-suite[hashing-extra]",
+)
 
 
 def reload_cli() -> ModuleType:
@@ -54,6 +66,7 @@ def test_keygen_pqc_does_not_print_private_key(monkeypatch, capsys):
     assert captured.err == ""
 
 
+@requires_blake3
 def test_main_hash(tmp_path, capsys):
     cli = reload_cli()
     file = tmp_path / "f.txt"
@@ -69,7 +82,11 @@ def test_main_hash(tmp_path, capsys):
         ("sha3-256", lambda payload: hashlib.sha3_256(payload).hexdigest()),
         ("sha3-512", lambda payload: hashlib.sha3_512(payload).hexdigest()),
         ("blake2b", lambda payload: hashlib.blake2b(payload).hexdigest()),
-        ("blake3", lambda payload: blake3(payload).hexdigest()),
+        pytest.param(
+            "blake3",
+            lambda payload: blake3(payload).hexdigest(),
+            marks=requires_blake3,
+        ),
     ],
 )
 def test_main_hash_binary_input(tmp_path, capsys, algorithm, expected):
@@ -91,6 +108,7 @@ def test_main_otp(monkeypatch, capsys):
     assert capsys.readouterr().out.strip() == "123"
 
 
+@requires_blake3
 def test_main_hash_json_output(tmp_path, capsys):
     cli = reload_cli()
     file = tmp_path / "f.txt"
@@ -101,6 +119,7 @@ def test_main_hash_json_output(tmp_path, capsys):
     assert '"digest"' in out
 
 
+@requires_blake3
 def test_main_json_alias_deprecation(tmp_path, capsys):
     cli = reload_cli()
     file = tmp_path / "f.txt"

--- a/tests/test_dependency_metadata.py
+++ b/tests/test_dependency_metadata.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+REQUIREMENTS = REPO_ROOT / "requirements.txt"
+
+DISALLOWED_DEFAULTS = {
+    "py-ecc",
+    "spake2",
+    "pqcrypto",
+    "pyfhel",
+    "ipywidgets",
+    "networkx",
+    "jinja2",
+    "rich",
+    "pytest",
+    "hypothesis",
+    "mypy",
+    "ruff",
+    "black",
+    "coverage",
+}
+EXPECTED_EXTRAS = {
+    "async",
+    "bls",
+    "cli",
+    "codegen",
+    "dev",
+    "docs",
+    "fhe",
+    "hashing-extra",
+    "hsm",
+    "kms",
+    "pake",
+    "pqc",
+    "viz",
+}
+OPTIONAL_IMPORT_ROOTS = [
+    "blake3",
+    "spake2",
+    "py_ecc",
+    "pqcrypto",
+    "Pyfhel",
+    "ipywidgets",
+    "networkx",
+    "jinja2",
+    "rich",
+    "requests",
+    "yaml",
+]
+
+
+def _pyproject() -> dict[str, Any]:
+    return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+
+
+def _requirement_name(requirement: str) -> str:
+    name = re.split(r"[\[<>=!~; ]", requirement, maxsplit=1)[0]
+    return name.lower().replace("_", "-")
+
+
+def _requirement_lines(path: Path) -> list[str]:
+    return [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+def test_pyproject_default_dependencies_are_minimal() -> None:
+    project = cast(dict[str, Any], _pyproject()["project"])
+    dependencies = {_requirement_name(req) for req in project.get("dependencies", [])}
+
+    assert dependencies == {"cryptography"}
+    assert not dependencies & DISALLOWED_DEFAULTS
+
+
+def test_requirements_txt_matches_minimal_runtime_dependencies() -> None:
+    requirements = {_requirement_name(req) for req in _requirement_lines(REQUIREMENTS)}
+
+    assert requirements == {"cryptography"}
+    assert not requirements & DISALLOWED_DEFAULTS
+
+
+def test_expected_optional_extras_exist() -> None:
+    project = cast(dict[str, Any], _pyproject()["project"])
+    optional_dependencies = cast(dict[str, list[str]], project["optional-dependencies"])
+    extras = set(optional_dependencies)
+
+    assert EXPECTED_EXTRAS <= extras
+
+
+def test_package_discovery_does_not_include_tools() -> None:
+    data = _pyproject()
+    tool = cast(dict[str, Any], data["tool"])
+    setuptools = cast(dict[str, Any], tool["setuptools"])
+    packages = cast(dict[str, Any], setuptools["packages"])
+    package_find = cast(dict[str, list[str]], packages["find"])
+    includes = package_find["include"]
+
+    assert "tools*" not in includes
+    assert "cryptography_suite*" in includes
+
+
+def test_importing_root_package_does_not_import_optional_dependencies() -> None:
+    code = f"""
+import json
+import sys
+
+import cryptography_suite  # noqa: F401
+
+optional = {OPTIONAL_IMPORT_ROOTS!r}
+print(json.dumps([name for name in optional if name in sys.modules]))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == []
+
+
+def test_importing_cli_module_does_not_import_optional_dependencies() -> None:
+    code = f"""
+import json
+import sys
+
+import cryptography_suite.cli  # noqa: F401
+
+optional = {OPTIONAL_IMPORT_ROOTS!r}
+print(json.dumps([name for name in optional if name in sys.modules]))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == []

--- a/tests/test_dependency_metadata.py
+++ b/tests/test_dependency_metadata.py
@@ -164,7 +164,7 @@ def test_package_discovery_does_not_include_tools() -> None:
     package_find = cast(dict[str, list[str]], packages["find"])
     includes = package_find["include"]
 
-    assert "tools*" not in includes
+    assert all(not include.startswith("tools") for include in includes)
     assert "cryptography_suite*" in includes
 
 

--- a/tests/test_dependency_metadata.py
+++ b/tests/test_dependency_metadata.py
@@ -156,6 +156,28 @@ def test_requests_is_not_part_of_local_cli_extra() -> None:
     assert "requests" in network_dependencies
 
 
+def test_codegen_and_pake_dependencies_stay_in_optional_extras() -> None:
+    project = cast(dict[str, Any], _pyproject()["project"])
+    base_dependencies = {
+        _requirement_name(req) for req in project.get("dependencies", [])
+    }
+    optional_dependencies = cast(dict[str, list[str]], project["optional-dependencies"])
+    codegen_dependencies = {
+        _requirement_name(req) for req in optional_dependencies.get("codegen", [])
+    }
+    pake_dependencies = {
+        _requirement_name(req) for req in optional_dependencies.get("pake", [])
+    }
+    cli_dependencies = {
+        _requirement_name(req) for req in optional_dependencies.get("cli", [])
+    }
+
+    assert {"jinja2", "pyyaml"} <= codegen_dependencies
+    assert "spake2" in pake_dependencies
+    assert not {"jinja2", "pyyaml", "spake2"} & base_dependencies
+    assert "spake2" not in cli_dependencies
+
+
 def test_package_discovery_does_not_include_tools() -> None:
     data = _pyproject()
     tool = cast(dict[str, Any], data["tool"])

--- a/tests/test_dependency_metadata.py
+++ b/tests/test_dependency_metadata.py
@@ -21,6 +21,11 @@ DISALLOWED_DEFAULTS = {
     "ipywidgets",
     "networkx",
     "jinja2",
+    "requests",
+    "boto3",
+    "python-pkcs11",
+    "pkcs11",
+    "pyyaml",
     "rich",
     "pytest",
     "hypothesis",
@@ -40,9 +45,31 @@ EXPECTED_EXTRAS = {
     "hashing-extra",
     "hsm",
     "kms",
+    "network",
     "pake",
     "pqc",
     "viz",
+    "aws",
+    "legacy",
+    "zk",
+}
+OPTIONAL_DISTRIBUTION_NAMES = {
+    "aiofiles",
+    "blake3",
+    "boto3",
+    "jinja2",
+    "networkx",
+    "pkcs11",
+    "pqcrypto",
+    "py-ecc",
+    "pybulletproofs",
+    "pyfhel",
+    "pyyaml",
+    "pysnark",
+    "python-pkcs11",
+    "requests",
+    "rich",
+    "spake2",
 }
 OPTIONAL_IMPORT_ROOTS = [
     "blake3",
@@ -91,12 +118,42 @@ def test_requirements_txt_matches_minimal_runtime_dependencies() -> None:
     assert not requirements & DISALLOWED_DEFAULTS
 
 
+def test_optional_dependency_names_are_not_base_dependencies() -> None:
+    project = cast(dict[str, Any], _pyproject()["project"])
+    base_dependencies = {
+        _requirement_name(req) for req in project.get("dependencies", [])
+    }
+    optional_dependencies = cast(dict[str, list[str]], project["optional-dependencies"])
+    extras_dependencies = {
+        _requirement_name(req)
+        for dependencies in optional_dependencies.values()
+        for req in dependencies
+    }
+
+    assert not base_dependencies & OPTIONAL_DISTRIBUTION_NAMES
+    assert extras_dependencies & OPTIONAL_DISTRIBUTION_NAMES
+
+
 def test_expected_optional_extras_exist() -> None:
     project = cast(dict[str, Any], _pyproject()["project"])
     optional_dependencies = cast(dict[str, list[str]], project["optional-dependencies"])
     extras = set(optional_dependencies)
 
     assert EXPECTED_EXTRAS <= extras
+
+
+def test_requests_is_not_part_of_local_cli_extra() -> None:
+    project = cast(dict[str, Any], _pyproject()["project"])
+    optional_dependencies = cast(dict[str, list[str]], project["optional-dependencies"])
+    cli_dependencies = {
+        _requirement_name(req) for req in optional_dependencies.get("cli", [])
+    }
+    network_dependencies = {
+        _requirement_name(req) for req in optional_dependencies.get("network", [])
+    }
+
+    assert "requests" not in cli_dependencies
+    assert "requests" in network_dependencies
 
 
 def test_package_discovery_does_not_include_tools() -> None:

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,49 +1,94 @@
 import hashlib
+import importlib
+from collections.abc import Callable
+from typing import Any
+
 import pytest
-from blake3 import blake3
 
 from cryptography_suite.hashing import (
-    sha256_hash,
-    sha384_hash,
-    sha512_hash,
-    sha3_256_hash,
-    sha3_512_hash,
     blake2b_hash,
     blake3_hash,
     blake3_hash_v2,
+    sha3_256_hash,
+    sha3_512_hash,
+    sha256_hash,
+    sha384_hash,
+    sha512_hash,
 )
 
+blake3: Any = None
+try:
+    blake3 = importlib.import_module("blake3").blake3
+except Exception:  # pragma: no cover - optional dependency missing
+    pass
+
+BLAKE3_AVAILABLE = blake3 is not None
+requires_blake3 = pytest.mark.skipif(
+    not BLAKE3_AVAILABLE,
+    reason="blake3 not installed; install cryptography-suite[hashing-extra]",
+)
 
 # Mapping of hashing functions to reference implementations from hashlib/blake3
-REF_HASHES = {
+REF_HASHES: dict[Callable[[str], str], Callable[[bytes], str]] = {
     sha256_hash: lambda s: hashlib.sha256(s).hexdigest(),
     sha384_hash: lambda s: hashlib.sha384(s).hexdigest(),
     sha512_hash: lambda s: hashlib.sha512(s).hexdigest(),
     sha3_256_hash: lambda s: hashlib.sha3_256(s).hexdigest(),
     sha3_512_hash: lambda s: hashlib.sha3_512(s).hexdigest(),
     blake2b_hash: lambda s: hashlib.blake2b(s, digest_size=64).hexdigest(),
-    blake3_hash: lambda s: blake3(s).hexdigest(),
-    blake3_hash_v2: lambda s: blake3(s).hexdigest(),
 }
 
+if BLAKE3_AVAILABLE:
+    REF_HASHES[blake3_hash] = lambda s: blake3(s).hexdigest()
+    REF_HASHES[blake3_hash_v2] = lambda s: blake3(s).hexdigest()
 
-@pytest.mark.parametrize("func,expected", [
-    (sha256_hash, 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9'),
-    (sha384_hash, 'fdbd8e75a67f29f701a4e040385e2e23986303ea10239211af907fcbb83578b3e417cb71ce646efd0819dd8c088de1bd'),
-    (sha512_hash, '309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f'),
-    (sha3_256_hash, '644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938'),
-    (sha3_512_hash, '840006653e9ac9e95117a15c915caab81662918e925de9e004f774ff82d7079a40d4d27b1b372657c61d46d470304c88c788b3a4527ad074d1dccbee5dbaa99a'),
-    (blake2b_hash, '021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0'),
-    (blake3_hash, 'd74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24'),
-    (blake3_hash_v2, 'd74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24'),
-])
-def test_known_vectors(func, expected):
+
+@pytest.mark.parametrize(
+    ("func", "expected"),
+    [
+        (
+            sha256_hash,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+        ),
+        (
+            sha384_hash,
+            "fdbd8e75a67f29f701a4e040385e2e23986303ea10239211af907fcbb83578b3e417cb71ce646efd0819dd8c088de1bd",
+        ),
+        (
+            sha512_hash,
+            "309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f",
+        ),
+        (
+            sha3_256_hash,
+            "644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938",
+        ),
+        (
+            sha3_512_hash,
+            "840006653e9ac9e95117a15c915caab81662918e925de9e004f774ff82d7079a40d4d27b1b372657c61d46d470304c88c788b3a4527ad074d1dccbee5dbaa99a",
+        ),
+        (
+            blake2b_hash,
+            "021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0",
+        ),
+        pytest.param(
+            blake3_hash,
+            "d74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24",
+            marks=requires_blake3,
+        ),
+        pytest.param(
+            blake3_hash_v2,
+            "d74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24",
+            marks=requires_blake3,
+        ),
+    ],
+)
+def test_known_vectors(func: Callable[[str], str], expected: str) -> None:
     """Verify each hash function against a known digest for 'hello world'."""
     assert func("hello world") == expected
 
 
 @pytest.mark.parametrize("func", list(REF_HASHES))
-def test_various_inputs(func):
+def test_various_inputs(func: Callable[[str], str]) -> None:
     """Hashing empty, unicode and long strings should match reference libs."""
     for text in ("", "こんにちは", "a" * 10000):
         expected = REF_HASHES[func](text.encode())
@@ -52,7 +97,7 @@ def test_various_inputs(func):
 
 @pytest.mark.parametrize("func", list(REF_HASHES))
 @pytest.mark.parametrize("invalid", [123, None, b"bytes"])
-def test_invalid_types_raise(func, invalid):
+def test_invalid_types_raise(func: Callable[[str], str], invalid: object) -> None:
     """Non-string inputs should raise AttributeError when .encode is missing."""
     with pytest.raises(AttributeError):
         func(invalid)  # type: ignore[arg-type]

--- a/tests/test_interfaces_full.py
+++ b/tests/test_interfaces_full.py
@@ -1,43 +1,44 @@
+import base64
 import importlib
+import os
 import sys
 import types
-import base64
-import os
+from typing import Any
 
 import pytest
 
 if not os.getenv("CRYPTOSUITE_ALLOW_EXPERIMENTAL"):
     pytest.skip("experimental features disabled", allow_module_level=True)
-from cryptography_suite.errors import DecryptionError
-from cryptography.exceptions import InvalidKey
+import warnings
+
+from cryptography.exceptions import InvalidKey, InvalidTag
 from cryptography.hazmat.primitives.asymmetric import x25519
-from cryptography.exceptions import InvalidTag
 
 from cryptography_suite.asymmetric import (
     ec_decrypt,
     ec_encrypt,
     generate_x25519_keypair,
 )
-from cryptography_suite.protocols import (
-    SPAKE2Client,
-    SPAKE2Server,
-)
-import warnings
-
+from cryptography_suite.errors import DecryptionError
 from cryptography_suite.experimental.signal_demo import (
-    initialize_signal_session,
     SignalReceiver,
-    SignalSender,
+    initialize_signal_session,
 )
-from cryptography_suite.zk import zksnark
-
 
 # ----------------------- SPAKE2 Tests -----------------------
 
 
-def test_spake2_success():
-    client = SPAKE2Client("secret")
-    server = SPAKE2Server("secret")
+def _spake2_classes() -> tuple[type[Any], type[Any]]:
+    pytest.importorskip("spake2", reason="requires pake extra")
+    from cryptography_suite.protocols import SPAKE2Client, SPAKE2Server
+
+    return SPAKE2Client, SPAKE2Server
+
+
+def test_spake2_success() -> None:
+    spake2_client, spake2_server = _spake2_classes()
+    client = spake2_client("secret")
+    server = spake2_server("secret")
     cm = client.generate_message()
     sm = server.generate_message()
     ck = client.compute_shared_key(sm)
@@ -45,9 +46,10 @@ def test_spake2_success():
     assert ck == sk
 
 
-def test_spake2_incorrect_password():
-    client = SPAKE2Client("secret")
-    server = SPAKE2Server("other")
+def test_spake2_incorrect_password() -> None:
+    spake2_client, spake2_server = _spake2_classes()
+    client = spake2_client("secret")
+    server = spake2_server("other")
     cm = client.generate_message()
     sm = server.generate_message()
     ck = client.compute_shared_key(sm)
@@ -55,8 +57,9 @@ def test_spake2_incorrect_password():
     assert ck != sk
 
 
-def test_spake2_invalid_peer_message():
-    client = SPAKE2Client("secret")
+def test_spake2_invalid_peer_message() -> None:
+    spake2_client, _ = _spake2_classes()
+    client = spake2_client("secret")
     client.generate_message()
     with pytest.raises(InvalidKey):
         client.compute_shared_key(b"bad")
@@ -65,7 +68,7 @@ def test_spake2_invalid_peer_message():
 # ------------------- Signal Protocol Tests ------------------
 
 
-def test_signal_protocol_valid_flow():
+def test_signal_protocol_valid_flow() -> None:
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         sender, receiver = initialize_signal_session()
@@ -79,7 +82,7 @@ def test_signal_protocol_valid_flow():
     assert sender.decrypt(enc2) == reply
 
 
-def test_signal_protocol_tampered_ciphertext():
+def test_signal_protocol_tampered_ciphertext() -> None:
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         sender, receiver = initialize_signal_session()
@@ -94,7 +97,7 @@ def test_signal_protocol_tampered_ciphertext():
         receiver.decrypt(tampered)
 
 
-def test_signal_protocol_wrong_receiver():
+def test_signal_protocol_wrong_receiver() -> None:
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         sender, receiver = initialize_signal_session()
@@ -103,14 +106,14 @@ def test_signal_protocol_wrong_receiver():
     other.initialize_session(*sender.handshake_public)
     enc = sender.encrypt(b"hi")
     # other has different keys; decryption should fail
-    with pytest.raises(Exception):
+    with pytest.raises(InvalidTag):
         other.decrypt(enc)
 
 
 # ----------------------- ECIES Tests -----------------------
 
 
-def test_ecies_roundtrip():
+def test_ecies_roundtrip() -> None:
     priv, pub = generate_x25519_keypair()
     msg = b"top"
     ct = ec_encrypt(msg, pub)
@@ -118,7 +121,7 @@ def test_ecies_roundtrip():
     assert ec_decrypt(ct, priv) == msg
 
 
-def test_ecies_wrong_key():
+def test_ecies_wrong_key() -> None:
     priv, pub = generate_x25519_keypair()
     wrong_priv, _ = generate_x25519_keypair()
     ct = ec_encrypt(b"msg", pub)
@@ -126,7 +129,7 @@ def test_ecies_wrong_key():
         ec_decrypt(ct, wrong_priv)
 
 
-def test_ecies_tamper(monkeypatch):
+def test_ecies_tamper(monkeypatch: pytest.MonkeyPatch) -> None:
     priv, pub = generate_x25519_keypair()
     ct = ec_encrypt(b"msg", pub)
     raw = base64.b64decode(ct)
@@ -136,7 +139,7 @@ def test_ecies_tamper(monkeypatch):
         ec_decrypt(tampered_b64, priv)
 
 
-def test_ecies_deterministic(monkeypatch):
+def test_ecies_deterministic(monkeypatch: pytest.MonkeyPatch) -> None:
     priv, pub = generate_x25519_keypair()
     fake_priv = x25519.X25519PrivateKey.from_private_bytes(b"\x01" * 32)
     monkeypatch.setattr(x25519.X25519PrivateKey, "generate", lambda: fake_priv)
@@ -152,13 +155,13 @@ def test_ecies_deterministic(monkeypatch):
 
 
 class DummyPrivVal:
-    def __init__(self, val):
+    def __init__(self, val: Any) -> None:
         self.val = val
 
 
-def dummy_sha256(secret):
+def dummy_sha256(secret: DummyPrivVal) -> Any:
     class Bits:
-        def __init__(self, val):
+        def __init__(self, val: Any) -> None:
             self.val = val
 
     return Bits(secret.val)
@@ -166,19 +169,21 @@ def dummy_sha256(secret):
 
 class DummySnark:
     @staticmethod
-    def prove():
+    def prove() -> str:
         return "proof"
 
 
 class DummyRun:
-    def __init__(self, result=True):
+    def __init__(self, result: bool = True) -> None:
         self._result = result
 
-    def verify(self, hash_hex, proof_path):
+    def verify(self, hash_hex: str, proof_path: str) -> bool:
         return self._result
 
 
-def _setup_pysnark(monkeypatch, result=True):
+def _setup_pysnark(
+    monkeypatch: pytest.MonkeyPatch, result: bool = True
+) -> types.ModuleType:
     runtime = types.SimpleNamespace(
         PrivVal=DummyPrivVal, snark=DummySnark, run=DummyRun(result)
     )
@@ -194,14 +199,14 @@ def _setup_pysnark(monkeypatch, result=True):
     return zk
 
 
-def test_zksnark_valid(monkeypatch):
+def test_zksnark_valid(monkeypatch: pytest.MonkeyPatch) -> None:
     zk = _setup_pysnark(monkeypatch, True)
     zk.setup()
     digest, proof = zk.prove(b"x")
     assert zk.verify(digest, proof)
 
 
-def test_zksnark_invalid_proof(monkeypatch):
+def test_zksnark_invalid_proof(monkeypatch: pytest.MonkeyPatch) -> None:
     zk = _setup_pysnark(monkeypatch, False)
     zk.setup()
     digest, proof = zk.prove(b"x")

--- a/tests/test_migrate_keys.py
+++ b/tests/test_migrate_keys.py
@@ -17,6 +17,7 @@ MODULE_PATH = (
 spec = importlib.util.spec_from_file_location(
     "cryptography_suite.cli.migrate_keys", MODULE_PATH
 )
+assert spec is not None
 migrate_keys = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = migrate_keys
 assert spec.loader is not None
@@ -65,7 +66,7 @@ def test_wizard_interactive(tmp_path, monkeypatch, capsys):
         "migrate",
         "migrate",
     ]
-    kyber_line = next(l for l in lines if "kyber" in l)
+    kyber_line = next(line for line in lines if "kyber" in line)
     assert "Kyber/3:file->vault" in kyber_line
     assert {p.name for p in tmp_path.iterdir()} == {"audit.log"}
 
@@ -154,14 +155,10 @@ def test_webhook_integration(tmp_path, monkeypatch):
     log = tmp_path / "audit.log"
     calls: list[dict] = []
 
-    class DummyResp:
-        status_code = 200
+    def fake_post_webhook(url, payload):
+        calls.append(payload)
 
-    def fake_post(url, json, timeout=5):
-        calls.append(json)
-        return DummyResp()
-
-    monkeypatch.setattr(migrate_keys.requests, "post", fake_post)
+    monkeypatch.setattr(migrate_keys, "_post_webhook", fake_post_webhook)
     logger = AuditLogger(log, webhook="https://example")
     migrate_batch(src, dst, logger, dry_run=True)
     assert len(calls) == 5

--- a/tests/test_mypy_plugin.py
+++ b/tests/test_mypy_plugin.py
@@ -1,14 +1,26 @@
+import importlib
 import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
+import tomllib
 
 pytest.importorskip("mypy")
 
 
-def run_mypy(path: str) -> subprocess.CompletedProcess:
+def configured_mypy_plugins() -> list[str]:
+    data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    mypy = cast(dict[str, Any], cast(dict[str, Any], data["tool"])["mypy"])
+    plugins = mypy.get("plugins", [])
+    if isinstance(plugins, str):
+        return [plugins]
+    return cast(list[str], plugins)
+
+
+def run_mypy(path: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, "-m", "mypy", path],
         stdout=subprocess.PIPE,
@@ -18,7 +30,17 @@ def run_mypy(path: str) -> subprocess.CompletedProcess:
     )
 
 
-def test_vulnerable_example_triggers_error():
+def test_configured_mypy_plugin_is_importable() -> None:
+    plugins = configured_mypy_plugins()
+
+    assert "cryptography_suite._mypy_crypto_checker" in plugins
+    assert all(not plugin.startswith("tools.") for plugin in plugins)
+    for plugin in plugins:
+        module = importlib.import_module(plugin)
+        assert module.__file__
+
+
+def test_vulnerable_example_triggers_error() -> None:
     proc = run_mypy("examples/vulnerable.py")
     assert proc.returncode != 0
     assert "Insecure hash function" in proc.stdout

--- a/tests/test_optional_features_missing.py
+++ b/tests/test_optional_features_missing.py
@@ -1,9 +1,34 @@
+import builtins
 import importlib
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import pytest
 
 from cryptography_suite.errors import MissingDependencyError
+
+
+@contextmanager
+def _blocked_imports(*roots: str) -> Iterator[None]:
+    original_import = builtins.__import__
+    removed = {}
+    for name in list(sys.modules):
+        if any(name == root or name.startswith(f"{root}.") for root in roots):
+            removed[name] = sys.modules.pop(name)
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if level == 0 and name.split(".", 1)[0] in roots:
+            raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+        return original_import(name, globals, locals, fromlist, level)
+
+    builtins.__import__ = guarded_import
+    try:
+        yield
+    finally:
+        builtins.__import__ = original_import
+        for name, module in removed.items():
+            sys.modules.setdefault(name, module)
 
 
 def test_homomorphic_requires_pyfhel(monkeypatch):
@@ -16,8 +41,124 @@ def test_homomorphic_requires_pyfhel(monkeypatch):
     ):
         sys.modules.pop(module_name, None)
     h = importlib.import_module("cryptography_suite.experimental.fhe")
-    with pytest.raises(MissingDependencyError):
+    with pytest.raises(MissingDependencyError, match=r"cryptography-suite\[fhe\]"):
         h.fhe_keygen()
+
+
+def test_blake3_hashing_requires_hashing_extra():
+    import cryptography_suite.hashing as hashing
+
+    with _blocked_imports("blake3"):
+        importlib.reload(hashing)
+        with pytest.raises(
+            MissingDependencyError,
+            match=r"cryptography-suite\[hashing-extra\]",
+        ):
+            hashing.blake3_hash("message")
+    importlib.reload(hashing)
+
+
+def test_bls_requires_bls_extra():
+    import cryptography_suite.asymmetric.bls as bls
+
+    with _blocked_imports("py_ecc"):
+        importlib.reload(bls)
+        with pytest.raises(MissingDependencyError, match=r"cryptography-suite\[bls\]"):
+            bls.generate_bls_keypair()
+    importlib.reload(bls)
+
+
+def test_spake2_requires_pake_extra():
+    import cryptography_suite.protocols.pake as pake
+
+    with _blocked_imports("spake2"):
+        importlib.reload(pake)
+        with pytest.raises(MissingDependencyError, match=r"cryptography-suite\[pake\]"):
+            pake.SPAKE2Client("password")
+    importlib.reload(pake)
+
+
+def test_codegen_requires_codegen_extra(tmp_path):
+    import cryptography_suite.codegen as codegen
+
+    pipeline = tmp_path / "pipeline.yaml"
+    pipeline.write_text("[]\n", encoding="utf-8")
+    with _blocked_imports("jinja2"):
+        importlib.reload(codegen)
+        with pytest.raises(
+            MissingDependencyError,
+            match=r"cryptography-suite\[codegen\]",
+        ):
+            codegen.generate("fastapi", str(pipeline), str(tmp_path / "out"))
+    importlib.reload(codegen)
+
+
+def test_rich_logging_requires_cli_extra():
+    import cryptography_suite.rich_logging as rich_logging
+
+    with _blocked_imports("rich"):
+        importlib.reload(rich_logging)
+        with pytest.raises(MissingDependencyError, match=r"cryptography-suite\[cli\]"):
+            rich_logging.get_rich_logger()
+    importlib.reload(rich_logging)
+
+
+def test_aws_kms_requires_kms_extra():
+    import cryptography_suite.keystores.aws_kms as aws_kms
+
+    with _blocked_imports("boto3"):
+        importlib.reload(aws_kms)
+        with pytest.raises(MissingDependencyError, match=r"cryptography-suite\[kms\]"):
+            aws_kms.AWSKMSKeyStore()
+    importlib.reload(aws_kms)
+
+
+def test_pkcs11_requires_hsm_extra():
+    import cryptography_suite.keystores.pkcs11 as pkcs11_module
+
+    with _blocked_imports("pkcs11"):
+        importlib.reload(pkcs11_module)
+        with pytest.raises(MissingDependencyError, match=r"cryptography-suite\[hsm\]"):
+            pkcs11_module.PKCS11KeyStore()
+    importlib.reload(pkcs11_module)
+
+
+def test_visualization_requires_viz_extra():
+    import cryptography_suite.viz.widgets as widgets
+
+    with _blocked_imports("ipywidgets", "networkx"):
+        importlib.reload(widgets)
+        with pytest.raises(MissingDependencyError, match=r"cryptography-suite\[viz\]"):
+            widgets.HandshakeFlowWidget(["start"])
+    importlib.reload(widgets)
+
+
+def test_cli_blake3_missing_message(tmp_path, capsys):
+    import cryptography_suite.cli as cli
+
+    payload = tmp_path / "payload.txt"
+    payload.write_text("hello", encoding="utf-8")
+    with _blocked_imports("blake3"):
+        importlib.reload(cli)
+        with pytest.raises(SystemExit):
+            cli.main(["hash", str(payload), "--algorithm", "blake3"])
+    importlib.reload(cli)
+
+    assert "Install cryptography-suite[hashing-extra]" in capsys.readouterr().out
+
+
+def test_cli_export_yaml_missing_message(tmp_path, capsys):
+    import cryptography_suite.cli as cli
+
+    pipeline = tmp_path / "pipeline.yaml"
+    pipeline.write_text("[]\n", encoding="utf-8")
+    with _blocked_imports("yaml"):
+        importlib.reload(cli)
+        with pytest.raises(SystemExit):
+            cli.main(["export", str(pipeline)])
+    importlib.reload(cli)
+
+    assert "Install cryptography-suite[cli]" in capsys.readouterr().out
 
 
 def test_bulletproof_requires_dependency(monkeypatch):

--- a/tests/test_pake.py
+++ b/tests/test_pake.py
@@ -1,10 +1,16 @@
 import unittest
+from importlib.util import find_spec
 
-from cryptography_suite.errors import CryptographySuiteError
-
+import pytest
 from cryptography.exceptions import InvalidKey
 
+from cryptography_suite.errors import CryptographySuiteError
 from cryptography_suite.protocols import SPAKE2Client, SPAKE2Server
+
+pytestmark = pytest.mark.skipif(
+    find_spec("spake2") is None,
+    reason="spake2 not installed; install cryptography-suite[pake]",
+)
 
 
 class TestPAKE(unittest.TestCase):
@@ -57,9 +63,9 @@ class TestPAKE(unittest.TestCase):
         client.generate_message()
         with self.assertRaises(CryptographySuiteError) as context:
             client.get_shared_key()
-        self.assertEqual(str(context.exception), "Shared key has not been computed yet.")
-
-
+        self.assertEqual(
+            str(context.exception), "Shared key has not been computed yet."
+        )
 
     def test_spake2_get_shared_key_after_computation(self):
         client = SPAKE2Client(self.password)

--- a/tests/test_pqc_stubs.py
+++ b/tests/test_pqc_stubs.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import pytest
 
+from cryptography_suite.errors import MissingDependencyError
+
 
 class DummyKEM:
     CIPHERTEXT = b"ct"
@@ -93,5 +95,5 @@ def test_pqc_import_error(monkeypatch):
 
     importlib.reload(pqc)
     pqc.PQCRYPTO_AVAILABLE = False
-    with pytest.raises(ImportError):
+    with pytest.raises(MissingDependencyError):
         pqc.generate_ml_kem_keypair()

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,4 +1,13 @@
+from importlib.util import find_spec
+
+import pytest
+
 from cryptography_suite.viz import HandshakeFlowWidget, export_widget_html
+
+pytestmark = pytest.mark.skipif(
+    find_spec("ipywidgets") is None or find_spec("networkx") is None,
+    reason="visualization dependencies not installed; install cryptography-suite[viz]",
+)
 
 
 def test_widget_instantiation(tmp_path):


### PR DESCRIPTION
## Summary
- Minimizes the default runtime install to the core `cryptography` dependency.
- Moves feature-specific dependencies into extras and keeps dev/test tooling out of runtime requirements.
- Adds lazy optional imports and clear `MissingDependencyError` guidance for optional feature paths.
- Updates installation docs and tests dependency metadata/import behavior.

## Default dependency changes
- `pyproject.toml` base dependencies now contain only `cryptography>=46.0.5`.
- `requirements.txt` now mirrors the minimal runtime dependency surface.
- Dev/test tools remain in the `dev` extra or `requirements-dev.txt`, not runtime dependencies.

## Extras added/updated
- Added/updated: `cli`, `hashing-extra`, `bls`, `pake`, `pqc`, `fhe`, `viz`, `codegen`, `kms`, `hsm`, `async`, `dev`.
- Retained existing compatibility extras such as `aws`, `docs`, `legacy`, and `zk`.

## Optional import behavior
- Root package import no longer imports optional dependencies such as `blake3`, `spake2`, `py_ecc`, `pqcrypto`, `Pyfhel`, `ipywidgets`, `networkx`, `jinja2`, `rich`, or `requests`.
- Optional features now lazy-load their dependencies and fail with explicit install guidance such as `Install cryptography-suite[extra-name] to use this feature.`
- CLI BLAKE3, YAML export, codegen, PQC keygen, migration helper imports, BLS, PAKE, FHE, viz, KMS, HSM, and async file paths were covered.

## Tests
- Added `tests/test_dependency_metadata.py` for base dependency, extras, package discovery, and root/CLI import-surface assertions.
- Expanded missing optional dependency tests for BLAKE3, BLS, PAKE, codegen, rich logging, KMS, HSM, viz, and CLI messages.
- Updated optional-dependency feature tests to skip cleanly when optional extras are not installed.

## Verification
- `python -m pytest -q tests/test_dependency_metadata.py tests/test_optional_features_missing.py tests/test_root_exports.py` -> 20 passed
- `python -m pytest -q tests/test_cli_main.py tests/test_pqc.py tests/test_pqc_stubs.py tests/test_homomorphic.py tests/test_keystore_plugins.py tests/test_hashing.py tests/test_bls.py tests/test_pake.py tests/test_viz.py` -> 93 passed, 7 skipped
- `python -m ruff check --fix <changed python files>` -> passed
- `python -m ruff format <changed python files>` -> passed
- `python -m black <changed python files>` -> passed
- `python -m mypy --follow-imports=skip --ignore-missing-imports --disable-error-code=no-any-return --disable-error-code=no-untyped-def --disable-error-code=misc --disable-error-code=type-arg <changed python files>` -> passed
- `python -m pytest -q` -> 490 passed, 16 skipped
- `git diff --check` -> passed

## Grep results and interpretation
- `tools*` has no package discovery hit.
- Optional dependency names appear in `pyproject.toml` extras/dev/tool configuration and in guarded or lazy optional-module imports.
- Optional names do not appear in base runtime dependencies.
- Root import optional dependency check passed.

## Remaining risks
- Experimental feature extras remain experimental and not independently audited.
- Some optional features are skipped when their extras are unavailable, so downstream CI should include explicit extras jobs if it wants exercised optional backends.
