### PR TITLE
feat(v4): add transactional filesystem boundary

### DIFF
--- a/.github/workflows/filesystem-boundary.yml
+++ b/.github/workflows/filesystem-boundary.yml
@@ -1,0 +1,78 @@
+name: Filesystem Boundary
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: filesystem-boundary-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  phase-4a:
+    name: Phase 4A (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: Linux
+          - os: windows-latest
+            label: Windows
+          - os: macos-latest
+            label: macOS
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            requirements-dev.txt
+            requirements.txt
+            pyproject.toml
+
+      - name: Install package and validation dependencies
+        run: |
+          python -m pip install --upgrade pip==24.2
+          python -m pip install -r requirements-dev.txt
+          python -m pip install -e .
+
+      - name: Report filesystem capabilities
+        run: >-
+          python -c "import json,tempfile;
+          from pathlib import Path;
+          from dataclasses import asdict;
+          from cryptography_suite.streaming.atomic import AtomicFileSink;
+          root=Path(tempfile.mkdtemp()).absolute();
+          print(json.dumps(asdict(AtomicFileSink.capabilities(root)),indent=2))"
+
+      - name: Validate filesystem contract and artifacts
+        run: >-
+          python -m pytest -ra
+          tests/unit/test_atomic_sink.py
+          tests/unit/test_atomic_failures.py
+          tests/negative/test_atomic_paths.py
+          tests/integration/test_atomic_concurrency.py
+          tests/contract/test_import_boundaries.py
+          tests/contract/test_root_api.py
+          tests/unit/test_public_submodules.py
+          tests/artifact/test_artifact_contract.py
+          tests/integration/test_installed_wheel.py
+
+      - name: Validate package typing and lint boundary
+        run: |
+          python -m mypy src/cryptography_suite
+          python -m ruff check src/cryptography_suite tests
+          python -m ruff format --check src/cryptography_suite tests

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Build Status](https://github.com/Psychevus/cryptography-suite/actions/workflows/quality-gate.yml/badge.svg)](https://github.com/Psychevus/cryptography-suite/actions/workflows/quality-gate.yml)
 
-Cryptography Suite is a declaration-only v4 development skeleton. It provides
-no operational encryption or decryption and is not suitable for protecting
+Cryptography Suite is an incomplete v4 development skeleton. It provides no
+operational encryption or decryption and is not suitable for protecting
 production secrets.
 
-Phase 3 establishes the package boundary, immutable value models, public
-protocols, typed errors, and fail-closed orchestration signatures needed for
-later reviewed implementation work. The package version remains `3.0.0` while
-that incompatible v4 architecture is developed on the main branch.
+Phase 3 established the package boundary, immutable value models, public
+protocols, typed errors, and fail-closed orchestration signatures. Phase 4A
+adds a private transactional filesystem foundation for later streaming work.
+The package version remains `3.0.0` while that incompatible v4 architecture is
+developed on the main branch.
 
 ## Current status
 
@@ -22,8 +23,11 @@ that incompatible v4 architecture is developed on the main branch.
 - No policy engine or policy evaluation is implemented.
 - No legacy parser, format autodetection, or migration implementation is
   shipped.
-- No filesystem transactional sink is implemented.
+- A private filesystem transactional sink is implemented, but it performs no
+  encryption or authentication and is not a package-root API.
 - The project has not completed an independent security audit.
+- The independent Deep Security Scan remains **BLOCKED BY TOOLING FAILURE** and
+  is required before Phase 4 completion or a stable release.
 
 The public `Protector` methods intentionally raise `NotImplementedError` before
 cryptographic, provider, filesystem, audit-sink, or network side effects.
@@ -95,7 +99,10 @@ source distribution and are not compatibility fallbacks for the v4 skeleton.
 - [Phase 2 RFCs](docs/v4/rfcs/)
 - [Architecture documents](docs/v4/architecture/)
 - [Phase 3 evidence](docs/v4/phase-3/)
+- [Phase 4A filesystem contract](docs/v4/phase-4a/filesystem-contract.md)
+- [Phase 4A platform capability matrix](docs/v4/phase-4a/platform-capability-matrix.md)
 - [Security policy](SECURITY.md)
 - [Contributing guide](CONTRIBUTING.md)
 
-Phase 4 implementation work has not started.
+Phase 4A is the filesystem boundary only. Phase 4B, 4C, and 4D remain
+unimplemented, and the overall Phase 4 is incomplete.

--- a/docs/v4/phase-4a/artifact-inventory.txt
+++ b/docs/v4/phase-4a/artifact-inventory.txt
@@ -5,7 +5,7 @@ Base SHA:
 fc50585b280dd9bb76c7671f1932a6d80bc4f06e
 
 Implementation SHA before evidence commit:
-86bc82df8124e1cf329fc4a5bf5ffe533774658a
+3c51950fb090475229f1206e685aaa59a9fe50a9
 
 Package version:
 3.0.0
@@ -14,15 +14,15 @@ Wheel:
 name=cryptography_suite-3.0.0-py3-none-any.whl
 file_count=26
 runtime_file_count=21
-bytes=30785
-sha256=c829aba275af5949d598c974675cf05cbbeb9c7f44de443e9bade2516fa64548
+bytes=31578
+sha256=7a0e6d78e853ff9c433642909220e276567e92f0a3bc78f6778ec74c22be28a8
 
 Source distribution:
 name=cryptography_suite-3.0.0.tar.gz
 file_count=33
 runtime_file_count=21
-bytes=27684
-sha256=629f60ca8ddaee6a6d74efc0f0398c7a11850c97b9624cc7884e57d675146aa0
+bytes=28451
+sha256=dfbb60b340033babcc551e3e805bf502c1c6e7d28da79a4a41b7b0f1ab79e983
 
 Exact runtime inventory:
 cryptography_suite/__init__.py
@@ -48,7 +48,7 @@ cryptography_suite/streaming/atomic.py
 cryptography_suite/streaming/sinks.py
 
 Installed-wheel origin:
-C:\Users\Mojta\AppData\Local\Temp\cryptography-suite-phase4a-evidence-20260730-c\venv\Lib\site-packages\cryptography_suite\__init__.py
+C:\Users\Mojta\AppData\Local\Temp\cryptography-suite-phase4a-evidence-20260730-d\venv\Lib\site-packages\cryptography_suite\__init__.py
 
 Installed-wheel result:
 non-editable install from outside checkout=pass

--- a/docs/v4/phase-4a/artifact-inventory.txt
+++ b/docs/v4/phase-4a/artifact-inventory.txt
@@ -1,0 +1,103 @@
+PHASE 4A ARTIFACT INVENTORY
+============================
+
+Base SHA:
+fc50585b280dd9bb76c7671f1932a6d80bc4f06e
+
+Implementation SHA before evidence commit:
+86bc82df8124e1cf329fc4a5bf5ffe533774658a
+
+Package version:
+3.0.0
+
+Wheel:
+name=cryptography_suite-3.0.0-py3-none-any.whl
+file_count=26
+runtime_file_count=21
+bytes=30785
+sha256=c829aba275af5949d598c974675cf05cbbeb9c7f44de443e9bade2516fa64548
+
+Source distribution:
+name=cryptography_suite-3.0.0.tar.gz
+file_count=33
+runtime_file_count=21
+bytes=27684
+sha256=629f60ca8ddaee6a6d74efc0f0398c7a11850c97b9624cc7884e57d675146aa0
+
+Exact runtime inventory:
+cryptography_suite/__init__.py
+cryptography_suite/_internal/__init__.py
+cryptography_suite/_internal/filesystem.py
+cryptography_suite/audit/__init__.py
+cryptography_suite/audit/events.py
+cryptography_suite/context.py
+cryptography_suite/envelope/__init__.py
+cryptography_suite/envelope/models.py
+cryptography_suite/errors.py
+cryptography_suite/legacy/__init__.py
+cryptography_suite/lifecycle/__init__.py
+cryptography_suite/lifecycle/models.py
+cryptography_suite/policy.py
+cryptography_suite/protector.py
+cryptography_suite/providers/__init__.py
+cryptography_suite/providers/base.py
+cryptography_suite/providers/models.py
+cryptography_suite/py.typed
+cryptography_suite/streaming/__init__.py
+cryptography_suite/streaming/atomic.py
+cryptography_suite/streaming/sinks.py
+
+Installed-wheel origin:
+C:\Users\Mojta\AppData\Local\Temp\cryptography-suite-phase4a-evidence-20260730-c\venv\Lib\site-packages\cryptography_suite\__init__.py
+
+Installed-wheel result:
+non-editable install from outside checkout=pass
+root API=pass
+private sink direct import=pass
+stage/abort=pass
+stage/commit=pass
+destination hidden before commit=true
+committed bytes=exact
+owned temporary names after completion=none
+pip check=no broken requirements
+sdist rebuilt-wheel runtime inventory=equal, 21 files
+
+Console entry points:
+none
+
+Exact root exports:
+AuthenticationError
+ContextMismatchError
+CryptographySuiteError
+EncryptionContext
+Envelope
+EnvelopeError
+EnvelopeMetadata
+ErrorCode
+KeyProvider
+KeyRef
+MigrationError
+Policy
+PolicyError
+Protector
+ProviderError
+
+Exact public streaming exports:
+SinkState
+TransactionalSink
+
+New approved internal runtime files:
+cryptography_suite/_internal/__init__.py
+cryptography_suite/_internal/filesystem.py
+cryptography_suite/streaming/atomic.py
+
+Prohibited artifact checks:
+tests in wheel=absent
+temporary files=absent
+generated failure fixtures=absent
+platform-private data=absent
+console entry point=absent
+removed runtime families=absent
+runtime allowlist mismatch=none
+sdist unexpected roots=none
+Phase 3 historical documents in artifacts=not packaged and unchanged in repository

--- a/docs/v4/phase-4a/failure-injection-evidence.md
+++ b/docs/v4/phase-4a/failure-injection-evidence.md
@@ -1,0 +1,54 @@
+# Phase 4A failure-injection evidence
+
+- **Implementation SHA:** `86bc82df8124e1cf329fc4a5bf5ffe533774658a`
+- **Injection seam:** private `FilesystemOS` facade
+- **Evidence test:** `tests/unit/test_atomic_failures.py`
+- **Result:** 25 cases collected; 24 passed and the POSIX namespace-replacement
+  case was skipped on Windows/Python 3.12
+
+The facade wrapper raises one-shot `FilesystemOperationError` instances without
+monkeypatching global filesystem functions. Except where the row says
+`PUBLISHED_DURABILITY_UNCERTAIN` or `CLEANUP_INCOMPLETE`, the legal next action
+is idempotent `abort()`, which was exercised and removed only the owned staging
+name. No injected exception string or repr contained the supplied root,
+destination, temporary name, source bytes, or staged bytes.
+
+| Injected point | Actual state / outcome | Destination and source | Owned temporary | Exception |
+| --- | --- | --- | --- | --- |
+| Capability probe unavailable | `FAILED` / `NOT_PUBLISHED` | absent; no source supplied | never created | `AtomicSinkError`, `IO_FAILED` |
+| Capability report lacks a required primitive | `FAILED` / `NOT_PUBLISHED` | absent; no source supplied | never created | `AtomicSinkError`, `IO_FAILED` |
+| Root open | `FAILED` / `NOT_PUBLISHED` | absent; no source supplied | never created | `AtomicSinkError`, `IO_FAILED` |
+| Parent traversal | `FAILED` / `NOT_PUBLISHED` | absent; nested parent unchanged | never created | `AtomicSinkError`, `IO_FAILED` |
+| Pre-mutation parent durability barrier | `FAILED` / `NOT_PUBLISHED` | absent; no source supplied | never created | represented by the `open_parent` facade failure, `IO_FAILED` |
+| Temporary creation | `FAILED` / `NOT_PUBLISHED` | absent; no source supplied | creation refused; parent closed | `AtomicSinkError`, `IO_FAILED` |
+| First write | `FAILED` / `NOT_PUBLISHED` | absent; no source supplied | removed by abort | `AtomicSinkError`, `IO_FAILED` |
+| Partial write followed by later failure | `FAILED` / `NOT_PUBLISHED` | absent; no source supplied; completed-chunk count remains zero | removed by abort | `AtomicSinkError`, `IO_FAILED` |
+| Interrupted write | remains `OPEN`, then `COMMITTED` / `PUBLISHED` | exact payload published | promotion removes staging name | interruption retried; no error escapes |
+| Zero-progress write | `FAILED` / `NOT_PUBLISHED` | absent; no source supplied | removed by abort | `AtomicSinkError`, `IO_FAILED` |
+| Userspace flush | not applicable: facade uses unbuffered OS writes | unchanged until commit | still owned | no weaker buffered path exists |
+| File fsync | `FAILED` / `NOT_PUBLISHED` | absent or original bytes unchanged; source unchanged | removed by abort | `AtomicSinkError`, `IO_FAILED` |
+| Temporary ownership revalidation | `FAILED` / `NOT_PUBLISHED` | absent or original bytes unchanged | removed only if identity still matches | `AtomicSinkError`, `IO_FAILED` |
+| Destination revalidation | `FAILED` / `NOT_PUBLISHED` | absent or original bytes unchanged; source unchanged | removed by abort | `AtomicSinkError`, `IO_FAILED` |
+| No-overwrite atomic promotion | `FAILED` / `NOT_PUBLISHED` | absent or concurrent winner unchanged | removed by abort | `AtomicSinkError`, `IO_FAILED` or `OUTPUT_EXISTS` |
+| Overwrite atomic promotion | `FAILED` / `NOT_PUBLISHED` | original bytes unchanged; source unchanged | removed by abort | `AtomicSinkError`, `IO_FAILED` |
+| Simulated cross-device promotion | `FAILED` / `NOT_PUBLISHED` | absent; no source supplied | removed by abort; no copy fallback | `AtomicSinkError`, `IO_FAILED` |
+| Abort-time temporary unlink | `CLEANUP_INCOMPLETE` / `CLEANUP_INCOMPLETE` | absent; no source supplied | retained for explicit retry, then removed | `AtomicSinkError`, `IO_FAILED` |
+| Abort-time owned-identity mismatch | `CLEANUP_INCOMPLETE` / `CLEANUP_INCOMPLETE` | absent; no source supplied | untrusted replacement not removed; one-shot facade retry cleans only the real fixture | `AtomicSinkError`, `IO_FAILED` |
+| POSIX temporary pathname replacement | `FAILED`, then cleanup incomplete / `CLEANUP_INCOMPLETE` | destination absent | attacker replacement preserved | `AtomicSinkError`, `IO_FAILED`; POSIX CI case |
+| Post-publication directory durability barrier | `PUBLICATION_UNCERTAIN` / `PUBLISHED_DURABILITY_UNCERTAIN` | new destination retained; source unchanged | closed; abort cannot remove destination | `AtomicSinkError`, `IO_FAILED` |
+| Post-publication temporary-handle close | `CLEANUP_INCOMPLETE` / `CLEANUP_INCOMPLETE` | new destination retained; source unchanged | explicit abort retries close | `AtomicSinkError`, `IO_FAILED` |
+| Post-publication parent-handle close | `CLEANUP_INCOMPLETE` / `CLEANUP_INCOMPLETE` | new destination retained; source unchanged | already promoted; explicit abort retries parent close | `AtomicSinkError`, `IO_FAILED` |
+
+Real namespace-race tests supplement the injected points:
+
+- a destination appearing after staging is preserved in both default and
+  dual-authorized overwrite modes;
+- an initially existing destination that is replaced after staging is
+  preserved and publication fails closed;
+- a POSIX staging pathname replacement is not deleted as owned;
+- Windows denies staging-name replacement while its no-share handle is open;
+- two synchronized processes race with no overwrite, producing one winner and
+  one `OUTPUT_EXISTS` loser with no staging-name leak.
+
+The independent Deep Security Scan remains **BLOCKED BY TOOLING FAILURE**. It
+was not retried and this document is not a substitute for that scan.

--- a/docs/v4/phase-4a/failure-injection-evidence.md
+++ b/docs/v4/phase-4a/failure-injection-evidence.md
@@ -1,9 +1,9 @@
 # Phase 4A failure-injection evidence
 
-- **Implementation SHA:** `86bc82df8124e1cf329fc4a5bf5ffe533774658a`
+- **Implementation SHA:** `3c51950fb090475229f1206e685aaa59a9fe50a9`
 - **Injection seam:** private `FilesystemOS` facade
 - **Evidence test:** `tests/unit/test_atomic_failures.py`
-- **Result:** 25 cases collected; 24 passed and the POSIX namespace-replacement
+- **Result:** 27 cases collected; 26 passed and the POSIX namespace-replacement
   case was skipped on Windows/Python 3.12
 
 The facade wrapper raises one-shot `FilesystemOperationError` instances without
@@ -21,6 +21,7 @@ destination, temporary name, source bytes, or staged bytes.
 | Parent traversal | `FAILED` / `NOT_PUBLISHED` | absent; nested parent unchanged | never created | `AtomicSinkError`, `IO_FAILED` |
 | Pre-mutation parent durability barrier | `FAILED` / `NOT_PUBLISHED` | absent; no source supplied | never created | represented by the `open_parent` facade failure, `IO_FAILED` |
 | Temporary creation | `FAILED` / `NOT_PUBLISHED` | absent; no source supplied | creation refused; parent closed | `AtomicSinkError`, `IO_FAILED` |
+| Existing-destination handle retention | `FAILED` / `NOT_PUBLISHED` | original bytes unchanged | never created | `AtomicSinkError`, `IO_FAILED` |
 | First write | `FAILED` / `NOT_PUBLISHED` | absent; no source supplied | removed by abort | `AtomicSinkError`, `IO_FAILED` |
 | Partial write followed by later failure | `FAILED` / `NOT_PUBLISHED` | absent; no source supplied; completed-chunk count remains zero | removed by abort | `AtomicSinkError`, `IO_FAILED` |
 | Interrupted write | remains `OPEN`, then `COMMITTED` / `PUBLISHED` | exact payload published | promotion removes staging name | interruption retried; no error escapes |
@@ -37,6 +38,7 @@ destination, temporary name, source bytes, or staged bytes.
 | POSIX temporary pathname replacement | `FAILED`, then cleanup incomplete / `CLEANUP_INCOMPLETE` | destination absent | attacker replacement preserved | `AtomicSinkError`, `IO_FAILED`; POSIX CI case |
 | Post-publication directory durability barrier | `PUBLICATION_UNCERTAIN` / `PUBLISHED_DURABILITY_UNCERTAIN` | new destination retained; source unchanged | closed; abort cannot remove destination | `AtomicSinkError`, `IO_FAILED` |
 | Post-publication temporary-handle close | `CLEANUP_INCOMPLETE` / `CLEANUP_INCOMPLETE` | new destination retained; source unchanged | explicit abort retries close | `AtomicSinkError`, `IO_FAILED` |
+| Post-publication destination-lease close | `CLEANUP_INCOMPLETE` / `CLEANUP_INCOMPLETE` | replacement retained; source unchanged | explicit abort retries retained-target close | `AtomicSinkError`, `IO_FAILED` |
 | Post-publication parent-handle close | `CLEANUP_INCOMPLETE` / `CLEANUP_INCOMPLETE` | new destination retained; source unchanged | already promoted; explicit abort retries parent close | `AtomicSinkError`, `IO_FAILED` |
 
 Real namespace-race tests supplement the injected points:

--- a/docs/v4/phase-4a/filesystem-contract.md
+++ b/docs/v4/phase-4a/filesystem-contract.md
@@ -60,6 +60,13 @@ Windows identity is volume serial plus file index from
 `GetFileInformationByHandle`. These values never enter exception text, repr,
 logs, or public metadata.
 
+For an existing overwrite destination, construction also retains an open
+destination handle. Commit compares the retained object with the immediately
+reinspected name before publication. On POSIX the retained handle prevents
+inode reuse from making a delete-and-recreate race look unchanged. Windows
+opens the retained target with delete sharing and uses POSIX-semantics replace
+flags so the handle can remain open through atomic replacement.
+
 ## Temporary ownership and permissions
 
 Staging occurs exclusively in the destination's existing parent. A random
@@ -117,7 +124,7 @@ operation-intent flag are true. An absent destination still uses the
 no-overwrite primitive so a newly appearing object is not replaced without
 inspection. A safely inspected existing destination is replaced atomically:
 POSIX uses same-directory `replace`; Windows uses handle-based rename with
-`FILE_RENAME_FLAG_REPLACE_IF_EXISTS`.
+`FILE_RENAME_FLAG_REPLACE_IF_EXISTS | FILE_RENAME_FLAG_POSIX_SEMANTICS`.
 
 The staged permission is the final permission; source or old-destination mode
 is not inherited.

--- a/docs/v4/phase-4a/filesystem-contract.md
+++ b/docs/v4/phase-4a/filesystem-contract.md
@@ -1,0 +1,189 @@
+# Phase 4A transactional filesystem contract
+
+- **Status:** implementation contract
+- **Rollback checkpoint:** `fc50585b280dd9bb76c7671f1932a6d80bc4f06e`
+- **Scope:** internal, non-cryptographic filesystem mechanics only
+
+## Responsibility and scope
+
+`cryptography_suite.streaming.atomic` supplies an internal
+`TransactionalSink` implementation. It accepts bounded `bytes`, keeps them
+under an operation-owned staging name, and publishes them only on an explicit
+commit. It is not exported by the package root or by
+`cryptography_suite.streaming`.
+
+The sink does not encrypt, decrypt, authenticate, hash caller data, invoke a
+provider, evaluate policy, parse an envelope, run a CLI, or delete a caller's
+source. `Protector` remains fail-closed.
+
+## Trusted root and untrusted relative destination
+
+The caller supplies:
+
+1. an explicit absolute trusted output root that already exists; and
+2. an untrusted relative destination below that root.
+
+The implementation never obtains either value from the current working
+directory or environment. The root is opened without following a final link.
+It must be a directory owned by the effective caller and must not permit
+group/other writes on POSIX. Windows requires a local NTFS root and retains
+non-reparse directory handles while the transaction is active.
+
+The relative path grammar rejects empty paths, absolute/anchored/drive/UNC
+paths, NUL, `.` and `..`, empty components, repeated separators, alternate
+separators, and platform-reserved or invalid names. Parent directories must
+already exist. No parent is created.
+
+POSIX traverses each parent with directory-relative `open`, `O_DIRECTORY`, and
+`O_NOFOLLOW`. Windows opens and retains each parent using `CreateFileW` with
+`FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT` and rejects every
+reparse point. Lexical validation is only the first check; it is not described
+as a race-proof containment mechanism.
+
+POSIX passes Unicode strings to the native filesystem unchanged. macOS
+filesystem normalization aliases remain filesystem-defined. Windows rejects
+trailing spaces/dots, reserved DOS device basenames, alternate data stream
+syntax, and invalid Win32 filename characters. Windows case comparison and
+normalization remain filesystem-defined.
+
+## Link and file-identity rules
+
+Destination inspection never follows a final symlink or reparse point. An
+existing directory or a file whose link count exceeds one is rejected. When a
+caller supplies an already-open source descriptor, the sink records its native
+file identity and compares that identity with the destination during
+construction and immediately before publication. The source handle remains
+caller-owned and is never closed or deleted.
+
+POSIX identity is device plus inode from `fstat`/directory-relative `stat`.
+Windows identity is volume serial plus file index from
+`GetFileInformationByHandle`. These values never enter exception text, repr,
+logs, or public metadata.
+
+## Temporary ownership and permissions
+
+Staging occurs exclusively in the destination's existing parent. A random
+nonsecret name is created with an exclusive create primitive and contains no
+source name, destination name, tenant, context, key, or data-derived value.
+The retained open handle and native identity establish ownership.
+
+POSIX creates with mode `0600`, applies `fchmod(0600)`, and verifies the mode.
+Windows creates with a protected DACL granting full control only through the
+owner-rights SID and verifies the resulting DACL. A platform/filesystem that
+cannot establish the permission property fails closed.
+
+Cleanup reopens or stats the staging name without following links and compares
+its identity with the retained identity. An identity mismatch is never
+unlinked.
+
+## Bounds and writes
+
+The immutable internal options object represents a future policy decision. It
+contains maximum write size, maximum total bytes, policy overwrite authority,
+and operation overwrite intent. It is not a public policy schema. Boolean
+values are rejected where integer bounds are required, caller bounds cannot
+exceed hard implementation ceilings, and overwrite defaults to false.
+
+`write` accepts exact `bytes`. Empty `bytes` is an accepted no-op. Each chunk
+and the checked cumulative total are validated before writing. Interrupted and
+partial system writes are retried until complete. A failed write makes the
+transaction non-committable but leaves deterministic abort available.
+
+## Publication
+
+Commit is permitted once from the open state:
+
+1. flush the retained file handle with the platform file-durability primitive;
+2. revalidate staging identity;
+3. revalidate destination type, link count, and optional source identity;
+4. atomically publish within the already-open parent;
+5. perform the platform directory/rename durability barrier; and
+6. close owned handles.
+
+No copy-and-delete or cross-filesystem fallback exists.
+
+### No overwrite
+
+No overwrite is the default. POSIX creates the destination atomically with
+`linkat` semantics and then removes only the owned staging name. Windows uses
+handle-based `SetFileInformationByHandle(FileRenameInfoEx)` without the
+replace flag. A concurrent destination causes a stable `OUTPUT_EXISTS`
+failure. Exactly one no-overwrite publisher can win.
+
+### Overwrite
+
+Replacement is enabled only when both the future-policy authority flag and the
+operation-intent flag are true. An absent destination still uses the
+no-overwrite primitive so a newly appearing object is not replaced without
+inspection. A safely inspected existing destination is replaced atomically:
+POSIX uses same-directory `replace`; Windows uses handle-based rename with
+`FILE_RENAME_FLAG_REPLACE_IF_EXISTS`.
+
+The staged permission is the final permission; source or old-destination mode
+is not inherited.
+
+## Durability and ambiguous outcomes
+
+POSIX performs file `fsync`, publication, staging-name cleanup, and containing
+directory `fsync`. Windows performs `FlushFileBuffers` before publication and
+uses a write-through file handle plus a post-rename `FlushFileBuffers` metadata
+barrier on local NTFS. Windows does not claim a portable POSIX directory-fsync
+API.
+
+Internal outcomes are:
+
+- `NOT_PUBLISHED`;
+- `PUBLISHED`;
+- `PUBLISHED_DURABILITY_UNCERTAIN`; and
+- `CLEANUP_INCOMPLETE`.
+
+A file-sync or promotion failure before publication leaves the old destination
+unchanged and permits abort. A failure of the post-publication durability
+barrier raises a typed uncertain error, keeps the destination, and prevents
+abort from claiming an aborted result. A failure removing a post-link staging
+name reports cleanup incomplete and never removes the destination.
+
+## Abort
+
+Abort is idempotent. Before publication it closes the staging handle, verifies
+the staging identity, and removes only that owned name. It never removes the
+destination or source. After commit it is a no-op with respect to the
+destination. After an uncertain or cleanup-incomplete publication it may
+retry cleanup of a distinct owned staging name but never changes the outcome
+to aborted.
+
+No destructor is relied upon for cleanup or correctness.
+
+## Errors and redaction
+
+Internal filesystem errors use existing stable codes `IO_FAILED`,
+`OUTPUT_EXISTS`, `LIMIT_EXCEEDED`, and `INTERNAL_ERROR`. Messages and reprs
+contain no trusted root, relative destination, temporary name, source or
+destination identity, staged bytes, or raw operating-system exception text.
+
+## State diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> OPEN
+    OPEN --> OPEN: bounded write
+    OPEN --> FAILED: write or pre-publication commit failure
+    OPEN --> PUBLISHING: commit
+    PUBLISHING --> COMMITTED: publication and durability complete
+    PUBLISHING --> PUBLICATION_UNCERTAIN: post-publication durability failure
+    PUBLISHING --> CLEANUP_INCOMPLETE: post-publication cleanup/close failure
+    OPEN --> ABORTED: abort and owned cleanup
+    FAILED --> ABORTED: abort and owned cleanup
+    OPEN --> CLEANUP_INCOMPLETE: abort cleanup failure
+    FAILED --> CLEANUP_INCOMPLETE: abort cleanup failure
+```
+
+## Unsupported behavior
+
+Relative-path roots, missing parents, writable-by-other POSIX parents, remote
+or non-NTFS Windows roots, reparse/link parents, unverifiable owner-only
+permissions, unavailable atomic publication, and unavailable durability
+barriers fail closed. Network shares, cross-filesystem publication, backups,
+automatic source deletion, stale-temp scanning, and recovery scanning are not
+implemented.
+

--- a/docs/v4/phase-4a/filesystem-contract.md
+++ b/docs/v4/phase-4a/filesystem-contract.md
@@ -186,4 +186,3 @@ permissions, unavailable atomic publication, and unavailable durability
 barriers fail closed. Network shares, cross-filesystem publication, backups,
 automatic source deletion, stale-temp scanning, and recovery scanning are not
 implemented.
-

--- a/docs/v4/phase-4a/phase-4a-summary.md
+++ b/docs/v4/phase-4a/phase-4a-summary.md
@@ -1,0 +1,143 @@
+# Phase 4A implementation summary
+
+- **Branch:** `feat/v4-phase-4a-safe-filesystem`
+- **Base and rollback SHA:** `fc50585b280dd9bb76c7671f1932a6d80bc4f06e`
+- **Implementation SHA:** `86bc82df8124e1cf329fc4a5bf5ffe533774658a`
+- **Goal:** private transactional filesystem publication with explicit failure
+  outcomes and no operational cryptography
+
+## Scope and architecture
+
+Phase 4A adds:
+
+- a private standard-library OS boundary in
+  `cryptography_suite._internal.filesystem`;
+- the private `AtomicFileSink` implementation and its internal options, states,
+  outcomes, and typed error in `cryptography_suite.streaming.atomic`;
+- path, state, link, race, permission, fault, import, artifact, and
+  installed-wheel tests;
+- a Linux/Windows/macOS filesystem-boundary workflow; and
+- the Phase 4A contract and evidence set.
+
+`StandardFilesystemOS` implements the `FilesystemOS` injection protocol.
+`AtomicFileSink` structurally satisfies the unchanged public
+`TransactionalSink` protocol. The root continues to export exactly 15 approved
+declarations, and public streaming exports remain exactly `SinkState` and
+`TransactionalSink`. No new public exception, option, state, or sink was added.
+
+The caller supplies an existing absolute trusted root and an untrusted relative
+destination. Components are validated lexically and traversed through
+no-follow directory descriptors on POSIX or retained non-reparse handles on
+Windows. Source/destination and owned-staging identity use device/inode on
+POSIX and volume/file-index values on Windows. Symlink/reparse destinations,
+linked parents, directories, and existing files with multiple hardlinks are
+rejected.
+
+No overwrite is the default. POSIX uses same-directory `linkat` semantics and
+Windows uses handle-based no-replace rename. Exactly one synchronized
+no-overwrite process wins. Overwrite requires both internal policy authority
+and explicit operation intent; it uses same-directory `renameat` replacement
+or Windows handle replacement only after destination revalidation. A
+destination that appears or changes after staging is preserved.
+
+POSIX staging and final files are verified as `0600`, including under a
+permissive umask. Windows creates and verifies the documented protected
+owner-only DACL on local NTFS. File durability uses `fsync` or
+`FlushFileBuffers`; containing-directory durability uses parent `fsync` on
+POSIX and the documented write-through/post-rename handle barrier on Windows.
+
+Pre-publication failure produces `NOT_PUBLISHED` and leaves abort available.
+Post-publication durability failure produces
+`PUBLISHED_DURABILITY_UNCERTAIN`; cleanup/close failure produces
+`CLEANUP_INCOMPLETE`. Abort is idempotent, retries safe owned cleanup, never
+deletes a caller source, and never converts a published uncertain result into
+an aborted result.
+
+## Files
+
+Added:
+
+- `.github/workflows/filesystem-boundary.yml`
+- `docs/v4/phase-4a/artifact-inventory.txt`
+- `docs/v4/phase-4a/failure-injection-evidence.md`
+- `docs/v4/phase-4a/filesystem-contract.md`
+- `docs/v4/phase-4a/phase-4a-summary.md`
+- `docs/v4/phase-4a/platform-capability-matrix.md`
+- `src/cryptography_suite/_internal/__init__.py`
+- `src/cryptography_suite/_internal/filesystem.py`
+- `src/cryptography_suite/streaming/atomic.py`
+- `tests/integration/test_atomic_concurrency.py`
+- `tests/negative/test_atomic_paths.py`
+- `tests/unit/test_atomic_failures.py`
+- `tests/unit/test_atomic_sink.py`
+
+Modified:
+
+- `README.md`
+- `pyproject.toml`
+- `tests/artifact/test_artifact_contract.py`
+- `tests/contract/test_import_boundaries.py`
+- `tests/integration/test_installed_wheel.py`
+- `tests/unit/test_public_submodules.py`
+
+No package version, root export, public streaming export, cryptographic,
+envelope, provider, policy, CLI, legacy, or migration implementation changed.
+
+## Validation and artifacts
+
+Local Windows/Python 3.12 evidence:
+
+- focused filesystem boundary before the documentation-only commit: 86 passed,
+  4 explicitly justified platform/capability skips;
+- final full suite with branch coverage: 123 collected, 119 passed, 4 explicit
+  Windows capability/platform skips, 78% aggregate branch coverage;
+- strict mypy: pass for 20 source files;
+- Ruff format and lint: pass;
+- Black: pass;
+- wheel: 26 entries, 21 runtime files;
+- sdist: 33 files, 21 runtime files;
+- isolated non-editable wheel stage/abort/commit: pass;
+- rebuilt-sdist wheel runtime inventory: exact match;
+- `pip check`: no broken requirements.
+
+The dedicated workflow runs the focused suite, installed-wheel smoke, artifact
+contract, capability report, typing, and lint on Ubuntu, Windows, and macOS.
+Final platform conclusions are recorded after GitHub completes the draft PR
+checks.
+
+Binding Phase 1 and Phase 2 documents and historical Phase 3 evidence remain
+byte-identical. The package remains at `3.0.0`. The independent Deep Security
+Scan remains **BLOCKED BY TOOLING FAILURE** and was not retried.
+
+## Definition of Done
+
+| Requirement | Result |
+| --- | --- |
+| Explicit root and strict relative path model | Complete |
+| No-follow parent traversal and final-link rejection | Complete |
+| Owned same-directory staging and identity-safe cleanup | Complete |
+| Bounded exact writes and deterministic states | Complete |
+| Atomic default no-overwrite and two-gate overwrite | Complete |
+| Source/destination identity and hardlink rejection | Complete |
+| POSIX owner-only mode and Windows protected DACL | Complete |
+| File and containing-directory durability contract | Complete |
+| Typed uncertain and cleanup-incomplete outcomes | Complete |
+| Real synchronized multi-process race | Complete |
+| Deterministic facade failure injection | Complete |
+| Exact wheel/sdist and installed-wheel boundary | Complete |
+| Linux, Windows, and macOS CI | Pending final GitHub conclusions |
+| Independent Deep Security Scan | **BLOCKED BY TOOLING FAILURE** |
+| Phase 4 overall | Incomplete; Phase 4B, 4C, and 4D not started |
+
+## Deferred work and rollback
+
+Phase 4B streaming transforms, Phase 4C envelope/cryptographic integration, and
+Phase 4D orchestration were not started. Backups, stale-transaction scanning,
+cross-filesystem copy transactions, network filesystems, alternate ACL models,
+CLI behavior, provider behavior, policy evaluation, envelope codecs, and
+migration remain out of scope.
+
+Rollback is a branch-level revert to
+`fc50585b280dd9bb76c7671f1932a6d80bc4f06e`, or reviewable reverts of the seven
+Phase 4A commits in reverse order. No data migration, published format, public
+API, or package-version rollback is required.

--- a/docs/v4/phase-4a/phase-4a-summary.md
+++ b/docs/v4/phase-4a/phase-4a-summary.md
@@ -140,6 +140,6 @@ CLI behavior, provider behavior, policy evaluation, envelope codecs, and
 migration remain out of scope.
 
 Rollback is a branch-level revert to
-`fc50585b280dd9bb76c7671f1932a6d80bc4f06e`, or reviewable reverts of the nine
+`fc50585b280dd9bb76c7671f1932a6d80bc4f06e`, or reviewable reverts of the ten
 Phase 4A commits in reverse order. No data migration, published format, public
 API, or package-version rollback is required.

--- a/docs/v4/phase-4a/phase-4a-summary.md
+++ b/docs/v4/phase-4a/phase-4a-summary.md
@@ -2,7 +2,7 @@
 
 - **Branch:** `feat/v4-phase-4a-safe-filesystem`
 - **Base and rollback SHA:** `fc50585b280dd9bb76c7671f1932a6d80bc4f06e`
-- **Implementation SHA:** `86bc82df8124e1cf329fc4a5bf5ffe533774658a`
+- **Implementation SHA:** `3c51950fb090475229f1206e685aaa59a9fe50a9`
 - **Goal:** private transactional filesystem publication with explicit failure
   outcomes and no operational cryptography
 
@@ -29,9 +29,11 @@ The caller supplies an existing absolute trusted root and an untrusted relative
 destination. Components are validated lexically and traversed through
 no-follow directory descriptors on POSIX or retained non-reparse handles on
 Windows. Source/destination and owned-staging identity use device/inode on
-POSIX and volume/file-index values on Windows. Symlink/reparse destinations,
-linked parents, directories, and existing files with multiple hardlinks are
-rejected.
+POSIX and volume/file-index values on Windows. Existing overwrite destinations
+are retained by handle through revalidation and replacement, preventing inode
+or file-index reuse from hiding a namespace replacement. Symlink/reparse
+destinations, linked parents, directories, and existing files with multiple
+hardlinks are rejected.
 
 No overwrite is the default. POSIX uses same-directory `linkat` semantics and
 Windows uses handle-based no-replace rename. Exactly one synchronized
@@ -87,10 +89,10 @@ envelope, provider, policy, CLI, legacy, or migration implementation changed.
 
 Local Windows/Python 3.12 evidence:
 
-- focused filesystem boundary before the documentation-only commit: 86 passed,
-  4 explicitly justified platform/capability skips;
-- final full suite with branch coverage: 123 collected, 119 passed, 4 explicit
-  Windows capability/platform skips, 78% aggregate branch coverage;
+- focused core filesystem suite: 75 collected, 71 passed, 4 explicitly
+  justified Windows capability/platform skips;
+- final full suite with branch coverage: 125 collected, 121 passed, 4 explicit
+  Windows capability/platform skips, 76% aggregate branch coverage;
 - strict mypy: pass for 20 source files;
 - Ruff format and lint: pass;
 - Black: pass;
@@ -138,6 +140,6 @@ CLI behavior, provider behavior, policy evaluation, envelope codecs, and
 migration remain out of scope.
 
 Rollback is a branch-level revert to
-`fc50585b280dd9bb76c7671f1932a6d80bc4f06e`, or reviewable reverts of the seven
+`fc50585b280dd9bb76c7671f1932a6d80bc4f06e`, or reviewable reverts of the nine
 Phase 4A commits in reverse order. No data migration, published format, public
 API, or package-version rollback is required.

--- a/docs/v4/phase-4a/platform-capability-matrix.md
+++ b/docs/v4/phase-4a/platform-capability-matrix.md
@@ -12,7 +12,7 @@
 | File identity/link count | `fstat`/`fstatat`, device+inode+nlink | `GetFileInformationByHandle` | `fstat`/`fstatat`, device+inode+nlink |
 | Final-link detection | `fstatat(..., AT_SYMLINK_NOFOLLOW)` | open reparse point and inspect attributes | `fstatat(..., AT_SYMLINK_NOFOLLOW)` |
 | Atomic no-overwrite | same-directory `linkat`, then owned-name unlink | handle rename without replace flag | same-directory `linkat`, then owned-name unlink |
-| Atomic overwrite | same-directory `renameat` replacement | handle rename with replace flag | same-directory `renameat` replacement |
+| Atomic overwrite | same-directory `renameat` replacement with retained target descriptor | handle rename with replace and POSIX-semantics flags while retaining the target handle | same-directory `renameat` replacement with retained target descriptor |
 | File durability | `fsync(file_fd)` | `FlushFileBuffers(file_handle)` | `fsync(file_fd)` |
 | Directory/rename durability | `fsync(parent_fd)` | write-through handle plus post-rename metadata flush | `fsync(parent_fd)` |
 | Cross-filesystem fallback | none; refused | none; refused | none; refused |

--- a/docs/v4/phase-4a/platform-capability-matrix.md
+++ b/docs/v4/phase-4a/platform-capability-matrix.md
@@ -1,0 +1,37 @@
+# Phase 4A platform capability matrix
+
+- **Status:** implementation capability contract
+- **Detailed contract:** [filesystem-contract.md](filesystem-contract.md)
+
+| Primitive | Linux mechanism | Windows mechanism | macOS mechanism |
+| --- | --- | --- | --- |
+| Existing absolute root | `open` with `O_DIRECTORY | O_NOFOLLOW` | `CreateFileW`, directory and reparse flags | `open` with `O_DIRECTORY | O_NOFOLLOW` |
+| Parent traversal | descriptor-relative `open` per component | retained non-reparse directory handles | descriptor-relative `open` per component |
+| Exclusive same-directory staging | `openat(O_CREAT | O_EXCL | O_NOFOLLOW)` | `CreateFileW(CREATE_NEW)` | `openat(O_CREAT | O_EXCL | O_NOFOLLOW)` |
+| Owner-only staging/final mode | `fchmod` and `fstat`, exact `0600` | protected owner-only DACL, queried after creation | `fchmod` and `fstat`, exact `0600` |
+| File identity/link count | `fstat`/`fstatat`, device+inode+nlink | `GetFileInformationByHandle` | `fstat`/`fstatat`, device+inode+nlink |
+| Final-link detection | `fstatat(..., AT_SYMLINK_NOFOLLOW)` | open reparse point and inspect attributes | `fstatat(..., AT_SYMLINK_NOFOLLOW)` |
+| Atomic no-overwrite | same-directory `linkat`, then owned-name unlink | handle rename without replace flag | same-directory `linkat`, then owned-name unlink |
+| Atomic overwrite | same-directory `renameat` replacement | handle rename with replace flag | same-directory `renameat` replacement |
+| File durability | `fsync(file_fd)` | `FlushFileBuffers(file_handle)` | `fsync(file_fd)` |
+| Directory/rename durability | `fsync(parent_fd)` | write-through handle plus post-rename metadata flush | `fsync(parent_fd)` |
+| Cross-filesystem fallback | none; refused | none; refused | none; refused |
+
+## Claim and CI status
+
+| Platform | Implementation | CI claim | Failure behavior | Known residual limitation |
+| --- | --- | --- | --- | --- |
+| Linux | Implemented for local filesystems exposing required `openat`, link, rename, permission, file-sync, and directory-sync semantics | Ubuntu matrix runs real path, permission, concurrency, failure, artifact, and installed-wheel tests | Capability failure occurs before staging; primitive failure is typed and nondisclosing | Filesystem/hardware may weaken crash persistence below kernel promises; caller must supply a parent not writable by another account |
+| Windows | Implemented for local NTFS with Win32 handle, reparse, ACL, identity, rename, and write-through APIs | Windows matrix runs real path, ACL, reparse, concurrency, failure, artifact, and installed-wheel tests | Remote/non-NTFS or unverifiable ACL/reparse/durability support fails before staging | No POSIX directory `fsync` is claimed; the guarantee is the documented NTFS write-through rename/metadata barrier |
+| macOS | Implemented using the POSIX path when runtime probes confirm every required primitive | macOS matrix runs real path, permission, concurrency, failure, artifact, and installed-wheel tests | Missing directory sync, no-follow, link, or permission support fails before staging | APFS/HFS Unicode normalization and case behavior are filesystem-defined |
+
+## Status categories
+
+- **Implemented and tested:** claimed rows after their required CI jobs pass.
+- **Implemented but not available in current local CI:** Linux and macOS while
+  development is performed on Windows; the GitHub matrix supplies evidence.
+- **Deliberately unsupported and fail-closed:** Windows remote/non-NTFS roots,
+  POSIX writable-by-other parents, and any runtime missing a required primitive.
+- **Deferred:** network filesystems, recovery scanning, backups, alternative
+  ACL models, and cross-filesystem copy-and-verify transactions.
+

--- a/docs/v4/phase-4a/platform-capability-matrix.md
+++ b/docs/v4/phase-4a/platform-capability-matrix.md
@@ -5,9 +5,9 @@
 
 | Primitive | Linux mechanism | Windows mechanism | macOS mechanism |
 | --- | --- | --- | --- |
-| Existing absolute root | `open` with `O_DIRECTORY | O_NOFOLLOW` | `CreateFileW`, directory and reparse flags | `open` with `O_DIRECTORY | O_NOFOLLOW` |
+| Existing absolute root | `open` with `O_DIRECTORY \| O_NOFOLLOW` | `CreateFileW`, directory and reparse flags | `open` with `O_DIRECTORY \| O_NOFOLLOW` |
 | Parent traversal | descriptor-relative `open` per component | retained non-reparse directory handles | descriptor-relative `open` per component |
-| Exclusive same-directory staging | `openat(O_CREAT | O_EXCL | O_NOFOLLOW)` | `CreateFileW(CREATE_NEW)` | `openat(O_CREAT | O_EXCL | O_NOFOLLOW)` |
+| Exclusive same-directory staging | `openat(O_CREAT \| O_EXCL \| O_NOFOLLOW)` | `CreateFileW(CREATE_NEW)` | `openat(O_CREAT \| O_EXCL \| O_NOFOLLOW)` |
 | Owner-only staging/final mode | `fchmod` and `fstat`, exact `0600` | protected owner-only DACL, queried after creation | `fchmod` and `fstat`, exact `0600` |
 | File identity/link count | `fstat`/`fstatat`, device+inode+nlink | `GetFileInformationByHandle` | `fstat`/`fstatat`, device+inode+nlink |
 | Final-link detection | `fstatat(..., AT_SYMLINK_NOFOLLOW)` | open reparse point and inspect attributes | `fstatat(..., AT_SYMLINK_NOFOLLOW)` |
@@ -34,4 +34,3 @@
   POSIX writable-by-other parents, and any runtime missing a required primitive.
 - **Deferred:** network filesystems, recovery scanning, backups, alternative
   ACL models, and cross-filesystem copy-and-verify transactions.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "cryptography-suite"
 dynamic = ["version"]
-description = "A declaration-only v4 development skeleton with no operational cryptography."
+description = "An incomplete v4 development skeleton with no operational cryptography."
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/src/cryptography_suite/_internal/__init__.py
+++ b/src/cryptography_suite/_internal/__init__.py
@@ -1,0 +1,4 @@
+"""Private implementation support.
+
+Nothing in this package is a stable public API.
+"""

--- a/src/cryptography_suite/_internal/filesystem.py
+++ b/src/cryptography_suite/_internal/filesystem.py
@@ -872,7 +872,12 @@ class StandardFilesystemOS:
         root: str,
         parent_components: tuple[str, ...],
     ) -> ParentDirectory:
-        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+        flags = (
+            os.O_RDONLY
+            | vars(os)["O_DIRECTORY"]
+            | vars(os)["O_NOFOLLOW"]
+            | vars(os)["O_CLOEXEC"]
+        )
         try:
             current = os.open(root, flags)
         except OSError:
@@ -911,7 +916,13 @@ class StandardFilesystemOS:
         parent: ParentDirectory,
         name: str,
     ) -> OwnedTemporary | None:
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC
+        flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | vars(os)["O_NOFOLLOW"]
+            | vars(os)["O_CLOEXEC"]
+        )
         try:
             fd = os.open(
                 name,
@@ -1224,7 +1235,11 @@ class StandardFilesystemOS:
             )
             length_offset = root_offset + ctypes.sizeof(wintypes.HANDLE)
             name_offset = length_offset + ctypes.sizeof(wintypes.DWORD)
-            size = name_offset + len(encoded)
+            # FileNameLength excludes the terminator. Still retain a zero
+            # WCHAR after the target: supported Windows/NTFS versions have
+            # otherwise been observed consuming adjacent bytes as a suffix.
+            information_size = name_offset + len(encoded)
+            size = information_size + ctypes.sizeof(wintypes.WCHAR)
             buffer = ctypes.create_string_buffer(size)
             flags = _FILE_RENAME_FLAG_REPLACE_IF_EXISTS if replace else 0
             ctypes.memmove(
@@ -1246,7 +1261,7 @@ class StandardFilesystemOS:
                 StandardFilesystemOS._windows_temporary_handle(temporary),
                 _FILE_RENAME_INFO_EX_CLASS,
                 buffer,
-                size,
+                information_size,
             ):
                 error = ctypes.get_last_error()
                 reason = (

--- a/src/cryptography_suite/_internal/filesystem.py
+++ b/src/cryptography_suite/_internal/filesystem.py
@@ -7,7 +7,7 @@ import ntpath
 import os
 import secrets
 import stat
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Final, Protocol, runtime_checkable
 
@@ -79,7 +79,7 @@ class FilesystemCapabilities:
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, repr=False)
 class FileIdentity:
     volume: int
     file_index: int
@@ -87,7 +87,7 @@ class FileIdentity:
 
 @dataclass(frozen=True)
 class DestinationInfo:
-    identity: FileIdentity
+    identity: FileIdentity = field(repr=False)
     link_count: int
     is_directory: bool
     is_link: bool
@@ -95,18 +95,18 @@ class DestinationInfo:
 
 @dataclass
 class ParentDirectory:
-    path: str
+    path: str = field(repr=False)
     posix_fd: int | None = None
-    windows_handles: tuple[int, ...] = ()
+    windows_handles: tuple[int, ...] = field(default=(), repr=False)
     closed: bool = False
 
 
 @dataclass
 class OwnedTemporary:
-    name: str
-    identity: FileIdentity
+    name: str = field(repr=False)
+    identity: FileIdentity = field(repr=False)
     posix_fd: int | None = None
-    windows_handle: int | None = None
+    windows_handle: int | None = field(default=None, repr=False)
     closed: bool = False
     published: bool = False
 

--- a/src/cryptography_suite/_internal/filesystem.py
+++ b/src/cryptography_suite/_internal/filesystem.py
@@ -1,0 +1,1261 @@
+"""Strict standard-library filesystem facade for transactional publication."""
+
+from __future__ import annotations
+
+import errno
+import ntpath
+import os
+import secrets
+import stat
+from dataclasses import dataclass
+from enum import Enum
+from typing import Final, Protocol, runtime_checkable
+
+
+class FilesystemFailureReason(str, Enum):
+    CAPABILITY_UNAVAILABLE = "capability_unavailable"
+    CLEANUP_FAILED = "cleanup_failed"
+    DESTINATION_EXISTS = "destination_exists"
+    DESTINATION_UNSAFE = "destination_unsafe"
+    DURABILITY_FAILED = "durability_failed"
+    IDENTITY_MISMATCH = "identity_mismatch"
+    INVALID_ROOT = "invalid_root"
+    IO_FAILED = "io_failed"
+    PATH_INVALID = "path_invalid"
+    PERMISSION_UNVERIFIED = "permission_unverified"
+    SOURCE_DESTINATION_IDENTICAL = "source_destination_identical"
+
+
+class FilesystemOperationError(Exception):
+    """Nondisclosing failure raised by the private OS boundary."""
+
+    def __init__(
+        self,
+        reason: FilesystemFailureReason,
+        *,
+        operation: str,
+        published: bool = False,
+    ) -> None:
+        self.reason = reason
+        self.operation = operation
+        self.published = published
+        super().__init__(f"filesystem {operation} failed safely")
+
+
+@dataclass(frozen=True)
+class FilesystemCapabilities:
+    platform: str
+    exclusive_same_directory_create: bool
+    no_follow_create: bool
+    directory_relative_traversal: bool
+    atomic_no_overwrite_publication: bool
+    atomic_replacement: bool
+    file_fsync: bool
+    directory_durability: bool
+    file_identity: bool
+    link_detection: bool
+    hardlink_count: bool
+    owner_only_permissions: bool
+    no_overwrite_primitive: str
+    overwrite_primitive: str
+    directory_durability_primitive: str
+
+    @property
+    def fully_supported(self) -> bool:
+        return all(
+            (
+                self.exclusive_same_directory_create,
+                self.no_follow_create,
+                self.directory_relative_traversal,
+                self.atomic_no_overwrite_publication,
+                self.atomic_replacement,
+                self.file_fsync,
+                self.directory_durability,
+                self.file_identity,
+                self.link_detection,
+                self.hardlink_count,
+                self.owner_only_permissions,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class FileIdentity:
+    volume: int
+    file_index: int
+
+
+@dataclass(frozen=True)
+class DestinationInfo:
+    identity: FileIdentity
+    link_count: int
+    is_directory: bool
+    is_link: bool
+
+
+@dataclass
+class ParentDirectory:
+    path: str
+    posix_fd: int | None = None
+    windows_handles: tuple[int, ...] = ()
+    closed: bool = False
+
+
+@dataclass
+class OwnedTemporary:
+    name: str
+    identity: FileIdentity
+    posix_fd: int | None = None
+    windows_handle: int | None = None
+    closed: bool = False
+    published: bool = False
+
+
+@runtime_checkable
+class FilesystemOS(Protocol):
+    def capabilities(self, root: str) -> FilesystemCapabilities: ...
+
+    def open_parent(
+        self, root: str, parent_components: tuple[str, ...]
+    ) -> ParentDirectory: ...
+
+    def close_parent(self, parent: ParentDirectory) -> None: ...
+
+    def source_identity(self, source_fd: int) -> FileIdentity: ...
+
+    def inspect_destination(
+        self,
+        parent: ParentDirectory,
+        name: str,
+    ) -> DestinationInfo | None: ...
+
+    def create_temporary(self, parent: ParentDirectory) -> OwnedTemporary: ...
+
+    def write(self, temporary: OwnedTemporary, data: memoryview) -> int: ...
+
+    def fsync_file(self, temporary: OwnedTemporary) -> None: ...
+
+    def revalidate_temporary(
+        self,
+        parent: ParentDirectory,
+        temporary: OwnedTemporary,
+    ) -> None: ...
+
+    def publish_no_overwrite(
+        self,
+        parent: ParentDirectory,
+        temporary: OwnedTemporary,
+        destination_name: str,
+    ) -> None: ...
+
+    def publish_overwrite(
+        self,
+        parent: ParentDirectory,
+        temporary: OwnedTemporary,
+        destination_name: str,
+    ) -> None: ...
+
+    def fsync_directory(
+        self,
+        parent: ParentDirectory,
+        temporary: OwnedTemporary,
+    ) -> None: ...
+
+    def close_temporary(self, temporary: OwnedTemporary) -> None: ...
+
+    def unlink_temporary(
+        self,
+        parent: ParentDirectory,
+        temporary: OwnedTemporary,
+    ) -> None: ...
+
+
+_TEMPORARY_MODE: Final = 0o600
+_TEMPORARY_PREFIX: Final = ".cs4a-"
+_TEMPORARY_ATTEMPTS: Final = 32
+
+
+def _operation_error(
+    reason: FilesystemFailureReason,
+    operation: str,
+    *,
+    published: bool = False,
+) -> FilesystemOperationError:
+    return FilesystemOperationError(
+        reason,
+        operation=operation,
+        published=published,
+    )
+
+
+def _native_identity(file_stat: os.stat_result) -> FileIdentity:
+    return FileIdentity(volume=int(file_stat.st_dev), file_index=int(file_stat.st_ino))
+
+
+def _validate_secure_posix_directory(file_stat: os.stat_result) -> None:
+    if not stat.S_ISDIR(file_stat.st_mode):
+        raise _operation_error(FilesystemFailureReason.INVALID_ROOT, "directory_open")
+    effective_user_id = vars(os)["geteuid"]()
+    if file_stat.st_uid != effective_user_id or (
+        stat.S_IMODE(file_stat.st_mode) & 0o022
+    ):
+        raise _operation_error(
+            FilesystemFailureReason.PERMISSION_UNVERIFIED,
+            "directory_permissions",
+        )
+
+
+if os.name == "nt":
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    _KERNEL32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _ADVAPI32 = ctypes.WinDLL("advapi32", use_last_error=True)
+
+    _INVALID_HANDLE_VALUE: Final = ctypes.c_void_p(-1).value
+    _GENERIC_READ: Final = 0x80000000
+    _GENERIC_WRITE: Final = 0x40000000
+    _DELETE: Final = 0x00010000
+    _READ_CONTROL: Final = 0x00020000
+    _FILE_SHARE_READ: Final = 0x00000001
+    _FILE_SHARE_WRITE: Final = 0x00000002
+    _FILE_SHARE_DELETE: Final = 0x00000004
+    _CREATE_NEW: Final = 1
+    _OPEN_EXISTING: Final = 3
+    _FILE_ATTRIBUTE_NORMAL: Final = 0x00000080
+    _FILE_ATTRIBUTE_DIRECTORY: Final = 0x00000010
+    _FILE_ATTRIBUTE_REPARSE_POINT: Final = 0x00000400
+    _FILE_FLAG_BACKUP_SEMANTICS: Final = 0x02000000
+    _FILE_FLAG_OPEN_REPARSE_POINT: Final = 0x00200000
+    _FILE_FLAG_WRITE_THROUGH: Final = 0x80000000
+    _ERROR_FILE_NOT_FOUND: Final = 2
+    _ERROR_PATH_NOT_FOUND: Final = 3
+    _ERROR_FILE_EXISTS: Final = 80
+    _ERROR_ALREADY_EXISTS: Final = 183
+    _SDDL_REVISION_1: Final = 1
+    _OWNER_SECURITY_INFORMATION: Final = 0x00000001
+    _DACL_SECURITY_INFORMATION: Final = 0x00000004
+    _SE_FILE_OBJECT: Final = 1
+    _FILE_RENAME_INFO_EX_CLASS: Final = 22
+    _FILE_RENAME_FLAG_REPLACE_IF_EXISTS: Final = 0x00000001
+    _OWNER_ONLY_SDDL: Final = "D:P(A;;FA;;;OW)"
+
+    class _FILETIME(ctypes.Structure):
+        _fields_ = [
+            ("dwLowDateTime", wintypes.DWORD),
+            ("dwHighDateTime", wintypes.DWORD),
+        ]
+
+    class _BY_HANDLE_FILE_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("dwFileAttributes", wintypes.DWORD),
+            ("ftCreationTime", _FILETIME),
+            ("ftLastAccessTime", _FILETIME),
+            ("ftLastWriteTime", _FILETIME),
+            ("dwVolumeSerialNumber", wintypes.DWORD),
+            ("nFileSizeHigh", wintypes.DWORD),
+            ("nFileSizeLow", wintypes.DWORD),
+            ("nNumberOfLinks", wintypes.DWORD),
+            ("nFileIndexHigh", wintypes.DWORD),
+            ("nFileIndexLow", wintypes.DWORD),
+        ]
+
+    class _SECURITY_ATTRIBUTES(ctypes.Structure):
+        _fields_ = [
+            ("nLength", wintypes.DWORD),
+            ("lpSecurityDescriptor", wintypes.LPVOID),
+            ("bInheritHandle", wintypes.BOOL),
+        ]
+
+    _KERNEL32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(_SECURITY_ATTRIBUTES),
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    _KERNEL32.CreateFileW.restype = wintypes.HANDLE
+    _KERNEL32.CloseHandle.argtypes = [wintypes.HANDLE]
+    _KERNEL32.CloseHandle.restype = wintypes.BOOL
+    _KERNEL32.GetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(_BY_HANDLE_FILE_INFORMATION),
+    ]
+    _KERNEL32.GetFileInformationByHandle.restype = wintypes.BOOL
+    _KERNEL32.WriteFile.argtypes = [
+        wintypes.HANDLE,
+        wintypes.LPCVOID,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+        wintypes.LPVOID,
+    ]
+    _KERNEL32.WriteFile.restype = wintypes.BOOL
+    _KERNEL32.FlushFileBuffers.argtypes = [wintypes.HANDLE]
+    _KERNEL32.FlushFileBuffers.restype = wintypes.BOOL
+    _KERNEL32.DeleteFileW.argtypes = [wintypes.LPCWSTR]
+    _KERNEL32.DeleteFileW.restype = wintypes.BOOL
+    _KERNEL32.SetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    _KERNEL32.SetFileInformationByHandle.restype = wintypes.BOOL
+    _KERNEL32.GetVolumeInformationW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+        ctypes.POINTER(wintypes.DWORD),
+        ctypes.POINTER(wintypes.DWORD),
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+    ]
+    _KERNEL32.GetVolumeInformationW.restype = wintypes.BOOL
+    _KERNEL32.LocalFree.argtypes = [wintypes.HLOCAL]
+    _KERNEL32.LocalFree.restype = wintypes.HLOCAL
+
+    _ADVAPI32.ConvertStringSecurityDescriptorToSecurityDescriptorW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.LPVOID),
+        ctypes.POINTER(wintypes.ULONG),
+    ]
+    _ADVAPI32.ConvertStringSecurityDescriptorToSecurityDescriptorW.restype = (
+        wintypes.BOOL
+    )
+    _ADVAPI32.GetSecurityInfo.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.LPVOID),
+        ctypes.POINTER(wintypes.LPVOID),
+        ctypes.POINTER(wintypes.LPVOID),
+        ctypes.POINTER(wintypes.LPVOID),
+        ctypes.POINTER(wintypes.LPVOID),
+    ]
+    _ADVAPI32.GetSecurityInfo.restype = wintypes.DWORD
+    _ADVAPI32.ConvertSecurityDescriptorToStringSecurityDescriptorW.argtypes = [
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.LPWSTR),
+        ctypes.POINTER(wintypes.ULONG),
+    ]
+    _ADVAPI32.ConvertSecurityDescriptorToStringSecurityDescriptorW.restype = (
+        wintypes.BOOL
+    )
+
+
+class StandardFilesystemOS:
+    """Narrow production facade over required standard-library OS primitives."""
+
+    def capabilities(self, root: str) -> FilesystemCapabilities:
+        if os.name == "posix":
+            required_dir_fd = {
+                os.open,
+                os.stat,
+                os.unlink,
+            }
+            directory_relative = required_dir_fd.issubset(os.supports_dir_fd)
+            link_relative = os.link in os.supports_dir_fd
+            no_follow = hasattr(os, "O_NOFOLLOW") and (
+                os.stat in os.supports_follow_symlinks
+            )
+            supported = (
+                directory_relative
+                and link_relative
+                and no_follow
+                and hasattr(os, "O_DIRECTORY")
+                and hasattr(os, "O_CLOEXEC")
+            )
+            return FilesystemCapabilities(
+                platform="posix",
+                exclusive_same_directory_create=supported,
+                no_follow_create=supported,
+                directory_relative_traversal=supported,
+                atomic_no_overwrite_publication=supported,
+                atomic_replacement=supported,
+                file_fsync=supported,
+                directory_durability=supported,
+                file_identity=supported,
+                link_detection=supported,
+                hardlink_count=supported,
+                owner_only_permissions=supported,
+                no_overwrite_primitive="linkat",
+                overwrite_primitive="renameat",
+                directory_durability_primitive="fsync(parent_fd)",
+            )
+        if os.name == "nt":
+            supported = self._windows_root_is_local_ntfs(root)
+            return FilesystemCapabilities(
+                platform="windows-ntfs",
+                exclusive_same_directory_create=supported,
+                no_follow_create=supported,
+                directory_relative_traversal=supported,
+                atomic_no_overwrite_publication=supported,
+                atomic_replacement=supported,
+                file_fsync=supported,
+                directory_durability=supported,
+                file_identity=supported,
+                link_detection=supported,
+                hardlink_count=supported,
+                owner_only_permissions=supported,
+                no_overwrite_primitive="SetFileInformationByHandle(no-replace)",
+                overwrite_primitive=(
+                    "SetFileInformationByHandle(FILE_RENAME_FLAG_REPLACE_IF_EXISTS)"
+                ),
+                directory_durability_primitive=(
+                    "FILE_FLAG_WRITE_THROUGH + post-rename FlushFileBuffers"
+                ),
+            )
+        return FilesystemCapabilities(
+            platform=os.name,
+            exclusive_same_directory_create=False,
+            no_follow_create=False,
+            directory_relative_traversal=False,
+            atomic_no_overwrite_publication=False,
+            atomic_replacement=False,
+            file_fsync=False,
+            directory_durability=False,
+            file_identity=False,
+            link_detection=False,
+            hardlink_count=False,
+            owner_only_permissions=False,
+            no_overwrite_primitive="unavailable",
+            overwrite_primitive="unavailable",
+            directory_durability_primitive="unavailable",
+        )
+
+    def open_parent(
+        self,
+        root: str,
+        parent_components: tuple[str, ...],
+    ) -> ParentDirectory:
+        capabilities = self.capabilities(root)
+        if not capabilities.fully_supported:
+            raise _operation_error(
+                FilesystemFailureReason.CAPABILITY_UNAVAILABLE,
+                "capability_probe",
+            )
+        if os.name == "posix":
+            return self._open_parent_posix(root, parent_components)
+        if os.name == "nt":
+            return self._open_parent_windows(root, parent_components)
+        raise _operation_error(
+            FilesystemFailureReason.CAPABILITY_UNAVAILABLE,
+            "parent_traversal",
+        )
+
+    def close_parent(self, parent: ParentDirectory) -> None:
+        if parent.closed:
+            return
+        failures = False
+        if parent.posix_fd is not None:
+            try:
+                os.close(parent.posix_fd)
+            except OSError:
+                failures = True
+            parent.posix_fd = None
+        if os.name == "nt":
+            for handle in reversed(parent.windows_handles):
+                if not _KERNEL32.CloseHandle(handle):
+                    failures = True
+            parent.windows_handles = ()
+        parent.closed = True
+        if failures:
+            raise _operation_error(FilesystemFailureReason.CLEANUP_FAILED, "close")
+
+    def source_identity(self, source_fd: int) -> FileIdentity:
+        if type(source_fd) is not int or source_fd < 0:
+            raise _operation_error(
+                FilesystemFailureReason.IO_FAILED,
+                "source_identity",
+            )
+        try:
+            if os.name == "posix":
+                return _native_identity(os.fstat(source_fd))
+            if os.name == "nt":
+                handle = int(msvcrt.get_osfhandle(source_fd))
+                return self._windows_handle_info(handle)[0]
+        except (OSError, ValueError):
+            pass
+        raise _operation_error(
+            FilesystemFailureReason.IO_FAILED,
+            "source_identity",
+        )
+
+    def inspect_destination(
+        self,
+        parent: ParentDirectory,
+        name: str,
+    ) -> DestinationInfo | None:
+        if os.name == "posix":
+            parent_fd = self._posix_parent_fd(parent)
+            try:
+                file_stat = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                return None
+            except OSError as error:
+                if error.errno == errno.ENOENT:
+                    return None
+                raise _operation_error(
+                    FilesystemFailureReason.IO_FAILED,
+                    "destination_inspection",
+                ) from None
+            return DestinationInfo(
+                identity=_native_identity(file_stat),
+                link_count=int(file_stat.st_nlink),
+                is_directory=stat.S_ISDIR(file_stat.st_mode),
+                is_link=stat.S_ISLNK(file_stat.st_mode),
+            )
+        if os.name == "nt":
+            path = ntpath.join(parent.path, name)
+            handle = self._windows_open_existing(path, share_delete=True)
+            if handle is None:
+                return None
+            try:
+                identity, links, attributes = self._windows_handle_info(handle)
+                return DestinationInfo(
+                    identity=identity,
+                    link_count=links,
+                    is_directory=bool(attributes & _FILE_ATTRIBUTE_DIRECTORY),
+                    is_link=bool(attributes & _FILE_ATTRIBUTE_REPARSE_POINT),
+                )
+            finally:
+                _KERNEL32.CloseHandle(handle)
+        raise _operation_error(
+            FilesystemFailureReason.CAPABILITY_UNAVAILABLE,
+            "destination_inspection",
+        )
+
+    def create_temporary(self, parent: ParentDirectory) -> OwnedTemporary:
+        for _ in range(_TEMPORARY_ATTEMPTS):
+            name = f"{_TEMPORARY_PREFIX}{secrets.token_hex(16)}"
+            if os.name == "posix":
+                result = self._create_temporary_posix(parent, name)
+            elif os.name == "nt":
+                result = self._create_temporary_windows(parent, name)
+            else:
+                raise _operation_error(
+                    FilesystemFailureReason.CAPABILITY_UNAVAILABLE,
+                    "temporary_create",
+                )
+            if result is not None:
+                return result
+        raise _operation_error(
+            FilesystemFailureReason.IO_FAILED,
+            "temporary_create",
+        )
+
+    def write(self, temporary: OwnedTemporary, data: memoryview) -> int:
+        if os.name == "posix":
+            fd = self._posix_temporary_fd(temporary)
+            try:
+                return os.write(fd, data)
+            except InterruptedError:
+                raise
+            except OSError:
+                raise _operation_error(
+                    FilesystemFailureReason.IO_FAILED,
+                    "write",
+                ) from None
+        if os.name == "nt":
+            handle = self._windows_temporary_handle(temporary)
+            if len(data) == 0:
+                return 0
+            buffer = (ctypes.c_char * len(data)).from_buffer_copy(data)
+            written = wintypes.DWORD()
+            if not _KERNEL32.WriteFile(
+                handle,
+                buffer,
+                len(data),
+                ctypes.byref(written),
+                None,
+            ):
+                raise _operation_error(
+                    FilesystemFailureReason.IO_FAILED,
+                    "write",
+                )
+            return int(written.value)
+        raise _operation_error(FilesystemFailureReason.IO_FAILED, "write")
+
+    def fsync_file(self, temporary: OwnedTemporary) -> None:
+        try:
+            if os.name == "posix":
+                os.fsync(self._posix_temporary_fd(temporary))
+                return
+            if os.name == "nt":
+                if _KERNEL32.FlushFileBuffers(
+                    self._windows_temporary_handle(temporary)
+                ):
+                    return
+        except OSError:
+            pass
+        raise _operation_error(
+            FilesystemFailureReason.DURABILITY_FAILED,
+            "file_fsync",
+        )
+
+    def revalidate_temporary(
+        self,
+        parent: ParentDirectory,
+        temporary: OwnedTemporary,
+    ) -> None:
+        if os.name == "posix":
+            fd = self._posix_temporary_fd(temporary)
+            parent_fd = self._posix_parent_fd(parent)
+            try:
+                handle_identity = _native_identity(os.fstat(fd))
+                named = os.stat(
+                    temporary.name,
+                    dir_fd=parent_fd,
+                    follow_symlinks=False,
+                )
+            except OSError:
+                raise _operation_error(
+                    FilesystemFailureReason.IDENTITY_MISMATCH,
+                    "temporary_identity",
+                ) from None
+            if (
+                handle_identity != temporary.identity
+                or _native_identity(named) != temporary.identity
+                or not stat.S_ISREG(named.st_mode)
+            ):
+                raise _operation_error(
+                    FilesystemFailureReason.IDENTITY_MISMATCH,
+                    "temporary_identity",
+                )
+            return
+        if os.name == "nt":
+            handle = self._windows_temporary_handle(temporary)
+            handle_identity, _, attributes = self._windows_handle_info(handle)
+            named_handle = self._windows_open_existing(
+                ntpath.join(parent.path, temporary.name),
+                share_delete=True,
+            )
+            if named_handle is None:
+                raise _operation_error(
+                    FilesystemFailureReason.IDENTITY_MISMATCH,
+                    "temporary_identity",
+                )
+            try:
+                named_identity, _, named_attributes = self._windows_handle_info(
+                    named_handle
+                )
+            finally:
+                _KERNEL32.CloseHandle(named_handle)
+            if (
+                handle_identity != temporary.identity
+                or named_identity != temporary.identity
+                or attributes
+                & (_FILE_ATTRIBUTE_DIRECTORY | _FILE_ATTRIBUTE_REPARSE_POINT)
+                or named_attributes
+                & (_FILE_ATTRIBUTE_DIRECTORY | _FILE_ATTRIBUTE_REPARSE_POINT)
+            ):
+                raise _operation_error(
+                    FilesystemFailureReason.IDENTITY_MISMATCH,
+                    "temporary_identity",
+                )
+            return
+        raise _operation_error(
+            FilesystemFailureReason.CAPABILITY_UNAVAILABLE,
+            "temporary_identity",
+        )
+
+    def publish_no_overwrite(
+        self,
+        parent: ParentDirectory,
+        temporary: OwnedTemporary,
+        destination_name: str,
+    ) -> None:
+        if os.name == "posix":
+            parent_fd = self._posix_parent_fd(parent)
+            try:
+                os.link(
+                    temporary.name,
+                    destination_name,
+                    src_dir_fd=parent_fd,
+                    dst_dir_fd=parent_fd,
+                    follow_symlinks=False,
+                )
+            except FileExistsError:
+                raise _operation_error(
+                    FilesystemFailureReason.DESTINATION_EXISTS,
+                    "publish",
+                ) from None
+            except OSError as error:
+                reason = (
+                    FilesystemFailureReason.CAPABILITY_UNAVAILABLE
+                    if error.errno in (errno.EXDEV, errno.ENOTSUP, errno.EOPNOTSUPP)
+                    else FilesystemFailureReason.IO_FAILED
+                )
+                raise _operation_error(reason, "publish") from None
+            temporary.published = True
+            try:
+                os.unlink(temporary.name, dir_fd=parent_fd)
+            except OSError:
+                raise _operation_error(
+                    FilesystemFailureReason.CLEANUP_FAILED,
+                    "temporary_unlink",
+                    published=True,
+                ) from None
+            return
+        if os.name == "nt":
+            self._windows_rename_by_handle(
+                temporary,
+                ntpath.join(parent.path, destination_name),
+                replace=False,
+            )
+            temporary.published = True
+            return
+        raise _operation_error(
+            FilesystemFailureReason.CAPABILITY_UNAVAILABLE,
+            "publish",
+        )
+
+    def publish_overwrite(
+        self,
+        parent: ParentDirectory,
+        temporary: OwnedTemporary,
+        destination_name: str,
+    ) -> None:
+        if os.name == "posix":
+            parent_fd = self._posix_parent_fd(parent)
+            try:
+                os.replace(
+                    temporary.name,
+                    destination_name,
+                    src_dir_fd=parent_fd,
+                    dst_dir_fd=parent_fd,
+                )
+            except OSError as error:
+                reason = (
+                    FilesystemFailureReason.CAPABILITY_UNAVAILABLE
+                    if error.errno == errno.EXDEV
+                    else FilesystemFailureReason.IO_FAILED
+                )
+                raise _operation_error(reason, "publish") from None
+            temporary.published = True
+            return
+        if os.name == "nt":
+            self._windows_rename_by_handle(
+                temporary,
+                ntpath.join(parent.path, destination_name),
+                replace=True,
+            )
+            temporary.published = True
+            return
+        raise _operation_error(
+            FilesystemFailureReason.CAPABILITY_UNAVAILABLE,
+            "publish",
+        )
+
+    def fsync_directory(
+        self,
+        parent: ParentDirectory,
+        temporary: OwnedTemporary,
+    ) -> None:
+        try:
+            if os.name == "posix":
+                os.fsync(self._posix_parent_fd(parent))
+                return
+            if os.name == "nt":
+                if _KERNEL32.FlushFileBuffers(
+                    self._windows_temporary_handle(temporary)
+                ):
+                    return
+        except OSError:
+            pass
+        raise _operation_error(
+            FilesystemFailureReason.DURABILITY_FAILED,
+            "directory_fsync",
+            published=True,
+        )
+
+    def close_temporary(self, temporary: OwnedTemporary) -> None:
+        if temporary.closed:
+            return
+        success = True
+        if temporary.posix_fd is not None:
+            try:
+                os.close(temporary.posix_fd)
+            except OSError:
+                success = False
+            temporary.posix_fd = None
+        if os.name == "nt" and temporary.windows_handle is not None:
+            if not _KERNEL32.CloseHandle(temporary.windows_handle):
+                success = False
+            temporary.windows_handle = None
+        temporary.closed = True
+        if not success:
+            raise _operation_error(
+                FilesystemFailureReason.CLEANUP_FAILED,
+                "close",
+                published=temporary.published,
+            )
+
+    def unlink_temporary(
+        self,
+        parent: ParentDirectory,
+        temporary: OwnedTemporary,
+    ) -> None:
+        if temporary.published and os.name != "posix":
+            return
+        if os.name == "posix":
+            parent_fd = self._posix_parent_fd(parent)
+            try:
+                named = os.stat(
+                    temporary.name,
+                    dir_fd=parent_fd,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                return
+            except OSError:
+                raise _operation_error(
+                    FilesystemFailureReason.CLEANUP_FAILED,
+                    "temporary_unlink",
+                    published=temporary.published,
+                ) from None
+            if _native_identity(named) != temporary.identity or not stat.S_ISREG(
+                named.st_mode
+            ):
+                raise _operation_error(
+                    FilesystemFailureReason.IDENTITY_MISMATCH,
+                    "temporary_unlink",
+                    published=temporary.published,
+                )
+            try:
+                os.unlink(temporary.name, dir_fd=parent_fd)
+            except OSError:
+                raise _operation_error(
+                    FilesystemFailureReason.CLEANUP_FAILED,
+                    "temporary_unlink",
+                    published=temporary.published,
+                ) from None
+            return
+        if os.name == "nt":
+            path = ntpath.join(parent.path, temporary.name)
+            handle = self._windows_open_existing(path, share_delete=True)
+            if handle is None:
+                return
+            try:
+                identity, _, attributes = self._windows_handle_info(handle)
+            finally:
+                _KERNEL32.CloseHandle(handle)
+            if identity != temporary.identity or attributes & (
+                _FILE_ATTRIBUTE_DIRECTORY | _FILE_ATTRIBUTE_REPARSE_POINT
+            ):
+                raise _operation_error(
+                    FilesystemFailureReason.IDENTITY_MISMATCH,
+                    "temporary_unlink",
+                    published=temporary.published,
+                )
+            if not _KERNEL32.DeleteFileW(path):
+                raise _operation_error(
+                    FilesystemFailureReason.CLEANUP_FAILED,
+                    "temporary_unlink",
+                    published=temporary.published,
+                )
+            return
+        raise _operation_error(
+            FilesystemFailureReason.CAPABILITY_UNAVAILABLE,
+            "temporary_unlink",
+        )
+
+    def _open_parent_posix(
+        self,
+        root: str,
+        parent_components: tuple[str, ...],
+    ) -> ParentDirectory:
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+        try:
+            current = os.open(root, flags)
+        except OSError:
+            raise _operation_error(
+                FilesystemFailureReason.INVALID_ROOT,
+                "root_open",
+            ) from None
+        try:
+            _validate_secure_posix_directory(os.fstat(current))
+            os.fsync(current)
+            for component in parent_components:
+                try:
+                    child = os.open(component, flags, dir_fd=current)
+                except OSError:
+                    raise _operation_error(
+                        FilesystemFailureReason.DESTINATION_UNSAFE,
+                        "parent_traversal",
+                    ) from None
+                os.close(current)
+                current = child
+                _validate_secure_posix_directory(os.fstat(current))
+                os.fsync(current)
+            return ParentDirectory(
+                path=root,
+                posix_fd=current,
+            )
+        except BaseException:
+            try:
+                os.close(current)
+            except OSError:
+                pass
+            raise
+
+    def _create_temporary_posix(
+        self,
+        parent: ParentDirectory,
+        name: str,
+    ) -> OwnedTemporary | None:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC
+        try:
+            fd = os.open(
+                name,
+                flags,
+                _TEMPORARY_MODE,
+                dir_fd=self._posix_parent_fd(parent),
+            )
+        except FileExistsError:
+            return None
+        except OSError:
+            raise _operation_error(
+                FilesystemFailureReason.IO_FAILED,
+                "temporary_create",
+            ) from None
+        try:
+            vars(os)["fchmod"](fd, _TEMPORARY_MODE)
+            file_stat = os.fstat(fd)
+            if (
+                not stat.S_ISREG(file_stat.st_mode)
+                or stat.S_IMODE(file_stat.st_mode) != _TEMPORARY_MODE
+                or file_stat.st_nlink != 1
+            ):
+                raise _operation_error(
+                    FilesystemFailureReason.PERMISSION_UNVERIFIED,
+                    "temporary_permissions",
+                )
+            return OwnedTemporary(
+                name=name,
+                identity=_native_identity(file_stat),
+                posix_fd=fd,
+            )
+        except BaseException:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            try:
+                os.unlink(name, dir_fd=self._posix_parent_fd(parent))
+            except OSError:
+                pass
+            raise
+
+    @staticmethod
+    def _posix_parent_fd(parent: ParentDirectory) -> int:
+        if parent.closed or parent.posix_fd is None:
+            raise _operation_error(
+                FilesystemFailureReason.CLEANUP_FAILED,
+                "parent_handle",
+            )
+        return parent.posix_fd
+
+    @staticmethod
+    def _posix_temporary_fd(temporary: OwnedTemporary) -> int:
+        if temporary.closed or temporary.posix_fd is None:
+            raise _operation_error(
+                FilesystemFailureReason.CLEANUP_FAILED,
+                "temporary_handle",
+                published=temporary.published,
+            )
+        return temporary.posix_fd
+
+    if os.name == "nt":
+
+        def _windows_root_is_local_ntfs(self, root: str) -> bool:
+            if root.startswith(("\\\\", "//", "\\\\?\\", "\\\\.\\", "//?/")):
+                return False
+            drive, _ = ntpath.splitdrive(root)
+            if len(drive) != 2 or drive[1] != ":":
+                return False
+            volume_root = f"{drive}\\"
+            filesystem_name = ctypes.create_unicode_buffer(32)
+            if not _KERNEL32.GetVolumeInformationW(
+                volume_root,
+                None,
+                0,
+                None,
+                None,
+                None,
+                filesystem_name,
+                len(filesystem_name),
+            ):
+                return False
+            return filesystem_name.value.upper() == "NTFS"
+
+        def _open_parent_windows(
+            self,
+            root: str,
+            parent_components: tuple[str, ...],
+        ) -> ParentDirectory:
+            handles: list[int] = []
+            current = root
+            try:
+                for path in (
+                    root,
+                    *(
+                        ntpath.join(root, *parent_components[:index])
+                        for index in range(1, len(parent_components) + 1)
+                    ),
+                ):
+                    handle = _KERNEL32.CreateFileW(
+                        path,
+                        0,
+                        _FILE_SHARE_READ | _FILE_SHARE_WRITE,
+                        None,
+                        _OPEN_EXISTING,
+                        _FILE_FLAG_BACKUP_SEMANTICS | _FILE_FLAG_OPEN_REPARSE_POINT,
+                        None,
+                    )
+                    if handle == _INVALID_HANDLE_VALUE:
+                        raise _operation_error(
+                            FilesystemFailureReason.DESTINATION_UNSAFE,
+                            "parent_traversal",
+                        )
+                    handles.append(int(handle))
+                    _, _, attributes = self._windows_handle_info(int(handle))
+                    if not attributes & _FILE_ATTRIBUTE_DIRECTORY or (
+                        attributes & _FILE_ATTRIBUTE_REPARSE_POINT
+                    ):
+                        raise _operation_error(
+                            FilesystemFailureReason.DESTINATION_UNSAFE,
+                            "parent_traversal",
+                        )
+                    current = path
+                return ParentDirectory(
+                    path=current,
+                    windows_handles=tuple(handles),
+                )
+            except BaseException:
+                for handle in reversed(handles):
+                    _KERNEL32.CloseHandle(handle)
+                raise
+
+        def _create_temporary_windows(
+            self,
+            parent: ParentDirectory,
+            name: str,
+        ) -> OwnedTemporary | None:
+            descriptor = wintypes.LPVOID()
+            if not _ADVAPI32.ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                _OWNER_ONLY_SDDL,
+                _SDDL_REVISION_1,
+                ctypes.byref(descriptor),
+                None,
+            ):
+                raise _operation_error(
+                    FilesystemFailureReason.CAPABILITY_UNAVAILABLE,
+                    "temporary_permissions",
+                )
+            attributes = _SECURITY_ATTRIBUTES(
+                nLength=ctypes.sizeof(_SECURITY_ATTRIBUTES),
+                lpSecurityDescriptor=descriptor,
+                bInheritHandle=False,
+            )
+            path = ntpath.join(parent.path, name)
+            try:
+                handle = _KERNEL32.CreateFileW(
+                    path,
+                    _GENERIC_READ | _GENERIC_WRITE | _DELETE | _READ_CONTROL,
+                    0,
+                    ctypes.byref(attributes),
+                    _CREATE_NEW,
+                    _FILE_ATTRIBUTE_NORMAL
+                    | _FILE_FLAG_OPEN_REPARSE_POINT
+                    | _FILE_FLAG_WRITE_THROUGH,
+                    None,
+                )
+            finally:
+                _KERNEL32.LocalFree(descriptor)
+            if handle == _INVALID_HANDLE_VALUE:
+                error = ctypes.get_last_error()
+                if error in (_ERROR_FILE_EXISTS, _ERROR_ALREADY_EXISTS):
+                    return None
+                raise _operation_error(
+                    FilesystemFailureReason.IO_FAILED,
+                    "temporary_create",
+                )
+            owned_handle = int(handle)
+            try:
+                identity, links, file_attributes = self._windows_handle_info(
+                    owned_handle
+                )
+                if (
+                    links != 1
+                    or file_attributes
+                    & (_FILE_ATTRIBUTE_DIRECTORY | _FILE_ATTRIBUTE_REPARSE_POINT)
+                    or not self._windows_has_owner_only_dacl(owned_handle)
+                ):
+                    raise _operation_error(
+                        FilesystemFailureReason.PERMISSION_UNVERIFIED,
+                        "temporary_permissions",
+                    )
+                return OwnedTemporary(
+                    name=name,
+                    identity=identity,
+                    windows_handle=owned_handle,
+                )
+            except BaseException:
+                _KERNEL32.CloseHandle(owned_handle)
+                _KERNEL32.DeleteFileW(path)
+                raise
+
+        def _windows_open_existing(
+            self,
+            path: str,
+            *,
+            share_delete: bool,
+        ) -> int | None:
+            share = _FILE_SHARE_READ | _FILE_SHARE_WRITE
+            if share_delete:
+                share |= _FILE_SHARE_DELETE
+            handle = _KERNEL32.CreateFileW(
+                path,
+                _READ_CONTROL,
+                share,
+                None,
+                _OPEN_EXISTING,
+                _FILE_FLAG_OPEN_REPARSE_POINT | _FILE_FLAG_BACKUP_SEMANTICS,
+                None,
+            )
+            if handle == _INVALID_HANDLE_VALUE:
+                error = ctypes.get_last_error()
+                if error in (_ERROR_FILE_NOT_FOUND, _ERROR_PATH_NOT_FOUND):
+                    return None
+                raise _operation_error(
+                    FilesystemFailureReason.IO_FAILED,
+                    "destination_inspection",
+                )
+            return int(handle)
+
+        @staticmethod
+        def _windows_handle_info(
+            handle: int,
+        ) -> tuple[FileIdentity, int, int]:
+            information = _BY_HANDLE_FILE_INFORMATION()
+            if not _KERNEL32.GetFileInformationByHandle(
+                handle,
+                ctypes.byref(information),
+            ):
+                raise _operation_error(
+                    FilesystemFailureReason.IO_FAILED,
+                    "file_identity",
+                )
+            identity = FileIdentity(
+                volume=int(information.dwVolumeSerialNumber),
+                file_index=(
+                    int(information.nFileIndexHigh) << 32
+                    | int(information.nFileIndexLow)
+                ),
+            )
+            return (
+                identity,
+                int(information.nNumberOfLinks),
+                int(information.dwFileAttributes),
+            )
+
+        @staticmethod
+        def _windows_temporary_handle(temporary: OwnedTemporary) -> int:
+            if temporary.closed or temporary.windows_handle is None:
+                raise _operation_error(
+                    FilesystemFailureReason.CLEANUP_FAILED,
+                    "temporary_handle",
+                    published=temporary.published,
+                )
+            return temporary.windows_handle
+
+        @staticmethod
+        def _windows_has_owner_only_dacl(handle: int) -> bool:
+            descriptor = wintypes.LPVOID()
+            result = _ADVAPI32.GetSecurityInfo(
+                handle,
+                _SE_FILE_OBJECT,
+                _OWNER_SECURITY_INFORMATION | _DACL_SECURITY_INFORMATION,
+                None,
+                None,
+                None,
+                None,
+                ctypes.byref(descriptor),
+            )
+            if result != 0:
+                return False
+            rendered = wintypes.LPWSTR()
+            try:
+                if not (
+                    _ADVAPI32.ConvertSecurityDescriptorToStringSecurityDescriptorW(
+                        descriptor,
+                        _SDDL_REVISION_1,
+                        _DACL_SECURITY_INFORMATION,
+                        ctypes.byref(rendered),
+                        None,
+                    )
+                ):
+                    return False
+                return rendered.value == _OWNER_ONLY_SDDL
+            finally:
+                if rendered:
+                    _KERNEL32.LocalFree(rendered)
+                _KERNEL32.LocalFree(descriptor)
+
+        @staticmethod
+        def _windows_rename_by_handle(
+            temporary: OwnedTemporary,
+            destination: str,
+            *,
+            replace: bool,
+        ) -> None:
+            encoded = destination.encode("utf-16-le")
+            alignment = ctypes.alignment(wintypes.HANDLE)
+            root_offset = (
+                (ctypes.sizeof(wintypes.DWORD) + alignment - 1) // alignment * alignment
+            )
+            length_offset = root_offset + ctypes.sizeof(wintypes.HANDLE)
+            name_offset = length_offset + ctypes.sizeof(wintypes.DWORD)
+            size = name_offset + len(encoded)
+            buffer = ctypes.create_string_buffer(size)
+            flags = _FILE_RENAME_FLAG_REPLACE_IF_EXISTS if replace else 0
+            ctypes.memmove(
+                ctypes.addressof(buffer),
+                ctypes.byref(wintypes.DWORD(flags)),
+                ctypes.sizeof(wintypes.DWORD),
+            )
+            ctypes.memmove(
+                ctypes.addressof(buffer) + length_offset,
+                ctypes.byref(wintypes.DWORD(len(encoded))),
+                ctypes.sizeof(wintypes.DWORD),
+            )
+            ctypes.memmove(
+                ctypes.addressof(buffer) + name_offset,
+                encoded,
+                len(encoded),
+            )
+            if not _KERNEL32.SetFileInformationByHandle(
+                StandardFilesystemOS._windows_temporary_handle(temporary),
+                _FILE_RENAME_INFO_EX_CLASS,
+                buffer,
+                size,
+            ):
+                error = ctypes.get_last_error()
+                reason = (
+                    FilesystemFailureReason.DESTINATION_EXISTS
+                    if not replace
+                    and error in (_ERROR_FILE_EXISTS, _ERROR_ALREADY_EXISTS)
+                    else FilesystemFailureReason.IO_FAILED
+                )
+                raise _operation_error(reason, "publish")
+
+
+__all__: list[str] = []

--- a/src/cryptography_suite/_internal/filesystem.py
+++ b/src/cryptography_suite/_internal/filesystem.py
@@ -94,6 +94,14 @@ class DestinationInfo:
 
 
 @dataclass
+class DestinationLease:
+    info: DestinationInfo
+    posix_fd: int | None = None
+    windows_handle: int | None = field(default=None, repr=False)
+    closed: bool = False
+
+
+@dataclass
 class ParentDirectory:
     path: str = field(repr=False)
     posix_fd: int | None = None
@@ -128,6 +136,19 @@ class FilesystemOS(Protocol):
         parent: ParentDirectory,
         name: str,
     ) -> DestinationInfo | None: ...
+
+    def retain_destination(
+        self,
+        parent: ParentDirectory,
+        name: str,
+    ) -> DestinationLease | None: ...
+
+    def revalidate_destination(
+        self,
+        lease: DestinationLease,
+    ) -> DestinationInfo: ...
+
+    def close_destination(self, lease: DestinationLease) -> None: ...
 
     def create_temporary(self, parent: ParentDirectory) -> OwnedTemporary: ...
 
@@ -210,8 +231,9 @@ if os.name == "nt":
     import msvcrt
     from ctypes import wintypes
 
-    _KERNEL32 = ctypes.WinDLL("kernel32", use_last_error=True)
-    _ADVAPI32 = ctypes.WinDLL("advapi32", use_last_error=True)
+    _win_dll = vars(ctypes)["WinDLL"]
+    _KERNEL32 = _win_dll("kernel32", use_last_error=True)
+    _ADVAPI32 = _win_dll("advapi32", use_last_error=True)
 
     _INVALID_HANDLE_VALUE: Final = ctypes.c_void_p(-1).value
     _GENERIC_READ: Final = 0x80000000
@@ -239,6 +261,7 @@ if os.name == "nt":
     _SE_FILE_OBJECT: Final = 1
     _FILE_RENAME_INFO_EX_CLASS: Final = 22
     _FILE_RENAME_FLAG_REPLACE_IF_EXISTS: Final = 0x00000001
+    _FILE_RENAME_FLAG_POSIX_SEMANTICS: Final = 0x00000002
     _OWNER_ONLY_SDDL: Final = "D:P(A;;FA;;;OW)"
 
     class _FILETIME(ctypes.Structure):
@@ -406,7 +429,9 @@ class StandardFilesystemOS:
                 owner_only_permissions=supported,
                 no_overwrite_primitive="SetFileInformationByHandle(no-replace)",
                 overwrite_primitive=(
-                    "SetFileInformationByHandle(FILE_RENAME_FLAG_REPLACE_IF_EXISTS)"
+                    "SetFileInformationByHandle("
+                    "FILE_RENAME_FLAG_REPLACE_IF_EXISTS | "
+                    "FILE_RENAME_FLAG_POSIX_SEMANTICS)"
                 ),
                 directory_durability_primitive=(
                     "FILE_FLAG_WRITE_THROUGH + post-rename FlushFileBuffers"
@@ -479,7 +504,7 @@ class StandardFilesystemOS:
             if os.name == "posix":
                 return _native_identity(os.fstat(source_fd))
             if os.name == "nt":
-                handle = int(msvcrt.get_osfhandle(source_fd))
+                handle = int(vars(msvcrt)["get_osfhandle"](source_fd))
                 return self._windows_handle_info(handle)[0]
         except (OSError, ValueError):
             pass
@@ -531,6 +556,125 @@ class StandardFilesystemOS:
             FilesystemFailureReason.CAPABILITY_UNAVAILABLE,
             "destination_inspection",
         )
+
+    def retain_destination(
+        self,
+        parent: ParentDirectory,
+        name: str,
+    ) -> DestinationLease | None:
+        if os.name == "posix":
+            flags = os.O_RDONLY | vars(os)["O_NOFOLLOW"] | vars(os)["O_CLOEXEC"]
+            try:
+                fd = os.open(
+                    name,
+                    flags,
+                    dir_fd=self._posix_parent_fd(parent),
+                )
+            except FileNotFoundError:
+                return None
+            except OSError:
+                raise _operation_error(
+                    FilesystemFailureReason.DESTINATION_UNSAFE,
+                    "destination_retain",
+                ) from None
+            try:
+                file_stat = os.fstat(fd)
+                return DestinationLease(
+                    info=DestinationInfo(
+                        identity=_native_identity(file_stat),
+                        link_count=int(file_stat.st_nlink),
+                        is_directory=stat.S_ISDIR(file_stat.st_mode),
+                        is_link=stat.S_ISLNK(file_stat.st_mode),
+                    ),
+                    posix_fd=fd,
+                )
+            except BaseException:
+                os.close(fd)
+                raise
+        if os.name == "nt":
+            handle = self._windows_open_existing(
+                ntpath.join(parent.path, name),
+                share_delete=True,
+            )
+            if handle is None:
+                return None
+            try:
+                identity, links, attributes = self._windows_handle_info(handle)
+                return DestinationLease(
+                    info=DestinationInfo(
+                        identity=identity,
+                        link_count=links,
+                        is_directory=bool(attributes & _FILE_ATTRIBUTE_DIRECTORY),
+                        is_link=bool(attributes & _FILE_ATTRIBUTE_REPARSE_POINT),
+                    ),
+                    windows_handle=handle,
+                )
+            except BaseException:
+                _KERNEL32.CloseHandle(handle)
+                raise
+        raise _operation_error(
+            FilesystemFailureReason.CAPABILITY_UNAVAILABLE,
+            "destination_retain",
+        )
+
+    def revalidate_destination(
+        self,
+        lease: DestinationLease,
+    ) -> DestinationInfo:
+        if lease.closed:
+            raise _operation_error(
+                FilesystemFailureReason.IDENTITY_MISMATCH,
+                "destination_identity",
+            )
+        if os.name == "posix" and lease.posix_fd is not None:
+            try:
+                file_stat = os.fstat(lease.posix_fd)
+            except OSError:
+                raise _operation_error(
+                    FilesystemFailureReason.IDENTITY_MISMATCH,
+                    "destination_identity",
+                ) from None
+            return DestinationInfo(
+                identity=_native_identity(file_stat),
+                link_count=int(file_stat.st_nlink),
+                is_directory=stat.S_ISDIR(file_stat.st_mode),
+                is_link=stat.S_ISLNK(file_stat.st_mode),
+            )
+        if os.name == "nt" and lease.windows_handle is not None:
+            identity, links, attributes = self._windows_handle_info(
+                lease.windows_handle
+            )
+            return DestinationInfo(
+                identity=identity,
+                link_count=links,
+                is_directory=bool(attributes & _FILE_ATTRIBUTE_DIRECTORY),
+                is_link=bool(attributes & _FILE_ATTRIBUTE_REPARSE_POINT),
+            )
+        raise _operation_error(
+            FilesystemFailureReason.IDENTITY_MISMATCH,
+            "destination_identity",
+        )
+
+    def close_destination(self, lease: DestinationLease) -> None:
+        if lease.closed:
+            return
+        success = True
+        if lease.posix_fd is not None:
+            try:
+                os.close(lease.posix_fd)
+            except OSError:
+                success = False
+            lease.posix_fd = None
+        if os.name == "nt" and lease.windows_handle is not None:
+            if not _KERNEL32.CloseHandle(lease.windows_handle):
+                success = False
+            lease.windows_handle = None
+        lease.closed = True
+        if not success:
+            raise _operation_error(
+                FilesystemFailureReason.CLEANUP_FAILED,
+                "destination_close",
+            )
 
     def create_temporary(self, parent: ParentDirectory) -> OwnedTemporary:
         for _ in range(_TEMPORARY_ATTEMPTS):
@@ -1092,7 +1236,7 @@ class StandardFilesystemOS:
             finally:
                 _KERNEL32.LocalFree(descriptor)
             if handle == _INVALID_HANDLE_VALUE:
-                error = ctypes.get_last_error()
+                error = vars(ctypes)["get_last_error"]()
                 if error in (_ERROR_FILE_EXISTS, _ERROR_ALREADY_EXISTS):
                     return None
                 raise _operation_error(
@@ -1143,7 +1287,7 @@ class StandardFilesystemOS:
                 None,
             )
             if handle == _INVALID_HANDLE_VALUE:
-                error = ctypes.get_last_error()
+                error = vars(ctypes)["get_last_error"]()
                 if error in (_ERROR_FILE_NOT_FOUND, _ERROR_PATH_NOT_FOUND):
                     return None
                 raise _operation_error(
@@ -1241,7 +1385,11 @@ class StandardFilesystemOS:
             information_size = name_offset + len(encoded)
             size = information_size + ctypes.sizeof(wintypes.WCHAR)
             buffer = ctypes.create_string_buffer(size)
-            flags = _FILE_RENAME_FLAG_REPLACE_IF_EXISTS if replace else 0
+            flags = (
+                _FILE_RENAME_FLAG_REPLACE_IF_EXISTS | _FILE_RENAME_FLAG_POSIX_SEMANTICS
+                if replace
+                else 0
+            )
             ctypes.memmove(
                 ctypes.addressof(buffer),
                 ctypes.byref(wintypes.DWORD(flags)),
@@ -1263,7 +1411,7 @@ class StandardFilesystemOS:
                 buffer,
                 information_size,
             ):
-                error = ctypes.get_last_error()
+                error = vars(ctypes)["get_last_error"]()
                 reason = (
                     FilesystemFailureReason.DESTINATION_EXISTS
                     if not replace

--- a/src/cryptography_suite/streaming/atomic.py
+++ b/src/cryptography_suite/streaming/atomic.py
@@ -240,11 +240,18 @@ class AtomicFileSink:
         self._parent: ParentDirectory | None = None
         self._temporary: OwnedTemporary | None = None
         self._source_identity: FileIdentity | None = None
+        self._initial_destination_identity: FileIdentity | None = None
+        self._initial_destination_present = False
         self._state = AtomicSinkState.FAILED
         self._outcome = CommitOutcome.NOT_PUBLISHED
         self._bytes_written = 0
 
         try:
+            if not self._filesystem.capabilities(root).fully_supported:
+                raise FilesystemOperationError(
+                    FilesystemFailureReason.CAPABILITY_UNAVAILABLE,
+                    operation="capability_check",
+                )
             if source_fd is not None:
                 self._source_identity = self._filesystem.source_identity(source_fd)
             self._parent = self._filesystem.open_parent(root, parent_components)
@@ -253,6 +260,9 @@ class AtomicFileSink:
                 self._destination_name,
             )
             self._validate_destination(existing)
+            if existing is not None:
+                self._initial_destination_present = True
+                self._initial_destination_identity = existing.identity
             self._temporary = self._filesystem.create_temporary(self._parent)
         except FilesystemOperationError as error:
             self._construction_cleanup()
@@ -347,6 +357,7 @@ class AtomicFileSink:
                     self._destination_name,
                 )
                 self._validate_destination(existing)
+                self._validate_observed_destination(existing)
                 if existing is None:
                     self._filesystem.publish_no_overwrite(
                         parent,
@@ -371,10 +382,18 @@ class AtomicFileSink:
             if self._state in {AtomicSinkState.ABORTED, AtomicSinkState.COMMITTED}:
                 return
 
-            published = self._outcome is not CommitOutcome.NOT_PUBLISHED
             cleanup_error: FilesystemOperationError | None = None
             temporary = self._temporary
             parent = self._parent
+            published = (
+                temporary.published
+                if temporary is not None
+                else self._outcome
+                in {
+                    CommitOutcome.PUBLISHED,
+                    CommitOutcome.PUBLISHED_DURABILITY_UNCERTAIN,
+                }
+            )
 
             if temporary is not None:
                 try:
@@ -393,7 +412,7 @@ class AtomicFileSink:
                     except FilesystemOperationError as error:
                         cleanup_error = error
 
-            if parent is not None:
+            if parent is not None and cleanup_error is None:
                 try:
                     self._filesystem.close_parent(parent)
                 except FilesystemOperationError as error:
@@ -468,6 +487,24 @@ class AtomicFileSink:
                 self._filesystem.close_parent(parent)
             except FilesystemOperationError:
                 pass
+
+    def _validate_observed_destination(
+        self,
+        destination: DestinationInfo | None,
+    ) -> None:
+        initial = self._initial_destination_identity
+        if not self._initial_destination_present:
+            if destination is not None:
+                raise FilesystemOperationError(
+                    FilesystemFailureReason.DESTINATION_EXISTS,
+                    operation="destination_revalidation",
+                )
+            return
+        if initial is None or destination is None or destination.identity != initial:
+            raise FilesystemOperationError(
+                FilesystemFailureReason.IDENTITY_MISMATCH,
+                operation="destination_revalidation",
+            )
 
     def _close_all(self) -> None:
         temporary = self._required_temporary()

--- a/src/cryptography_suite/streaming/atomic.py
+++ b/src/cryptography_suite/streaming/atomic.py
@@ -16,6 +16,7 @@ from typing import Final
 
 from .._internal.filesystem import (
     DestinationInfo,
+    DestinationLease,
     FileIdentity,
     FilesystemCapabilities,
     FilesystemFailureReason,
@@ -239,6 +240,7 @@ class AtomicFileSink:
         self._destination_name = destination_name
         self._parent: ParentDirectory | None = None
         self._temporary: OwnedTemporary | None = None
+        self._destination_lease: DestinationLease | None = None
         self._source_identity: FileIdentity | None = None
         self._initial_destination_identity: FileIdentity | None = None
         self._initial_destination_present = False
@@ -263,6 +265,18 @@ class AtomicFileSink:
             if existing is not None:
                 self._initial_destination_present = True
                 self._initial_destination_identity = existing.identity
+                self._destination_lease = self._filesystem.retain_destination(
+                    self._parent,
+                    self._destination_name,
+                )
+                if (
+                    self._destination_lease is None
+                    or self._destination_lease.info != existing
+                ):
+                    raise FilesystemOperationError(
+                        FilesystemFailureReason.IDENTITY_MISMATCH,
+                        operation="destination_retain",
+                    )
             self._temporary = self._filesystem.create_temporary(self._parent)
         except FilesystemOperationError as error:
             self._construction_cleanup()
@@ -358,6 +372,7 @@ class AtomicFileSink:
                 )
                 self._validate_destination(existing)
                 self._validate_observed_destination(existing)
+                self._validate_retained_destination(existing)
                 if existing is None:
                     self._filesystem.publish_no_overwrite(
                         parent,
@@ -409,6 +424,14 @@ class AtomicFileSink:
                 ):
                     try:
                         self._filesystem.unlink_temporary(parent, temporary)
+                    except FilesystemOperationError as error:
+                        cleanup_error = error
+
+            if parent is not None and cleanup_error is None:
+                lease = self._destination_lease
+                if lease is not None:
+                    try:
+                        self._filesystem.close_destination(lease)
                     except FilesystemOperationError as error:
                         cleanup_error = error
 
@@ -483,6 +506,12 @@ class AtomicFileSink:
                 except FilesystemOperationError:
                     pass
         if parent is not None:
+            lease = self._destination_lease
+            if lease is not None:
+                try:
+                    self._filesystem.close_destination(lease)
+                except FilesystemOperationError:
+                    pass
             try:
                 self._filesystem.close_parent(parent)
             except FilesystemOperationError:
@@ -506,10 +535,34 @@ class AtomicFileSink:
                 operation="destination_revalidation",
             )
 
+    def _validate_retained_destination(
+        self,
+        destination: DestinationInfo | None,
+    ) -> None:
+        lease = self._destination_lease
+        if lease is None:
+            return
+        retained = self._filesystem.revalidate_destination(lease)
+        if (
+            destination is None
+            or retained.identity != lease.info.identity
+            or retained.identity != destination.identity
+            or retained.is_directory
+            or retained.is_link
+            or retained.link_count != 1
+        ):
+            raise FilesystemOperationError(
+                FilesystemFailureReason.IDENTITY_MISMATCH,
+                operation="destination_revalidation",
+            )
+
     def _close_all(self) -> None:
         temporary = self._required_temporary()
         parent = self._required_parent()
         self._filesystem.close_temporary(temporary)
+        lease = self._destination_lease
+        if lease is not None:
+            self._filesystem.close_destination(lease)
         self._filesystem.close_parent(parent)
 
     def _handle_commit_failure(self, error: FilesystemOperationError) -> None:

--- a/src/cryptography_suite/streaming/atomic.py
+++ b/src/cryptography_suite/streaming/atomic.py
@@ -1,0 +1,535 @@
+"""Internal failure-atomic filesystem sink.
+
+This module is intentionally absent from public ``streaming.__all__``.
+"""
+
+from __future__ import annotations
+
+import ntpath
+import os
+import sys
+import threading
+from dataclasses import dataclass
+from enum import Enum
+from types import TracebackType
+from typing import Final
+
+from .._internal.filesystem import (
+    DestinationInfo,
+    FileIdentity,
+    FilesystemCapabilities,
+    FilesystemFailureReason,
+    FilesystemOperationError,
+    FilesystemOS,
+    OwnedTemporary,
+    ParentDirectory,
+    StandardFilesystemOS,
+)
+from ..errors import CryptographySuiteError, ErrorCode
+
+_HARD_MAX_WRITE_SIZE: Final = 4 * 1024 * 1024
+_HARD_MAX_TOTAL_BYTES: Final = 1 << 40
+_DEFAULT_MAX_WRITE_SIZE: Final = 1024 * 1024
+_DEFAULT_MAX_TOTAL_BYTES: Final = 1024 * 1024 * 1024
+_WINDOWS_INVALID_CHARACTERS: Final = frozenset('<>:"|?*')
+_WINDOWS_RESERVED_BASENAMES: Final = frozenset(
+    {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        *(f"COM{index}" for index in range(1, 10)),
+        *(f"LPT{index}" for index in range(1, 10)),
+    }
+)
+
+
+class AtomicSinkState(str, Enum):
+    OPEN = "open"
+    PUBLISHING = "publishing"
+    COMMITTED = "committed"
+    ABORTED = "aborted"
+    FAILED = "failed"
+    PUBLICATION_UNCERTAIN = "publication_uncertain"
+    CLEANUP_INCOMPLETE = "cleanup_incomplete"
+
+
+class CommitOutcome(str, Enum):
+    NOT_PUBLISHED = "not_published"
+    PUBLISHED = "published"
+    PUBLISHED_DURABILITY_UNCERTAIN = "published_durability_uncertain"
+    CLEANUP_INCOMPLETE = "cleanup_incomplete"
+
+
+@dataclass(frozen=True)
+class AtomicSinkOptions:
+    """Internal result of a future policy decision."""
+
+    max_write_size: int = _DEFAULT_MAX_WRITE_SIZE
+    max_total_bytes: int = _DEFAULT_MAX_TOTAL_BYTES
+    policy_allows_overwrite: bool = False
+    overwrite_requested: bool = False
+
+    def __post_init__(self) -> None:
+        _validate_bound(
+            self.max_write_size,
+            name="max_write_size",
+            hard_maximum=_HARD_MAX_WRITE_SIZE,
+        )
+        _validate_bound(
+            self.max_total_bytes,
+            name="max_total_bytes",
+            hard_maximum=_HARD_MAX_TOTAL_BYTES,
+        )
+        if self.max_write_size > self.max_total_bytes:
+            raise ValueError("max_write_size must not exceed max_total_bytes")
+        if type(self.policy_allows_overwrite) is not bool:
+            raise TypeError("policy_allows_overwrite must be bool")
+        if type(self.overwrite_requested) is not bool:
+            raise TypeError("overwrite_requested must be bool")
+
+    @property
+    def overwrite_enabled(self) -> bool:
+        return self.policy_allows_overwrite and self.overwrite_requested
+
+
+class AtomicSinkError(CryptographySuiteError):
+    """Typed nondisclosing internal filesystem transaction failure."""
+
+    def __init__(
+        self,
+        code: ErrorCode,
+        *,
+        state: AtomicSinkState,
+        outcome: CommitOutcome,
+    ) -> None:
+        if code not in {
+            ErrorCode.IO_FAILED,
+            ErrorCode.OUTPUT_EXISTS,
+            ErrorCode.LIMIT_EXCEEDED,
+            ErrorCode.INTERNAL_ERROR,
+        }:
+            raise ValueError("unsupported atomic sink error code")
+        self._state = state
+        self._outcome = outcome
+        super().__init__(code)
+
+    @property
+    def state(self) -> AtomicSinkState:
+        return self._state
+
+    @property
+    def outcome(self) -> CommitOutcome:
+        return self._outcome
+
+
+def _validate_bound(value: int, *, name: str, hard_maximum: int) -> None:
+    if type(value) is not int:
+        raise TypeError(f"{name} must be an integer")
+    if not 1 <= value <= hard_maximum:
+        raise ValueError(f"{name} is outside the internal safety bounds")
+
+
+def _path_string(value: os.PathLike[str] | str, *, field: str) -> str:
+    try:
+        path = os.fspath(value)
+    except TypeError:
+        raise TypeError(f"{field} must be a text path") from None
+    if not isinstance(path, str):
+        raise TypeError(f"{field} must be a text path")
+    if "\x00" in path:
+        raise ValueError(f"{field} is invalid")
+    if any(0xD800 <= ord(character) <= 0xDFFF for character in path):
+        raise ValueError(f"{field} is invalid")
+    return path
+
+
+def _validate_root(value: os.PathLike[str] | str) -> str:
+    root = _path_string(value, field="output_root")
+    if not root or not os.path.isabs(root):
+        raise ValueError("output_root must be an explicit absolute path")
+    if os.name == "nt" and root.startswith(
+        ("\\\\", "//", "\\\\?\\", "\\\\.\\", "//?/")
+    ):
+        raise ValueError("output_root uses an unsupported anchor")
+    return root
+
+
+def _validate_relative_destination(
+    value: os.PathLike[str] | str,
+) -> tuple[tuple[str, ...], str]:
+    destination = _path_string(value, field="relative_destination")
+    if not destination:
+        raise ValueError("relative_destination must not be empty")
+    drive, _ = ntpath.splitdrive(destination)
+    if drive or destination.startswith(("/", "\\")):
+        raise ValueError("relative_destination must be unanchored")
+
+    if os.name == "nt":
+        if "/" in destination:
+            raise ValueError("relative_destination uses an alternate separator")
+        separator = "\\"
+    else:
+        if "\\" in destination:
+            raise ValueError("relative_destination uses an alternate separator")
+        separator = "/"
+
+    components = destination.split(separator)
+    if any(not component for component in components):
+        raise ValueError("relative_destination contains an empty component")
+    for component in components:
+        if component in {".", ".."}:
+            raise ValueError("relative_destination contains a traversal component")
+        _validate_component(component)
+    return tuple(components[:-1]), components[-1]
+
+
+def _validate_component(component: str) -> None:
+    if os.name != "nt":
+        try:
+            component.encode(sys.getfilesystemencoding(), "strict")
+        except UnicodeError:
+            raise ValueError(
+                "relative_destination contains an invalid component"
+            ) from None
+        return
+
+    if component.endswith((" ", ".")):
+        raise ValueError("relative_destination contains an invalid Windows name")
+    if any(
+        character in _WINDOWS_INVALID_CHARACTERS or ord(character) < 32
+        for character in component
+    ):
+        raise ValueError("relative_destination contains an invalid Windows name")
+    basename = component.split(".", 1)[0].upper()
+    if basename in _WINDOWS_RESERVED_BASENAMES:
+        raise ValueError("relative_destination contains a reserved Windows name")
+
+
+def _filesystem_code(error: FilesystemOperationError) -> ErrorCode:
+    if error.reason is FilesystemFailureReason.DESTINATION_EXISTS:
+        return ErrorCode.OUTPUT_EXISTS
+    return ErrorCode.IO_FAILED
+
+
+class AtomicFileSink:
+    """Private filesystem-backed implementation of ``TransactionalSink``."""
+
+    def __init__(
+        self,
+        *,
+        output_root: os.PathLike[str] | str,
+        relative_destination: os.PathLike[str] | str,
+        options: AtomicSinkOptions | None = None,
+        source_fd: int | None = None,
+        _filesystem: FilesystemOS | None = None,
+    ) -> None:
+        self._lock = threading.RLock()
+        self._filesystem = (
+            StandardFilesystemOS() if _filesystem is None else _filesystem
+        )
+        self._options = AtomicSinkOptions() if options is None else options
+        if not isinstance(self._options, AtomicSinkOptions):
+            raise TypeError("options must be AtomicSinkOptions")
+        root = _validate_root(output_root)
+        parent_components, destination_name = _validate_relative_destination(
+            relative_destination
+        )
+
+        self._destination_name = destination_name
+        self._parent: ParentDirectory | None = None
+        self._temporary: OwnedTemporary | None = None
+        self._source_identity: FileIdentity | None = None
+        self._state = AtomicSinkState.FAILED
+        self._outcome = CommitOutcome.NOT_PUBLISHED
+        self._bytes_written = 0
+
+        try:
+            if source_fd is not None:
+                self._source_identity = self._filesystem.source_identity(source_fd)
+            self._parent = self._filesystem.open_parent(root, parent_components)
+            existing = self._filesystem.inspect_destination(
+                self._parent,
+                self._destination_name,
+            )
+            self._validate_destination(existing)
+            self._temporary = self._filesystem.create_temporary(self._parent)
+        except FilesystemOperationError as error:
+            self._construction_cleanup()
+            raise AtomicSinkError(
+                _filesystem_code(error),
+                state=AtomicSinkState.FAILED,
+                outcome=CommitOutcome.NOT_PUBLISHED,
+            ) from None
+        except BaseException:
+            self._construction_cleanup()
+            raise
+        self._state = AtomicSinkState.OPEN
+
+    @property
+    def max_write_size(self) -> int:
+        return self._options.max_write_size
+
+    @property
+    def max_total_bytes(self) -> int:
+        return self._options.max_total_bytes
+
+    @property
+    def state(self) -> AtomicSinkState:
+        return self._state
+
+    @property
+    def outcome(self) -> CommitOutcome:
+        return self._outcome
+
+    @property
+    def bytes_written(self) -> int:
+        return self._bytes_written
+
+    @classmethod
+    def capabilities(
+        cls,
+        output_root: os.PathLike[str] | str,
+    ) -> FilesystemCapabilities:
+        root = _validate_root(output_root)
+        return StandardFilesystemOS().capabilities(root)
+
+    def write(self, chunk: bytes) -> None:
+        with self._lock:
+            self._require_state(AtomicSinkState.OPEN)
+            if type(chunk) is not bytes:
+                raise TypeError("chunk must be bytes")
+            if not chunk:
+                return
+            if len(chunk) > self._options.max_write_size:
+                raise self._limit_error()
+            remaining_capacity = self._options.max_total_bytes - self._bytes_written
+            if len(chunk) > remaining_capacity:
+                raise self._limit_error()
+
+            temporary = self._required_temporary()
+            view = memoryview(chunk)
+            offset = 0
+            try:
+                while offset < len(view):
+                    try:
+                        written = self._filesystem.write(temporary, view[offset:])
+                    except InterruptedError:
+                        continue
+                    if not 0 < written <= len(view) - offset:
+                        raise FilesystemOperationError(
+                            FilesystemFailureReason.IO_FAILED,
+                            operation="write",
+                        )
+                    offset += written
+            except FilesystemOperationError as error:
+                self._state = AtomicSinkState.FAILED
+                raise AtomicSinkError(
+                    _filesystem_code(error),
+                    state=self._state,
+                    outcome=self._outcome,
+                ) from None
+            finally:
+                view.release()
+            self._bytes_written += len(chunk)
+
+    def commit(self) -> None:
+        with self._lock:
+            self._require_state(AtomicSinkState.OPEN)
+            self._state = AtomicSinkState.PUBLISHING
+            parent = self._required_parent()
+            temporary = self._required_temporary()
+            try:
+                self._filesystem.fsync_file(temporary)
+                self._filesystem.revalidate_temporary(parent, temporary)
+                existing = self._filesystem.inspect_destination(
+                    parent,
+                    self._destination_name,
+                )
+                self._validate_destination(existing)
+                if existing is None:
+                    self._filesystem.publish_no_overwrite(
+                        parent,
+                        temporary,
+                        self._destination_name,
+                    )
+                else:
+                    self._filesystem.publish_overwrite(
+                        parent,
+                        temporary,
+                        self._destination_name,
+                    )
+                self._outcome = CommitOutcome.PUBLISHED
+                self._filesystem.fsync_directory(parent, temporary)
+                self._close_all()
+            except FilesystemOperationError as error:
+                self._handle_commit_failure(error)
+            self._state = AtomicSinkState.COMMITTED
+
+    def abort(self) -> None:
+        with self._lock:
+            if self._state in {AtomicSinkState.ABORTED, AtomicSinkState.COMMITTED}:
+                return
+
+            published = self._outcome is not CommitOutcome.NOT_PUBLISHED
+            cleanup_error: FilesystemOperationError | None = None
+            temporary = self._temporary
+            parent = self._parent
+
+            if temporary is not None:
+                try:
+                    self._filesystem.close_temporary(temporary)
+                except FilesystemOperationError as error:
+                    cleanup_error = error
+                if parent is not None and (
+                    not published
+                    or (
+                        self._outcome is CommitOutcome.CLEANUP_INCOMPLETE
+                        and temporary.published
+                    )
+                ):
+                    try:
+                        self._filesystem.unlink_temporary(parent, temporary)
+                    except FilesystemOperationError as error:
+                        cleanup_error = error
+
+            if parent is not None:
+                try:
+                    self._filesystem.close_parent(parent)
+                except FilesystemOperationError as error:
+                    cleanup_error = error
+
+            if cleanup_error is not None:
+                self._state = AtomicSinkState.CLEANUP_INCOMPLETE
+                self._outcome = CommitOutcome.CLEANUP_INCOMPLETE
+                raise AtomicSinkError(
+                    ErrorCode.IO_FAILED,
+                    state=self._state,
+                    outcome=self._outcome,
+                ) from None
+
+            if not published:
+                self._state = AtomicSinkState.ABORTED
+
+    def __enter__(self) -> AtomicFileSink:
+        return self
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del exception_type, exception, traceback
+        if self._state is not AtomicSinkState.COMMITTED:
+            self.abort()
+
+    def _validate_destination(self, destination: DestinationInfo | None) -> None:
+        if destination is None:
+            return
+        if (
+            destination.is_link
+            or destination.is_directory
+            or destination.link_count != 1
+        ):
+            raise FilesystemOperationError(
+                FilesystemFailureReason.DESTINATION_UNSAFE,
+                operation="destination_validation",
+            )
+        if (
+            self._source_identity is not None
+            and destination.identity == self._source_identity
+        ):
+            raise FilesystemOperationError(
+                FilesystemFailureReason.SOURCE_DESTINATION_IDENTICAL,
+                operation="destination_validation",
+            )
+        if not self._options.overwrite_enabled:
+            raise FilesystemOperationError(
+                FilesystemFailureReason.DESTINATION_EXISTS,
+                operation="destination_validation",
+            )
+
+    def _construction_cleanup(self) -> None:
+        temporary = self._temporary
+        parent = self._parent
+        if temporary is not None:
+            try:
+                self._filesystem.close_temporary(temporary)
+            except FilesystemOperationError:
+                pass
+            if parent is not None:
+                try:
+                    self._filesystem.unlink_temporary(parent, temporary)
+                except FilesystemOperationError:
+                    pass
+        if parent is not None:
+            try:
+                self._filesystem.close_parent(parent)
+            except FilesystemOperationError:
+                pass
+
+    def _close_all(self) -> None:
+        temporary = self._required_temporary()
+        parent = self._required_parent()
+        self._filesystem.close_temporary(temporary)
+        self._filesystem.close_parent(parent)
+
+    def _handle_commit_failure(self, error: FilesystemOperationError) -> None:
+        if error.published or self._required_temporary().published:
+            if error.reason is FilesystemFailureReason.DURABILITY_FAILED:
+                self._state = AtomicSinkState.PUBLICATION_UNCERTAIN
+                self._outcome = CommitOutcome.PUBLISHED_DURABILITY_UNCERTAIN
+            else:
+                self._state = AtomicSinkState.CLEANUP_INCOMPLETE
+                self._outcome = CommitOutcome.CLEANUP_INCOMPLETE
+            if self._state is AtomicSinkState.PUBLICATION_UNCERTAIN:
+                try:
+                    self._close_all()
+                except FilesystemOperationError:
+                    self._state = AtomicSinkState.CLEANUP_INCOMPLETE
+                    self._outcome = CommitOutcome.CLEANUP_INCOMPLETE
+        else:
+            self._state = AtomicSinkState.FAILED
+            self._outcome = CommitOutcome.NOT_PUBLISHED
+        raise AtomicSinkError(
+            _filesystem_code(error),
+            state=self._state,
+            outcome=self._outcome,
+        ) from None
+
+    def _limit_error(self) -> AtomicSinkError:
+        return AtomicSinkError(
+            ErrorCode.LIMIT_EXCEEDED,
+            state=self._state,
+            outcome=self._outcome,
+        )
+
+    def _require_state(self, required: AtomicSinkState) -> None:
+        if self._state is not required:
+            raise AtomicSinkError(
+                ErrorCode.INTERNAL_ERROR,
+                state=self._state,
+                outcome=self._outcome,
+            )
+
+    def _required_parent(self) -> ParentDirectory:
+        if self._parent is None:
+            raise AtomicSinkError(
+                ErrorCode.INTERNAL_ERROR,
+                state=self._state,
+                outcome=self._outcome,
+            )
+        return self._parent
+
+    def _required_temporary(self) -> OwnedTemporary:
+        if self._temporary is None:
+            raise AtomicSinkError(
+                ErrorCode.INTERNAL_ERROR,
+                state=self._state,
+                outcome=self._outcome,
+            )
+        return self._temporary
+
+
+__all__: list[str] = []

--- a/tests/artifact/test_artifact_contract.py
+++ b/tests/artifact/test_artifact_contract.py
@@ -132,14 +132,17 @@ def test_wheel_metadata_has_no_entry_points(
 
     assert metadata["Name"] == "cryptography-suite"
     assert metadata["Version"] == "3.0.0"
+    assert metadata["Summary"] == (
+        "An incomplete v4 development skeleton with no operational cryptography."
+    )
     assert metadata["Requires-Python"] == ">=3.10"
     assert set(metadata.get_all("Provides-Extra", [])) == EXPECTED_EXTRAS
     assert set(metadata.get_all("Provides-Extra", [])).isdisjoint(REMOVED_EXTRAS)
 
     payload = metadata.get_payload()
     assert isinstance(payload, str)
-    description = payload.lower()
-    assert "declaration-only v4 development skeleton" in description
+    description = " ".join(payload.lower().split())
+    assert "incomplete v4 development skeleton" in description
     assert "no operational encryption or decryption" in description
     for obsolete_advertisement in (
         "cryptography_suite.cli",

--- a/tests/artifact/test_artifact_contract.py
+++ b/tests/artifact/test_artifact_contract.py
@@ -11,6 +11,8 @@ from conftest import REPO_ROOT, BuiltArtifacts
 
 RUNTIME_FILES = {
     "cryptography_suite/__init__.py",
+    "cryptography_suite/_internal/__init__.py",
+    "cryptography_suite/_internal/filesystem.py",
     "cryptography_suite/audit/__init__.py",
     "cryptography_suite/audit/events.py",
     "cryptography_suite/context.py",
@@ -27,6 +29,7 @@ RUNTIME_FILES = {
     "cryptography_suite/providers/models.py",
     "cryptography_suite/py.typed",
     "cryptography_suite/streaming/__init__.py",
+    "cryptography_suite/streaming/atomic.py",
     "cryptography_suite/streaming/sinks.py",
 }
 

--- a/tests/contract/test_import_boundaries.py
+++ b/tests/contract/test_import_boundaries.py
@@ -51,6 +51,7 @@ def _string_list(value: object, field: str) -> list[str]:
 def _import_snapshot(cwd: Path, environment_value: str) -> ImportSnapshot:
     code = """
 import json
+import os
 import socket
 import sys
 
@@ -58,6 +59,15 @@ def blocked(*args, **kwargs):
     raise AssertionError("network access during import")
 
 socket.socket.connect = blocked
+for filesystem_operation in (
+    "fsync",
+    "link",
+    "mkdir",
+    "open",
+    "replace",
+    "unlink",
+):
+    setattr(os, filesystem_operation, blocked)
 import cryptography_suite
 print(json.dumps({
     "all": cryptography_suite.__all__,
@@ -103,6 +113,8 @@ def test_root_import_is_stable_across_cwd_and_environment(tmp_path: Path) -> Non
     assert snapshot_one["modules"] == snapshot_two["modules"]
     assert "cryptography_suite.legacy" not in snapshot_one["modules"]
     assert "cryptography_suite.lifecycle" not in snapshot_one["modules"]
+    assert "cryptography_suite.streaming.atomic" not in snapshot_one["modules"]
+    assert "cryptography_suite._internal.filesystem" not in snapshot_one["modules"]
     assert all(".cli" not in name for name in snapshot_one["modules"])
     assert all(".labs" not in name for name in snapshot_one["modules"])
 
@@ -150,6 +162,7 @@ def test_internal_import_graph_matches_phase_2_layers() -> None:
         "cryptography_suite.context": set(),
         "cryptography_suite.envelope": {"providers"},
         "cryptography_suite.errors": set(),
+        "cryptography_suite._internal": set(),
         "cryptography_suite.legacy": set(),
         "cryptography_suite.lifecycle": {"providers"},
         "cryptography_suite.policy": set(),
@@ -162,7 +175,7 @@ def test_internal_import_graph_matches_phase_2_layers() -> None:
             "streaming",
         },
         "cryptography_suite.providers": set(),
-        "cryptography_suite.streaming": set(),
+        "cryptography_suite.streaming": {"_internal", "errors"},
     }
     violations: list[str] = []
     for path in sorted(SOURCE.rglob("*.py")):
@@ -216,6 +229,30 @@ def test_audit_package_has_no_provider_import_edge() -> None:
                 )
                 if is_provider_edge:
                     violations.append(str(path.relative_to(REPO_ROOT)))
+    assert violations == []
+
+
+def test_atomic_module_has_only_approved_internal_edges() -> None:
+    path = SOURCE / "streaming" / "atomic.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    forbidden = {
+        "audit",
+        "cli",
+        "envelope",
+        "labs",
+        "legacy",
+        "lifecycle",
+        "policy",
+        "protector",
+        "providers",
+    }
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        target = (node.module or "").split(".", 1)[0]
+        if target in forbidden:
+            violations.append(target)
     assert violations == []
 
 

--- a/tests/integration/test_atomic_concurrency.py
+++ b/tests/integration/test_atomic_concurrency.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import multiprocessing
+import os
+from pathlib import Path
+from queue import Empty
+
+from cryptography_suite.streaming.atomic import AtomicFileSink, AtomicSinkError
+
+
+def _concurrent_writer(
+    root: str,
+    payload: bytes,
+    ready: multiprocessing.synchronize.Event,
+    start: multiprocessing.synchronize.Event,
+    results: multiprocessing.queues.Queue,
+) -> None:
+    try:
+        sink = AtomicFileSink(
+            output_root=root,
+            relative_destination="winner.bin",
+        )
+        sink.write(payload)
+        ready.set()
+        if not start.wait(20):
+            sink.abort()
+            results.put(("timeout", ""))
+            return
+        sink.commit()
+        results.put(("committed", payload.decode("ascii")))
+    except AtomicSinkError as error:
+        sink.abort()
+        results.put(("failed", error.code.value))
+
+
+def test_two_process_no_overwrite_race_has_exactly_one_winner(
+    tmp_path: Path,
+) -> None:
+    context = multiprocessing.get_context("spawn" if os.name == "nt" else "fork")
+    ready_one = context.Event()
+    ready_two = context.Event()
+    start = context.Event()
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_concurrent_writer,
+            args=(str(tmp_path.absolute()), payload, ready, start, results),
+        )
+        for payload, ready in ((b"one", ready_one), (b"two", ready_two))
+    ]
+    for process in processes:
+        process.start()
+    assert ready_one.wait(20)
+    assert ready_two.wait(20)
+    start.set()
+    for process in processes:
+        process.join(30)
+        assert process.exitcode == 0
+
+    observed: list[tuple[str, str]] = []
+    for _ in processes:
+        try:
+            observed.append(results.get(timeout=5))
+        except Empty as error:
+            raise AssertionError("concurrent writer result missing") from error
+
+    committed = [value for status, value in observed if status == "committed"]
+    failed = [value for status, value in observed if status == "failed"]
+    assert len(committed) == 1
+    assert failed == ["OUTPUT_EXISTS"]
+    assert (tmp_path / "winner.bin").read_bytes() == committed[0].encode("ascii")
+    assert [path.name for path in tmp_path.iterdir()] == ["winner.bin"]

--- a/tests/integration/test_atomic_concurrency.py
+++ b/tests/integration/test_atomic_concurrency.py
@@ -42,7 +42,7 @@ def test_two_process_no_overwrite_race_has_exactly_one_winner(
     start = context.Event()
     results = context.Queue()
     processes = [
-        context.Process(
+        context.Process(  # type: ignore[attr-defined]
             target=_concurrent_writer,
             args=(str(tmp_path.absolute()), payload, ready, start, results),
         )

--- a/tests/integration/test_installed_wheel.py
+++ b/tests/integration/test_installed_wheel.py
@@ -61,8 +61,13 @@ def test_isolated_installed_wheel_and_sdist_rebuild(
     code = """
 import importlib.metadata
 import json
+import os
+import stat
 import sys
+import tempfile
+from pathlib import Path
 import cryptography_suite
+from cryptography_suite.streaming.atomic import AtomicFileSink
 
 forbidden = [
     "cryptography_suite.aead",
@@ -80,8 +85,40 @@ for name in forbidden:
         continue
     failures.append(name)
 
+with tempfile.TemporaryDirectory() as directory:
+    root = Path(directory).absolute()
+    destination = root / "installed.bin"
+    aborted = AtomicFileSink(
+        output_root=root,
+        relative_destination="aborted.bin",
+    )
+    aborted.write(b"not-published")
+    stage_hidden = not (root / "aborted.bin").exists()
+    aborted.abort()
+
+    committed = AtomicFileSink(
+        output_root=root,
+        relative_destination="installed.bin",
+    )
+    committed.write(b"installed-wheel")
+    committed.commit()
+    atomic = {
+        "bytes": destination.read_bytes().decode("ascii"),
+        "mode": (
+            stat.S_IMODE(destination.stat().st_mode)
+            if os.name == "posix"
+            else None
+        ),
+        "stage_hidden": stage_hidden,
+        "temporary_names": [
+            path.name for path in root.iterdir()
+            if path.name.startswith(".cs4a-")
+        ],
+    }
+
 print(json.dumps({
     "all": cryptography_suite.__all__,
+    "atomic": atomic,
     "failures": failures,
     "origin": cryptography_suite.__file__,
     "version": importlib.metadata.version("cryptography-suite"),
@@ -103,6 +140,11 @@ print(json.dumps({
     snapshot = json.loads(result.stdout)
 
     assert snapshot["all"] == EXPECTED_ROOT
+    assert snapshot["atomic"]["bytes"] == "installed-wheel"
+    assert snapshot["atomic"]["stage_hidden"] is True
+    assert snapshot["atomic"]["temporary_names"] == []
+    if os.name == "posix":
+        assert snapshot["atomic"]["mode"] == 0o600
     assert snapshot["failures"] == []
     assert snapshot["version"] == "3.0.0"
     assert "site-packages" in snapshot["origin"].lower()

--- a/tests/negative/test_atomic_paths.py
+++ b/tests/negative/test_atomic_paths.py
@@ -13,7 +13,7 @@ from cryptography_suite.streaming.atomic import (
 )
 
 
-@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+@pytest.mark.parametrize(
     "destination",
     [
         "",

--- a/tests/negative/test_atomic_paths.py
+++ b/tests/negative/test_atomic_paths.py
@@ -13,7 +13,7 @@ from cryptography_suite.streaming.atomic import (
 )
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     "destination",
     [
         "",

--- a/tests/negative/test_atomic_paths.py
+++ b/tests/negative/test_atomic_paths.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from cryptography_suite import ErrorCode
+from cryptography_suite.streaming.atomic import (
+    AtomicFileSink,
+    AtomicSinkError,
+    AtomicSinkOptions,
+)
+
+
+@pytest.mark.parametrize(
+    "destination",
+    [
+        "",
+        ".",
+        "..",
+        "../escape",
+        "parent/../escape",
+        "/absolute",
+        "C:\\absolute",
+        "\\\\server\\share\\file",
+        "nul\x00name",
+        "repeated//separator",
+    ],
+)
+def test_rejects_invalid_destination_grammar(
+    tmp_path: Path,
+    destination: str,
+) -> None:
+    with pytest.raises(ValueError):
+        AtomicFileSink(
+            output_root=tmp_path.absolute(),
+            relative_destination=destination,
+        )
+
+
+def test_rejects_platform_alternate_separator(tmp_path: Path) -> None:
+    destination = "parent/file" if os.name == "nt" else "parent\\file"
+    with pytest.raises(ValueError, match="alternate separator"):
+        AtomicFileSink(
+            output_root=tmp_path.absolute(),
+            relative_destination=destination,
+        )
+
+
+def test_rejects_relative_or_missing_root(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="explicit absolute"):
+        AtomicFileSink(output_root="relative", relative_destination="result.bin")
+    missing = tmp_path / "missing"
+    with pytest.raises(AtomicSinkError) as captured:
+        AtomicFileSink(
+            output_root=missing.absolute(),
+            relative_destination="result.bin",
+        )
+    assert captured.value.code is ErrorCode.IO_FAILED
+
+
+def test_valid_nested_unicode_path(tmp_path: Path) -> None:
+    parent = tmp_path / "داده"
+    parent.mkdir()
+    destination_name = "résultat.bin"
+    sink = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination=os.path.join(parent.name, destination_name),
+    )
+    sink.write(b"unicode")
+    sink.commit()
+    assert (parent / destination_name).read_bytes() == b"unicode"
+
+
+def test_missing_parent_and_parent_file_fail_without_staging(tmp_path: Path) -> None:
+    with pytest.raises(AtomicSinkError):
+        AtomicFileSink(
+            output_root=tmp_path.absolute(),
+            relative_destination=os.path.join("missing", "result.bin"),
+        )
+    parent_file = tmp_path / "parent"
+    parent_file.write_bytes(b"not-directory")
+    with pytest.raises(AtomicSinkError):
+        AtomicFileSink(
+            output_root=tmp_path.absolute(),
+            relative_destination=os.path.join("parent", "result.bin"),
+        )
+    assert [path.name for path in tmp_path.iterdir()] == ["parent"]
+
+
+def _create_symlink_or_skip(target: Path, link: Path, *, directory: bool) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=directory)
+    except OSError as error:
+        pytest.skip(
+            "symlink creation privilege unavailable; reparse/symlink rejection "
+            "is covered by the Phase 4A platform matrix: "
+            f"{type(error).__name__}"
+        )
+
+
+def test_rejects_parent_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "linked-parent"
+    _create_symlink_or_skip(target, link, directory=True)
+
+    with pytest.raises(AtomicSinkError):
+        AtomicFileSink(
+            output_root=tmp_path.absolute(),
+            relative_destination=os.path.join("linked-parent", "result.bin"),
+        )
+    assert list(target.iterdir()) == []
+
+
+def test_rejects_destination_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target.bin"
+    target.write_bytes(b"target")
+    link = tmp_path / "result.bin"
+    _create_symlink_or_skip(target, link, directory=False)
+
+    with pytest.raises(AtomicSinkError):
+        AtomicFileSink(
+            output_root=tmp_path.absolute(),
+            relative_destination="result.bin",
+            options=AtomicSinkOptions(
+                policy_allows_overwrite=True,
+                overwrite_requested=True,
+            ),
+        )
+    assert target.read_bytes() == b"target"
+
+
+def test_rejects_destination_directory(tmp_path: Path) -> None:
+    (tmp_path / "result.bin").mkdir()
+    with pytest.raises(AtomicSinkError):
+        AtomicFileSink(
+            output_root=tmp_path.absolute(),
+            relative_destination="result.bin",
+            options=AtomicSinkOptions(
+                policy_allows_overwrite=True,
+                overwrite_requested=True,
+            ),
+        )
+
+
+def test_rejects_destination_with_multiple_hardlinks(tmp_path: Path) -> None:
+    destination = tmp_path / "result.bin"
+    destination.write_bytes(b"original")
+    os.link(destination, tmp_path / "alias.bin")
+    with pytest.raises(AtomicSinkError):
+        AtomicFileSink(
+            output_root=tmp_path.absolute(),
+            relative_destination="result.bin",
+            options=AtomicSinkOptions(
+                policy_allows_overwrite=True,
+                overwrite_requested=True,
+            ),
+        )
+    assert destination.read_bytes() == b"original"
+
+
+def test_rejects_source_destination_identity_and_preserves_source(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"source")
+    with source.open("rb") as source_stream:
+        with pytest.raises(AtomicSinkError):
+            AtomicFileSink(
+                output_root=tmp_path.absolute(),
+                relative_destination="source.bin",
+                source_fd=source_stream.fileno(),
+                options=AtomicSinkOptions(
+                    policy_allows_overwrite=True,
+                    overwrite_requested=True,
+                ),
+            )
+        assert not source_stream.closed
+    assert source.read_bytes() == b"source"
+
+
+def test_rejects_source_destination_hardlink_identity(tmp_path: Path) -> None:
+    source = tmp_path / "source.bin"
+    destination = tmp_path / "result.bin"
+    source.write_bytes(b"source")
+    os.link(source, destination)
+    with source.open("rb") as source_stream:
+        with pytest.raises(AtomicSinkError):
+            AtomicFileSink(
+                output_root=tmp_path.absolute(),
+                relative_destination="result.bin",
+                source_fd=source_stream.fileno(),
+                options=AtomicSinkOptions(
+                    policy_allows_overwrite=True,
+                    overwrite_requested=True,
+                ),
+            )
+    assert source.read_bytes() == b"source"
+    assert destination.read_bytes() == b"source"
+
+
+def test_destination_appearance_after_staging_is_not_overwritten(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "result.bin"
+    sink = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="result.bin",
+    )
+    sink.write(b"staged")
+    destination.write_bytes(b"winner")
+
+    with pytest.raises(AtomicSinkError) as captured:
+        sink.commit()
+    assert captured.value.code is ErrorCode.OUTPUT_EXISTS
+    assert destination.read_bytes() == b"winner"
+    sink.abort()
+    assert destination.read_bytes() == b"winner"
+
+
+def test_destination_replacement_after_staging_fails_closed(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "result.bin"
+    destination.write_bytes(b"original")
+    sink = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="result.bin",
+        options=AtomicSinkOptions(
+            policy_allows_overwrite=True,
+            overwrite_requested=True,
+        ),
+    )
+    destination.unlink()
+    destination.write_bytes(b"changed")
+
+    with pytest.raises(AtomicSinkError) as captured:
+        sink.commit()
+    assert captured.value.code is ErrorCode.IO_FAILED
+    assert destination.read_bytes() == b"changed"
+    sink.abort()
+    assert destination.read_bytes() == b"changed"
+
+
+def test_overwrite_mode_does_not_replace_destination_that_appears_late(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "result.bin"
+    sink = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="result.bin",
+        options=AtomicSinkOptions(
+            policy_allows_overwrite=True,
+            overwrite_requested=True,
+        ),
+    )
+    sink.write(b"staged")
+    destination.write_bytes(b"late-winner")
+
+    with pytest.raises(AtomicSinkError) as captured:
+        sink.commit()
+
+    assert captured.value.code is ErrorCode.OUTPUT_EXISTS
+    assert destination.read_bytes() == b"late-winner"
+    sink.abort()
+    assert destination.read_bytes() == b"late-winner"
+
+
+def test_errors_and_repr_never_expose_paths_or_temporary_names(
+    tmp_path: Path,
+) -> None:
+    secret_root = str(tmp_path.absolute())
+    destination = "sensitive-customer-name.bin"
+    (tmp_path / destination).write_bytes(b"existing")
+
+    with pytest.raises(AtomicSinkError) as captured:
+        AtomicFileSink(
+            output_root=secret_root,
+            relative_destination=destination,
+        )
+    rendered = f"{captured.value!s} {captured.value!r}"
+    assert secret_root not in rendered
+    assert destination not in rendered
+    assert ".cs4a-" not in rendered
+
+
+def test_platform_case_behavior_is_native_and_documented(tmp_path: Path) -> None:
+    first = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="Case.bin",
+    )
+    first.commit()
+
+    if os.name == "nt":
+        with pytest.raises(AtomicSinkError):
+            AtomicFileSink(
+                output_root=tmp_path.absolute(),
+                relative_destination="case.bin",
+            )
+    else:
+        second = AtomicFileSink(
+            output_root=tmp_path.absolute(),
+            relative_destination="case.bin",
+        )
+        second.abort()

--- a/tests/negative/test_atomic_paths.py
+++ b/tests/negative/test_atomic_paths.py
@@ -293,7 +293,8 @@ def test_platform_case_behavior_is_native_and_documented(tmp_path: Path) -> None
     )
     first.commit()
 
-    if os.name == "nt":
+    alternate_case_aliases = (tmp_path / "case.bin").exists()
+    if alternate_case_aliases:
         with pytest.raises(AtomicSinkError):
             AtomicFileSink(
                 output_root=tmp_path.absolute(),

--- a/tests/unit/test_atomic_failures.py
+++ b/tests/unit/test_atomic_failures.py
@@ -71,7 +71,7 @@ def _sink(tmp_path: Path, filesystem: FaultFilesystem) -> AtomicFileSink:
     )
 
 
-@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+@pytest.mark.parametrize(
     "method",
     ["capabilities", "open_parent", "create_temporary"],
 )
@@ -131,6 +131,32 @@ def test_parent_traversal_failure_never_creates_a_temporary(
     assert list((tmp_path / "nested").iterdir()) == []
 
 
+def test_destination_lease_failure_preserves_existing_destination(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "result.bin"
+    destination.write_bytes(b"original")
+    filesystem = FaultFilesystem(
+        "retain_destination",
+        reason=FilesystemFailureReason.IDENTITY_MISMATCH,
+    )
+
+    with pytest.raises(AtomicSinkError) as captured:
+        AtomicFileSink(
+            output_root=tmp_path.absolute(),
+            relative_destination="result.bin",
+            options=AtomicSinkOptions(
+                policy_allows_overwrite=True,
+                overwrite_requested=True,
+            ),
+            _filesystem=filesystem,
+        )
+
+    assert captured.value.outcome is CommitOutcome.NOT_PUBLISHED
+    assert destination.read_bytes() == b"original"
+    assert [path.name for path in tmp_path.iterdir()] == ["result.bin"]
+
+
 def test_first_write_failure_is_abortable_without_publication(
     tmp_path: Path,
 ) -> None:
@@ -166,7 +192,7 @@ def test_partial_then_failed_write_tracks_no_completed_chunk(
     assert list(tmp_path.iterdir()) == []
 
 
-@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+@pytest.mark.parametrize(
     ("method", "occurrence"),
     [
         ("fsync_file", 1),
@@ -215,7 +241,7 @@ def test_cross_device_publication_failure_has_no_copy_fallback(
     assert list(tmp_path.iterdir()) == []
 
 
-@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+@pytest.mark.parametrize(
     ("method", "occurrence"),
     [
         ("fsync_file", 1),
@@ -273,7 +299,7 @@ def test_postpublication_durability_failure_reports_uncertainty(
     assert (tmp_path / "result.bin").read_bytes() == b"payload"
 
 
-@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+@pytest.mark.parametrize(
     "method",
     ["close_temporary", "close_parent"],
 )
@@ -297,6 +323,37 @@ def test_postpublication_close_failure_never_removes_destination(
     assert (tmp_path / "result.bin").exists()
     sink.abort()
     assert (tmp_path / "result.bin").read_bytes() == b"payload"
+
+
+def test_postpublication_destination_lease_close_failure_is_retryable(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "result.bin"
+    destination.write_bytes(b"original")
+    filesystem = FaultFilesystem(
+        "close_destination",
+        reason=FilesystemFailureReason.CLEANUP_FAILED,
+        published=True,
+    )
+    sink = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="result.bin",
+        options=AtomicSinkOptions(
+            policy_allows_overwrite=True,
+            overwrite_requested=True,
+        ),
+        _filesystem=filesystem,
+    )
+    sink.write(b"replacement")
+
+    with pytest.raises(AtomicSinkError) as captured:
+        sink.commit()
+
+    assert captured.value.state is AtomicSinkState.CLEANUP_INCOMPLETE
+    assert captured.value.outcome is CommitOutcome.CLEANUP_INCOMPLETE
+    assert destination.read_bytes() == b"replacement"
+    sink.abort()
+    assert destination.read_bytes() == b"replacement"
 
 
 def test_abort_cleanup_failure_can_be_retried_without_publication(
@@ -390,7 +447,7 @@ def test_abort_does_not_touch_source_handle_or_source_bytes(
     assert not (tmp_path / "result.bin").exists()
 
 
-@pytest.mark.skipif(  # type: ignore[untyped-decorator]
+@pytest.mark.skipif(
     os.name != "posix",
     reason="POSIX namespace replacement test",
 )

--- a/tests/unit/test_atomic_failures.py
+++ b/tests/unit/test_atomic_failures.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cryptography_suite import ErrorCode
+from cryptography_suite._internal.filesystem import (
+    FilesystemFailureReason,
+    FilesystemOperationError,
+    StandardFilesystemOS,
+)
+from cryptography_suite.streaming.atomic import (
+    AtomicFileSink,
+    AtomicSinkError,
+    AtomicSinkOptions,
+    AtomicSinkState,
+    CommitOutcome,
+)
+
+
+class FaultFilesystem:
+    """One-shot fault wrapper around the real platform facade."""
+
+    def __init__(
+        self,
+        method: str,
+        *,
+        occurrence: int = 1,
+        reason: FilesystemFailureReason = FilesystemFailureReason.IO_FAILED,
+        published: bool = False,
+        partial_first_write: bool = False,
+    ) -> None:
+        self.base = StandardFilesystemOS()
+        self.method = method
+        self.occurrence = occurrence
+        self.reason = reason
+        self.published = published
+        self.partial_first_write = partial_first_write
+        self.calls: defaultdict[str, int] = defaultdict(int)
+
+    def __getattr__(self, name: str) -> Any:
+        target = getattr(self.base, name)
+
+        def intercepted(*args: Any, **kwargs: Any) -> Any:
+            self.calls[name] += 1
+            call = self.calls[name]
+            if name == "write" and self.partial_first_write and call == 1:
+                limited = args[1][:2]
+                return target(args[0], limited)
+            if name == self.method and call == self.occurrence:
+                raise FilesystemOperationError(
+                    self.reason,
+                    operation=name,
+                    published=self.published,
+                )
+            return target(*args, **kwargs)
+
+        return intercepted
+
+
+def _sink(tmp_path: Path, filesystem: FaultFilesystem) -> AtomicFileSink:
+    return AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="result.bin",
+        _filesystem=filesystem,
+    )
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["capabilities", "open_parent", "create_temporary"],
+)
+def test_construction_failure_never_stages_or_publishes(
+    tmp_path: Path,
+    method: str,
+) -> None:
+    filesystem = FaultFilesystem(method)
+
+    with pytest.raises(AtomicSinkError) as captured:
+        _sink(tmp_path, filesystem)
+
+    assert captured.value.code is ErrorCode.IO_FAILED
+    assert captured.value.state is AtomicSinkState.FAILED
+    assert captured.value.outcome is CommitOutcome.NOT_PUBLISHED
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_unsupported_filesystem_report_fails_before_staging(
+    tmp_path: Path,
+) -> None:
+    filesystem = FaultFilesystem("unused")
+    real_capabilities = filesystem.base.capabilities
+
+    def unsupported(root: str) -> Any:
+        return replace(
+            real_capabilities(root),
+            atomic_no_overwrite_publication=False,
+        )
+
+    filesystem.capabilities = unsupported  # type: ignore[method-assign]
+
+    with pytest.raises(AtomicSinkError) as captured:
+        _sink(tmp_path, filesystem)
+
+    assert captured.value.code is ErrorCode.IO_FAILED
+    assert filesystem.calls["create_temporary"] == 0
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_parent_traversal_failure_never_creates_a_temporary(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "nested").mkdir()
+    filesystem = FaultFilesystem(
+        "open_parent",
+        reason=FilesystemFailureReason.DESTINATION_UNSAFE,
+    )
+
+    with pytest.raises(AtomicSinkError):
+        AtomicFileSink(
+            output_root=tmp_path.absolute(),
+            relative_destination=os.path.join("nested", "result.bin"),
+            _filesystem=filesystem,
+        )
+
+    assert list((tmp_path / "nested").iterdir()) == []
+
+
+def test_first_write_failure_is_abortable_without_publication(
+    tmp_path: Path,
+) -> None:
+    filesystem = FaultFilesystem("write")
+    sink = _sink(tmp_path, filesystem)
+
+    with pytest.raises(AtomicSinkError) as captured:
+        sink.write(b"payload")
+
+    assert captured.value.state is AtomicSinkState.FAILED
+    assert captured.value.outcome is CommitOutcome.NOT_PUBLISHED
+    sink.abort()
+    assert sink.state is AtomicSinkState.ABORTED
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_partial_then_failed_write_tracks_no_completed_chunk(
+    tmp_path: Path,
+) -> None:
+    filesystem = FaultFilesystem(
+        "write",
+        occurrence=2,
+        partial_first_write=True,
+    )
+    sink = _sink(tmp_path, filesystem)
+
+    with pytest.raises(AtomicSinkError):
+        sink.write(b"payload")
+
+    assert sink.bytes_written == 0
+    assert sink.state is AtomicSinkState.FAILED
+    sink.abort()
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    ("method", "occurrence"),
+    [
+        ("fsync_file", 1),
+        ("revalidate_temporary", 1),
+        ("inspect_destination", 2),
+        ("publish_no_overwrite", 1),
+    ],
+)
+def test_prepublication_commit_failure_is_explicit_and_abortable(
+    tmp_path: Path,
+    method: str,
+    occurrence: int,
+) -> None:
+    filesystem = FaultFilesystem(method, occurrence=occurrence)
+    sink = _sink(tmp_path, filesystem)
+    sink.write(b"payload")
+
+    with pytest.raises(AtomicSinkError) as captured:
+        sink.commit()
+
+    assert captured.value.state is AtomicSinkState.FAILED
+    assert captured.value.outcome is CommitOutcome.NOT_PUBLISHED
+    assert not (tmp_path / "result.bin").exists()
+    sink.abort()
+    assert sink.state is AtomicSinkState.ABORTED
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_cross_device_publication_failure_has_no_copy_fallback(
+    tmp_path: Path,
+) -> None:
+    filesystem = FaultFilesystem(
+        "publish_no_overwrite",
+        reason=FilesystemFailureReason.CAPABILITY_UNAVAILABLE,
+    )
+    sink = _sink(tmp_path, filesystem)
+    sink.write(b"payload")
+
+    with pytest.raises(AtomicSinkError) as captured:
+        sink.commit()
+
+    assert captured.value.code is ErrorCode.IO_FAILED
+    assert captured.value.outcome is CommitOutcome.NOT_PUBLISHED
+    assert filesystem.calls["publish_no_overwrite"] == 1
+    sink.abort()
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    ("method", "occurrence"),
+    [
+        ("fsync_file", 1),
+        ("revalidate_temporary", 1),
+        ("inspect_destination", 2),
+        ("publish_overwrite", 1),
+    ],
+)
+def test_prepublication_overwrite_failure_preserves_existing_bytes(
+    tmp_path: Path,
+    method: str,
+    occurrence: int,
+) -> None:
+    destination = tmp_path / "result.bin"
+    destination.write_bytes(b"original")
+    filesystem = FaultFilesystem(method, occurrence=occurrence)
+    sink = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="result.bin",
+        options=AtomicSinkOptions(
+            policy_allows_overwrite=True,
+            overwrite_requested=True,
+        ),
+        _filesystem=filesystem,
+    )
+    sink.write(b"replacement")
+
+    with pytest.raises(AtomicSinkError) as captured:
+        sink.commit()
+
+    assert captured.value.outcome is CommitOutcome.NOT_PUBLISHED
+    assert destination.read_bytes() == b"original"
+    sink.abort()
+    assert destination.read_bytes() == b"original"
+
+
+def test_postpublication_durability_failure_reports_uncertainty(
+    tmp_path: Path,
+) -> None:
+    filesystem = FaultFilesystem(
+        "fsync_directory",
+        reason=FilesystemFailureReason.DURABILITY_FAILED,
+        published=True,
+    )
+    sink = _sink(tmp_path, filesystem)
+    sink.write(b"payload")
+
+    with pytest.raises(AtomicSinkError) as captured:
+        sink.commit()
+
+    assert captured.value.state is AtomicSinkState.PUBLICATION_UNCERTAIN
+    assert captured.value.outcome is CommitOutcome.PUBLISHED_DURABILITY_UNCERTAIN
+    assert (tmp_path / "result.bin").read_bytes() == b"payload"
+    sink.abort()
+    assert (tmp_path / "result.bin").read_bytes() == b"payload"
+
+
+@pytest.mark.parametrize("method", ["close_temporary", "close_parent"])
+def test_postpublication_close_failure_never_removes_destination(
+    tmp_path: Path,
+    method: str,
+) -> None:
+    filesystem = FaultFilesystem(
+        method,
+        reason=FilesystemFailureReason.CLEANUP_FAILED,
+        published=True,
+    )
+    sink = _sink(tmp_path, filesystem)
+    sink.write(b"payload")
+
+    with pytest.raises(AtomicSinkError) as captured:
+        sink.commit()
+
+    assert captured.value.state is AtomicSinkState.CLEANUP_INCOMPLETE
+    assert captured.value.outcome is CommitOutcome.CLEANUP_INCOMPLETE
+    assert (tmp_path / "result.bin").exists()
+    sink.abort()
+    assert (tmp_path / "result.bin").read_bytes() == b"payload"
+
+
+def test_abort_cleanup_failure_can_be_retried_without_publication(
+    tmp_path: Path,
+) -> None:
+    filesystem = FaultFilesystem(
+        "unlink_temporary",
+        reason=FilesystemFailureReason.CLEANUP_FAILED,
+    )
+    sink = _sink(tmp_path, filesystem)
+    sink.write(b"payload")
+
+    with pytest.raises(AtomicSinkError) as captured:
+        sink.abort()
+
+    assert captured.value.state is AtomicSinkState.CLEANUP_INCOMPLETE
+    assert not (tmp_path / "result.bin").exists()
+    sink.abort()
+    assert sink.state is AtomicSinkState.ABORTED
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_owned_temporary_identity_cleanup_failure_is_explicit(
+    tmp_path: Path,
+) -> None:
+    filesystem = FaultFilesystem(
+        "unlink_temporary",
+        reason=FilesystemFailureReason.IDENTITY_MISMATCH,
+    )
+    sink = _sink(tmp_path, filesystem)
+
+    with pytest.raises(AtomicSinkError) as captured:
+        sink.abort()
+
+    assert captured.value.state is AtomicSinkState.CLEANUP_INCOMPLETE
+    assert captured.value.outcome is CommitOutcome.CLEANUP_INCOMPLETE
+    sink.abort()
+    assert sink.state is AtomicSinkState.ABORTED
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_interrupted_write_is_retried(tmp_path: Path) -> None:
+    filesystem = FaultFilesystem("unused")
+    base_write = filesystem.base.write
+    interrupted = False
+
+    def write_once_interrupted(temporary: Any, data: memoryview) -> int:
+        nonlocal interrupted
+        if not interrupted:
+            interrupted = True
+            raise InterruptedError
+        return base_write(temporary, data)
+
+    filesystem.write = write_once_interrupted  # type: ignore[method-assign]
+    sink = _sink(tmp_path, filesystem)
+    sink.write(b"payload")
+    sink.commit()
+
+    assert interrupted is True
+    assert (tmp_path / "result.bin").read_bytes() == b"payload"
+
+
+def test_zero_progress_write_fails_closed(tmp_path: Path) -> None:
+    filesystem = FaultFilesystem("unused")
+    filesystem.write = lambda temporary, data: 0  # type: ignore[method-assign]
+    sink = _sink(tmp_path, filesystem)
+
+    with pytest.raises(AtomicSinkError):
+        sink.write(b"payload")
+
+    sink.abort()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_abort_does_not_touch_source_handle_or_source_bytes(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"source")
+    with source.open("rb") as source_stream:
+        sink = AtomicFileSink(
+            output_root=tmp_path.absolute(),
+            relative_destination="result.bin",
+            source_fd=source_stream.fileno(),
+        )
+        sink.write(b"staged")
+        sink.abort()
+        assert not source_stream.closed
+        assert source_stream.read() == b"source"
+    assert source.read_bytes() == b"source"
+    assert not (tmp_path / "result.bin").exists()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX namespace replacement test")
+def test_replaced_temporary_name_is_not_deleted_as_owned(tmp_path: Path) -> None:
+    sink = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="result.bin",
+    )
+    temporary_name = sink._temporary.name  # type: ignore[union-attr]
+    temporary_path = tmp_path / temporary_name
+    temporary_path.unlink()
+    temporary_path.write_bytes(b"attacker")
+
+    with pytest.raises(AtomicSinkError) as captured:
+        sink.commit()
+
+    assert captured.value.state is AtomicSinkState.FAILED
+    with pytest.raises(AtomicSinkError):
+        sink.abort()
+    assert temporary_path.read_bytes() == b"attacker"
+    assert not (tmp_path / "result.bin").exists()

--- a/tests/unit/test_atomic_failures.py
+++ b/tests/unit/test_atomic_failures.py
@@ -71,7 +71,7 @@ def _sink(tmp_path: Path, filesystem: FaultFilesystem) -> AtomicFileSink:
     )
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     "method",
     ["capabilities", "open_parent", "create_temporary"],
 )
@@ -102,7 +102,7 @@ def test_unsupported_filesystem_report_fails_before_staging(
             atomic_no_overwrite_publication=False,
         )
 
-    filesystem.capabilities = unsupported  # type: ignore[method-assign]
+    filesystem.capabilities = unsupported  # type: ignore[attr-defined]
 
     with pytest.raises(AtomicSinkError) as captured:
         _sink(tmp_path, filesystem)
@@ -166,7 +166,7 @@ def test_partial_then_failed_write_tracks_no_completed_chunk(
     assert list(tmp_path.iterdir()) == []
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("method", "occurrence"),
     [
         ("fsync_file", 1),
@@ -215,7 +215,7 @@ def test_cross_device_publication_failure_has_no_copy_fallback(
     assert list(tmp_path.iterdir()) == []
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("method", "occurrence"),
     [
         ("fsync_file", 1),
@@ -273,7 +273,10 @@ def test_postpublication_durability_failure_reports_uncertainty(
     assert (tmp_path / "result.bin").read_bytes() == b"payload"
 
 
-@pytest.mark.parametrize("method", ["close_temporary", "close_parent"])
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    "method",
+    ["close_temporary", "close_parent"],
+)
 def test_postpublication_close_failure_never_removes_destination(
     tmp_path: Path,
     method: str,
@@ -347,7 +350,7 @@ def test_interrupted_write_is_retried(tmp_path: Path) -> None:
             raise InterruptedError
         return base_write(temporary, data)
 
-    filesystem.write = write_once_interrupted  # type: ignore[method-assign]
+    filesystem.write = write_once_interrupted  # type: ignore[attr-defined]
     sink = _sink(tmp_path, filesystem)
     sink.write(b"payload")
     sink.commit()
@@ -358,7 +361,7 @@ def test_interrupted_write_is_retried(tmp_path: Path) -> None:
 
 def test_zero_progress_write_fails_closed(tmp_path: Path) -> None:
     filesystem = FaultFilesystem("unused")
-    filesystem.write = lambda temporary, data: 0  # type: ignore[method-assign]
+    filesystem.write = lambda temporary, data: 0  # type: ignore[attr-defined]
     sink = _sink(tmp_path, filesystem)
 
     with pytest.raises(AtomicSinkError):
@@ -387,7 +390,10 @@ def test_abort_does_not_touch_source_handle_or_source_bytes(
     assert not (tmp_path / "result.bin").exists()
 
 
-@pytest.mark.skipif(os.name != "posix", reason="POSIX namespace replacement test")
+@pytest.mark.skipif(  # type: ignore[untyped-decorator]
+    os.name != "posix",
+    reason="POSIX namespace replacement test",
+)
 def test_replaced_temporary_name_is_not_deleted_as_owned(tmp_path: Path) -> None:
     sink = AtomicFileSink(
         output_root=tmp_path.absolute(),

--- a/tests/unit/test_atomic_sink.py
+++ b/tests/unit/test_atomic_sink.py
@@ -33,8 +33,8 @@ def test_stage_is_invisible_until_commit_and_has_secure_final_mode(
     )
 
     assert isinstance(sink, TransactionalSink)
-    assert sink.state is AtomicSinkState.OPEN
-    assert sink.outcome is CommitOutcome.NOT_PUBLISHED
+    assert sink.state.value == AtomicSinkState.OPEN.value
+    assert sink.outcome.value == CommitOutcome.NOT_PUBLISHED.value
     assert not destination.exists()
     sink.write(b"first")
     sink.write(b"")
@@ -113,7 +113,7 @@ def test_write_bounds_and_type_are_deterministic(tmp_path: Path) -> None:
     sink.abort()
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("field", "value", "exception_type"),
     [
         ("max_write_size", True, TypeError),
@@ -147,7 +147,7 @@ def test_options_reject_write_bound_above_total_bound() -> None:
         AtomicSinkOptions(max_write_size=2, max_total_bytes=1)
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("policy_allows", "requested"),
     [(False, False), (True, False), (False, True)],
 )
@@ -230,7 +230,10 @@ def test_capability_report_names_atomic_primitives(tmp_path: Path) -> None:
     assert "replace" in capabilities.overwrite_primitive.lower()
 
 
-@pytest.mark.skipif(os.name != "posix", reason="POSIX mode guarantee")
+@pytest.mark.skipif(  # type: ignore[untyped-decorator]
+    os.name != "posix",
+    reason="POSIX mode guarantee",
+)
 def test_permissive_umask_cannot_weaken_owner_only_mode(tmp_path: Path) -> None:
     previous = os.umask(0)
     try:
@@ -248,7 +251,10 @@ def test_permissive_umask_cannot_weaken_owner_only_mode(tmp_path: Path) -> None:
     assert stat.S_IMODE((tmp_path / "result.bin").stat().st_mode) == 0o600
 
 
-@pytest.mark.skipif(os.name != "nt", reason="Windows owner-only DACL guarantee")
+@pytest.mark.skipif(  # type: ignore[untyped-decorator]
+    os.name != "nt",
+    reason="Windows owner-only DACL guarantee",
+)
 def test_windows_staging_dacl_matches_claim(tmp_path: Path) -> None:
     sink = AtomicFileSink(
         output_root=tmp_path.absolute(),

--- a/tests/unit/test_atomic_sink.py
+++ b/tests/unit/test_atomic_sink.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from cryptography_suite import ErrorCode
+from cryptography_suite.streaming import TransactionalSink
+from cryptography_suite.streaming.atomic import (
+    AtomicFileSink,
+    AtomicSinkError,
+    AtomicSinkOptions,
+    AtomicSinkState,
+    CommitOutcome,
+)
+
+
+def _relative(*components: str) -> str:
+    return os.path.join(*components)
+
+
+def test_stage_is_invisible_until_commit_and_has_secure_final_mode(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "nested"
+    parent.mkdir()
+    destination = parent / "result.bin"
+    sink = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination=_relative("nested", "result.bin"),
+    )
+
+    assert isinstance(sink, TransactionalSink)
+    assert sink.state is AtomicSinkState.OPEN
+    assert sink.outcome is CommitOutcome.NOT_PUBLISHED
+    assert not destination.exists()
+    sink.write(b"first")
+    sink.write(b"")
+    sink.write(b"-second")
+    assert not destination.exists()
+
+    sink.commit()
+
+    assert destination.read_bytes() == b"first-second"
+    assert sink.state is AtomicSinkState.COMMITTED
+    assert sink.outcome is CommitOutcome.PUBLISHED
+    assert sink.bytes_written == len(b"first-second")
+    if os.name == "posix":
+        assert stat.S_IMODE(destination.stat().st_mode) == 0o600
+
+
+def test_abort_is_idempotent_and_never_publishes(tmp_path: Path) -> None:
+    destination = tmp_path / "result.bin"
+    sink = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="result.bin",
+    )
+    sink.write(b"staged")
+
+    sink.abort()
+    sink.abort()
+
+    assert sink.state is AtomicSinkState.ABORTED
+    assert sink.outcome is CommitOutcome.NOT_PUBLISHED
+    assert not destination.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_abort_after_commit_does_not_remove_destination(tmp_path: Path) -> None:
+    destination = tmp_path / "result.bin"
+    sink = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="result.bin",
+    )
+    sink.write(b"committed")
+    sink.commit()
+
+    sink.abort()
+
+    assert destination.read_bytes() == b"committed"
+    assert sink.state is AtomicSinkState.COMMITTED
+
+
+def test_context_manager_aborts_without_commit(tmp_path: Path) -> None:
+    with AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="result.bin",
+    ) as sink:
+        sink.write(b"staged")
+
+    assert sink.state is AtomicSinkState.ABORTED
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_write_bounds_and_type_are_deterministic(tmp_path: Path) -> None:
+    sink = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="result.bin",
+        options=AtomicSinkOptions(max_write_size=4, max_total_bytes=6),
+    )
+    sink.write(b"1234")
+    with pytest.raises(AtomicSinkError) as chunk_error:
+        sink.write(b"12345")
+    assert chunk_error.value.code is ErrorCode.LIMIT_EXCEEDED
+    with pytest.raises(AtomicSinkError) as total_error:
+        sink.write(b"789")
+    assert total_error.value.code is ErrorCode.LIMIT_EXCEEDED
+    with pytest.raises(TypeError):
+        sink.write(bytearray(b"x"))  # type: ignore[arg-type]
+    assert sink.state is AtomicSinkState.OPEN
+    sink.abort()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "exception_type"),
+    [
+        ("max_write_size", True, TypeError),
+        ("max_write_size", 0, ValueError),
+        ("max_write_size", 4 * 1024 * 1024 + 1, ValueError),
+        ("max_total_bytes", False, TypeError),
+        ("max_total_bytes", 0, ValueError),
+        ("max_total_bytes", (1 << 40) + 1, ValueError),
+        ("policy_allows_overwrite", 1, TypeError),
+        ("overwrite_requested", 1, TypeError),
+    ],
+)
+def test_options_reject_invalid_values(
+    field: str,
+    value: object,
+    exception_type: type[Exception],
+) -> None:
+    arguments: dict[str, object] = {
+        "max_write_size": 1024,
+        "max_total_bytes": 2048,
+        "policy_allows_overwrite": False,
+        "overwrite_requested": False,
+    }
+    arguments[field] = value
+    with pytest.raises(exception_type):
+        AtomicSinkOptions(**arguments)  # type: ignore[arg-type]
+
+
+def test_options_reject_write_bound_above_total_bound() -> None:
+    with pytest.raises(ValueError, match="must not exceed"):
+        AtomicSinkOptions(max_write_size=2, max_total_bytes=1)
+
+
+@pytest.mark.parametrize(
+    ("policy_allows", "requested"),
+    [(False, False), (True, False), (False, True)],
+)
+def test_overwrite_requires_both_authorization_gates(
+    tmp_path: Path,
+    policy_allows: bool,
+    requested: bool,
+) -> None:
+    destination = tmp_path / "result.bin"
+    destination.write_bytes(b"original")
+    with pytest.raises(AtomicSinkError) as captured:
+        AtomicFileSink(
+            output_root=tmp_path.absolute(),
+            relative_destination="result.bin",
+            options=AtomicSinkOptions(
+                policy_allows_overwrite=policy_allows,
+                overwrite_requested=requested,
+            ),
+        )
+    assert captured.value.code is ErrorCode.OUTPUT_EXISTS
+    assert destination.read_bytes() == b"original"
+
+
+def test_dual_authorized_overwrite_replaces_without_inheriting_mode(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "result.bin"
+    destination.write_bytes(b"original")
+    if os.name == "posix":
+        destination.chmod(0o666)
+    sink = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="result.bin",
+        options=AtomicSinkOptions(
+            policy_allows_overwrite=True,
+            overwrite_requested=True,
+        ),
+    )
+    sink.write(b"replacement")
+    sink.commit()
+
+    assert destination.read_bytes() == b"replacement"
+    if os.name == "posix":
+        assert stat.S_IMODE(destination.stat().st_mode) == 0o600
+
+
+def test_state_rejects_repeated_commit_and_use_after_terminal_state(
+    tmp_path: Path,
+) -> None:
+    committed = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="committed.bin",
+    )
+    committed.commit()
+    with pytest.raises(AtomicSinkError) as second_commit:
+        committed.commit()
+    assert second_commit.value.code is ErrorCode.INTERNAL_ERROR
+    with pytest.raises(AtomicSinkError):
+        committed.write(b"x")
+
+    aborted = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="aborted.bin",
+    )
+    aborted.abort()
+    with pytest.raises(AtomicSinkError):
+        aborted.commit()
+    with pytest.raises(AtomicSinkError):
+        aborted.write(b"x")
+
+
+def test_capability_report_names_atomic_primitives(tmp_path: Path) -> None:
+    capabilities = AtomicFileSink.capabilities(tmp_path.absolute())
+
+    assert capabilities.fully_supported is True
+    assert capabilities.atomic_no_overwrite_publication is True
+    assert capabilities.atomic_replacement is True
+    assert capabilities.file_fsync is True
+    assert capabilities.directory_durability is True
+    assert "replace" in capabilities.overwrite_primitive.lower()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX mode guarantee")
+def test_permissive_umask_cannot_weaken_owner_only_mode(tmp_path: Path) -> None:
+    previous = os.umask(0)
+    try:
+        sink = AtomicFileSink(
+            output_root=tmp_path.absolute(),
+            relative_destination="result.bin",
+        )
+        temporary = tmp_path / sink._temporary.name  # type: ignore[union-attr]
+        assert stat.S_IMODE(temporary.stat().st_mode) == 0o600
+        sink.write(b"payload")
+        sink.commit()
+    finally:
+        os.umask(previous)
+
+    assert stat.S_IMODE((tmp_path / "result.bin").stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows owner-only DACL guarantee")
+def test_windows_staging_dacl_matches_claim(tmp_path: Path) -> None:
+    sink = AtomicFileSink(
+        output_root=tmp_path.absolute(),
+        relative_destination="result.bin",
+    )
+    temporary = sink._temporary
+    assert temporary is not None
+    handle = temporary.windows_handle
+    assert handle is not None
+    assert sink._filesystem._windows_has_owner_only_dacl(handle)  # type: ignore[attr-defined]
+    sink.abort()

--- a/tests/unit/test_atomic_sink.py
+++ b/tests/unit/test_atomic_sink.py
@@ -108,12 +108,12 @@ def test_write_bounds_and_type_are_deterministic(tmp_path: Path) -> None:
         sink.write(b"789")
     assert total_error.value.code is ErrorCode.LIMIT_EXCEEDED
     with pytest.raises(TypeError):
-        sink.write(bytearray(b"x"))  # type: ignore[arg-type]
+        sink.write(bytearray(b"x"))
     assert sink.state is AtomicSinkState.OPEN
     sink.abort()
 
 
-@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+@pytest.mark.parametrize(
     ("field", "value", "exception_type"),
     [
         ("max_write_size", True, TypeError),
@@ -147,7 +147,7 @@ def test_options_reject_write_bound_above_total_bound() -> None:
         AtomicSinkOptions(max_write_size=2, max_total_bytes=1)
 
 
-@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+@pytest.mark.parametrize(
     ("policy_allows", "requested"),
     [(False, False), (True, False), (False, True)],
 )
@@ -227,10 +227,10 @@ def test_capability_report_names_atomic_primitives(tmp_path: Path) -> None:
     assert capabilities.atomic_replacement is True
     assert capabilities.file_fsync is True
     assert capabilities.directory_durability is True
-    assert "replace" in capabilities.overwrite_primitive.lower()
+    assert "rename" in capabilities.overwrite_primitive.lower()
 
 
-@pytest.mark.skipif(  # type: ignore[untyped-decorator]
+@pytest.mark.skipif(
     os.name != "posix",
     reason="POSIX mode guarantee",
 )
@@ -251,7 +251,7 @@ def test_permissive_umask_cannot_weaken_owner_only_mode(tmp_path: Path) -> None:
     assert stat.S_IMODE((tmp_path / "result.bin").stat().st_mode) == 0o600
 
 
-@pytest.mark.skipif(  # type: ignore[untyped-decorator]
+@pytest.mark.skipif(
     os.name != "nt",
     reason="Windows owner-only DACL guarantee",
 )

--- a/tests/unit/test_public_submodules.py
+++ b/tests/unit/test_public_submodules.py
@@ -52,6 +52,14 @@ def test_all_public_submodule_exports_are_exact() -> None:
     assert "KeyRecord" not in suite.__all__
 
 
+def test_atomic_filesystem_sink_remains_private() -> None:
+    for module in (suite, streaming):
+        assert not hasattr(module, "AtomicFileSink")
+        assert not hasattr(module, "AtomicSinkOptions")
+        assert not hasattr(module, "AtomicSinkState")
+        assert not hasattr(module, "CommitOutcome")
+
+
 def test_legacy_namespace_is_declaration_only() -> None:
     assert {member.name: member.value for member in LegacyFormat} == {
         "CSF_V2": "csf-v2",


### PR DESCRIPTION
## Phase 4A goal

Add the private transactional filesystem boundary required by later v4 streaming work. The sink stages bounded bytes in the destination parent and publishes only on explicit commit. It implements no cryptography.

- Base and rollback SHA: `fc50585b280dd9bb76c7671f1932a6d80bc4f06e`
- Implementation SHA before evidence: `3c51950fb090475229f1206e685aaa59a9fe50a9`
- Branch HEAD: `2003a17274773e980126944054d2562144833976`
- Package version: `3.0.0`

## Exact scope

Added a private standard-library OS facade (`FilesystemOS` / `StandardFilesystemOS`), private `AtomicFileSink`, internal options/states/outcomes/errors, focused path/link/state/race/failure/permission/artifact tests, Phase 4A evidence, and a narrow Ubuntu/Windows/macOS workflow. README and package summary now state the actual incomplete, non-cryptographic capability.

No encryption, decryption, envelope codec, provider, policy engine, CLI, legacy parser, or migration behavior was implemented. `Protector` remains fail-closed. Phase 4B, 4C, and 4D were not started; overall Phase 4 remains incomplete.

## Public API preservation

Root `__all__` remains the exact approved 15 symbols. Streaming `__all__` remains exactly `SinkState` and `TransactionalSink`. `AtomicFileSink` and its options, states, outcomes, and error remain private and are not imported by the package root.

## Filesystem contract

- Explicit existing absolute trusted root; strict untrusted relative destination.
- Component traversal uses no-follow directory descriptors on POSIX and retained non-reparse handles on Windows.
- Device/inode or volume/file-index identity protects source, destination, and owned staging files; overwrite retains an open destination handle through revalidation and replacement so inode/file-index reuse cannot hide a namespace change.
- Symlink/reparse parents and destinations, destination directories, and destination hardlink counts greater than one are rejected.
- No overwrite is the default: POSIX same-directory `linkat` semantics; Windows handle-based no-replace rename.
- Overwrite requires both future-policy authority and explicit operation intent: POSIX same-directory replacement; Windows handle replacement.
- Destinations that appear or change after staging are preserved and publication fails closed.
- POSIX staging/final mode is verified `0600`, including under permissive umask. Windows local NTFS staging uses and verifies the documented protected owner-only DACL.
- File durability uses `fsync` / `FlushFileBuffers`. POSIX uses parent-directory `fsync`; Windows uses the documented write-through and post-rename handle barrier without claiming POSIX directory-fsync semantics.
- Pre-publication failures are `NOT_PUBLISHED`; post-publication durability failures are `PUBLISHED_DURABILITY_UNCERTAIN`; cleanup/close failures are `CLEANUP_INCOMPLETE`.
- Abort is idempotent, retries only identity-verified owned cleanup, never deletes the caller source or destination, and never converts uncertain publication to aborted.
- Remote/non-NTFS Windows roots, missing required POSIX primitives, cross-filesystem promotion, and unverifiable guarantees fail closed. No copy fallback exists.

See `docs/v4/phase-4a/filesystem-contract.md`, `platform-capability-matrix.md`, and `failure-injection-evidence.md` for the full contract.

## Tests and failure injection

Local supported environment: Windows, Python 3.12.3.

- Full suite with branch coverage: 125 collected, 121 passed, 4 explicit platform/capability skips, 76% aggregate branch coverage.
- Focused core filesystem boundary: 75 collected, 71 passed, 4 explicit skips.
- Failure injection: 27 collected, 26 passed; POSIX namespace-replacement case skipped on Windows.
- Real synchronized two-process no-overwrite race: exactly one winner, one `OUTPUT_EXISTS` loser, winner preserved, no owned-temp leak.
- Strict mypy (20 source files): pass.
- Exact Quality-Gate-style mypy over changed Python files: pass.
- Ruff lint/format and Black: pass.
- Bandit: pass.
- `pip-audit -r requirements.txt --strict`: no known vulnerabilities.
- Markdown lint, actionlint, documentation references, banned trust claims: pass.
- Phase 1/2 document preservation and Phase 3 evidence preservation: pass.

Injected points include capability/root/parent/temp construction, first/partial/later/interrupted/zero-progress writes, file fsync, ownership and destination revalidation, no-overwrite/overwrite promotion, simulated EXDEV, temp unlink/identity cleanup, directory durability, and handle close. Each error is typed and redacted.

## Artifacts

- Wheel: `cryptography_suite-3.0.0-py3-none-any.whl`, 26 entries / 21 runtime files, SHA-256 `7a0e6d78e853ff9c433642909220e276567e92f0a3bc78f6778ec74c22be28a8`.
- Sdist: `cryptography_suite-3.0.0.tar.gz`, 33 files / 21 runtime files, SHA-256 `dfbb60b340033babcc551e3e805bf502c1c6e7d28da79a4a41b7b0f1ab79e983`.
- Non-editable wheel installed outside checkout; direct private-sink stage/abort/commit passed; destination remained hidden until commit; no temp remained; `pip check` passed.
- Wheel rebuilt from sdist with an identical 21-file runtime inventory.
- No tests, temp files, generated failure fixtures, platform-private data, console entry point, or prohibited runtime family entered artifacts.

## Platform matrix and review hold

The dedicated Filesystem Boundary workflow reports capabilities and runs focused tests, installed-wheel smoke, artifacts, typing, and lint on Ubuntu, Windows, and macOS. This PR remains draft pending independent review of traversal, links, identity, races, permissions, directory durability uncertainty, abort-after-partial-failure, Windows behavior, and artifact contents.

The independent Deep Security Scan remains **BLOCKED BY TOOLING FAILURE**. It was not retried and is still required before Phase 4 completion or stable release.

## Document preservation and rollback

`docs/v4/baseline`, `docs/v4/rfcs`, `docs/v4/architecture`, and `docs/v4/phase-3` are unchanged. Roll back by reverting the nine Phase 4A commits in reverse order or returning the branch to `fc50585b280dd9bb76c7671f1932a6d80bc4f06e`. No migration, public-format, public-API, or version rollback is needed.

