### PR TITLE
ci: fix musllinux Python bootstrap mismatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,15 @@ jobs:
           - os: ubuntu-latest
             cibw_build: "cp3{10,11,12}-manylinux_x86_64 pp310-manylinux_x86_64"
             plat_name: manylinux_2_28_x86_64
-            manylinux_image: quay.io/pypa/manylinux_2_28_x86_64
+            manylinux_image: manylinux_2_28
           - os: manylinux_x86_64
             cibw_build: "cp3{10,11,12}-manylinux_x86_64 pp310-manylinux_x86_64"
             plat_name: manylinux_2_28_x86_64
-            manylinux_image: quay.io/pypa/manylinux_2_28_x86_64
+            manylinux_image: manylinux_2_28
           - os: musllinux_x86_64
             cibw_build: "cp3{10,11,12}-musllinux_x86_64"
             plat_name: musllinux_1_2_x86_64
-            musllinux_image: quay.io/pypa/musllinux_1_2_x86_64
+            musllinux_image: musllinux_1_2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,15 +11,15 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            cibw_build: "*-manylinux_x86_64"
+            cibw_build: "cp3{10,11,12}-manylinux_x86_64 pp310-manylinux_x86_64"
             plat_name: manylinux_2_28_x86_64
             manylinux_image: quay.io/pypa/manylinux_2_28_x86_64
           - os: manylinux_x86_64
-            cibw_build: "*-manylinux_x86_64"
+            cibw_build: "cp3{10,11,12}-manylinux_x86_64 pp310-manylinux_x86_64"
             plat_name: manylinux_2_28_x86_64
             manylinux_image: quay.io/pypa/manylinux_2_28_x86_64
           - os: musllinux_x86_64
-            cibw_build: "*-musllinux_x86_64"
+            cibw_build: "cp3{10,11,12}-musllinux_x86_64"
             plat_name: musllinux_1_2_x86_64
             musllinux_image: quay.io/pypa/musllinux_1_2_x86_64
     runs-on: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
           PIP_BREAK_SYSTEM_PACKAGES: "1"
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install cibuildwheel==2.18 pip-audit 'cryptography>=46.0.5'
+          python3 -m pip install cibuildwheel==2.22.0 pip-audit 'cryptography>=46.0.5'
       - name: Build wheels
         env:
           CFLAGS: -O2 -fstack-protector-strong -fPIC


### PR DESCRIPTION
## Root cause

The failure had two coupled causes:

1. **Incompatible cibuildwheel utility Python.** `cibuildwheel==2.18.0` hard-codes `/opt/python/cp38-cp38/bin/python` as its Linux container utility interpreter. Current supported PyPA images no longer contain CPython 3.8, so environment setup failed before the selected CPython 3.10 build could start.
2. **Floating container-image drift.** The workflow supplied full untagged `quay.io/pypa/*_x86_64` image names. Those values bypass cibuildwheel's matched, dated image pins and resolve through the registry's floating `latest` tag, allowing the container contents to drift independently of the pinned cibuildwheel version.

`requires-python = ">=3.10"` correctly controls target selection but does not alter cibuildwheel's independent utility interpreter. No `setup.py`, `setup.cfg`, PATH, `PYTHON`, or user-defined `CIBW_ENVIRONMENT` setting caused the failure.

## Focused fix

- Bump cibuildwheel from 2.18.0 to 2.22.0, the first release that replaces the EOL CPython 3.8 Linux utility interpreter with CPython 3.9.
- Replace the floating full image names with cibuildwheel's official aliases:
  - `manylinux_2_28`
  - `musllinux_1_2`
- Make the intended target set explicit so the tool upgrade cannot silently expand it:
  - musllinux: `cp310`, `cp311`, `cp312`
  - manylinux: `cp310`, `cp311`, `cp312`, and the pre-existing `pp310`

No product code, packaging, tests, documentation, actions, unrelated workflow behavior, or dependency other than cibuildwheel changed.

## Validation

- `actionlint .github/workflows/build.yml` — passed.
- cibuildwheel 2.22's own option resolver maps the aliases to dated internal pins:
  - `manylinux_2_28` → `quay.io/pypa/manylinux_2_28_x86_64:2024.11.16-1`
  - `musllinux_1_2` → `quay.io/pypa/musllinux_1_2_x86_64:2024.11.16-1`
- Resolved build identifiers:
  - musllinux: `cp310`, `cp311`, `cp312`
  - manylinux: `cp310`, `cp311`, `cp312`, `pp310`
- [GitHub Actions Build run 30480559573](https://github.com/Psychevus/cryptography-suite/actions/runs/30480559573) — all three matrix jobs passed.
  - musllinux processed and finished `cp310`, `cp311`, and `cp312`.
  - both manylinux jobs processed and finished `cp310`, `cp311`, `cp312`, and `pp310`.
  - `ubuntu-latest-wheels`, `manylinux_x86_64-wheels`, and `musllinux_x86_64-wheels` artifacts uploaded successfully.
- Quality Gate, Reproducible Build, and Formal Model workflows all passed for commit `8e6768155711f622a0c4a8a1ba46f85ea44d7151`.
- `git diff --check` — passed.

## Rollback considerations

This change has no data or package-format migration. Reverting it restores both the cibuildwheel 2.18 utility-Python incompatibility and the floating-image drift. A functional rollback would need an explicitly dated image compatible with cibuildwheel 2.18, which would reintroduce an image containing the unsupported CPython 3.8 utility interpreter and is therefore not recommended.